### PR TITLE
Harden CI workflow and merge expectations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Lint and format check
         run: npm run check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,15 @@ A feature is only done when all of the following are true:
 - no direct pushes
 - required CI checks before merge
 
+Repository settings should enforce this with branch protection on `main`.
+
+Recommended protection rules:
+
+- require a pull request before merging
+- require the CI workflow to pass before merging
+- dismiss or re-run checks when the PR head changes
+- prevent direct pushes to `main`
+
 ## Local development
 
 ```bash
@@ -64,6 +73,15 @@ That means:
 - unit tests for isolated logic
 - integration tests for API + DB + auth boundaries
 - end-to-end coverage for critical flows when relevant
+
+At minimum, every PR is expected to keep the following commands green:
+
+```bash
+npm run check
+npm run typecheck
+npm run test
+npm run build
+```
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,17 @@ Required checks are expected to include:
 - end-to-end tests for critical flows
 - build verification
 
+The baseline PR validation commands are:
+
+```bash
+npm run check
+npm run typecheck
+npm run test
+npm run build
+```
+
+`main` should be protected so pull requests cannot merge unless the CI workflow is green.
+
 ## Testing strategy
 
 The default test pyramid for Mi Casa Su Casa is:


### PR DESCRIPTION
## Summary
- switch CI installs to `npm ci` for deterministic pull request validation
- document the baseline required validation commands for contributors and reviewers
- make the intended branch protection and merge expectations explicit in project docs

## Validation
- npm run check
- npm run typecheck
- npm run test
- npm run build

## Issue mapping
- closes #1

## Notes
- This PR is intentionally stacked on top of #10 so the CI hardening lands on the application scaffold branch first.
- After #10 and this PR merge, `main` should have branch protection enabled immediately.