### PR TITLE
Build email ingestion, normalization, and quarantine pipeline

### DIFF
--- a/src/server/db/repositories/messages.ts
+++ b/src/server/db/repositories/messages.ts
@@ -12,6 +12,30 @@ function addRetentionWindow(isoDate: string): string {
   return next.toISOString();
 }
 
+function resolveReceivedAt(dateHeader: string | null): string {
+  if (!dateHeader) {
+    return new Date().toISOString();
+  }
+
+  const receivedAt = new Date(dateHeader);
+
+  if (Number.isNaN(receivedAt.getTime())) {
+    return new Date().toISOString();
+  }
+
+  return receivedAt.toISOString();
+}
+
+function isDuplicateMessageError(
+  error: unknown,
+  tableName: "messages" | "quarantine_messages",
+): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes(`UNIQUE constraint failed: ${tableName}.message_id`)
+  );
+}
+
 export async function insertMessage(
   db: D1Database,
   parsed: ParsedIncomingEmail,
@@ -19,34 +43,38 @@ export async function insertMessage(
   result: Extract<ClassificationResult, { kind: "matched" }>,
 ) {
   const id = crypto.randomUUID();
-  const receivedAt = parsed.dateHeader
-    ? new Date(parsed.dateHeader).toISOString()
-    : new Date().toISOString();
+  const receivedAt = resolveReceivedAt(parsed.dateHeader);
   const deleteAfter = addRetentionWindow(receivedAt);
 
-  await db
-    .prepare(
-      `INSERT INTO messages (
-        id, message_id, provider_id, envelope_from, envelope_to, from_header, subject,
-        text_body, extracted_code, classification_reason, raw_size, received_at, delete_after
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    )
-    .bind(
-      id,
-      parsed.messageId ?? id,
-      providerId,
-      parsed.envelopeFrom,
-      parsed.envelopeTo,
-      parsed.fromHeader,
-      parsed.subject,
-      parsed.textBody,
-      result.code,
-      result.reason,
-      parsed.rawSize,
-      receivedAt,
-      deleteAfter,
-    )
-    .run();
+  try {
+    await db
+      .prepare(
+        `INSERT INTO messages (
+          id, message_id, provider_id, envelope_from, envelope_to, from_header, subject,
+          text_body, extracted_code, classification_reason, raw_size, received_at, delete_after
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        id,
+        parsed.messageId ?? id,
+        providerId,
+        parsed.envelopeFrom,
+        parsed.envelopeTo,
+        parsed.fromHeader,
+        parsed.subject,
+        parsed.textBody,
+        result.code,
+        result.reason,
+        parsed.rawSize,
+        receivedAt,
+        deleteAfter,
+      )
+      .run();
+  } catch (error) {
+    if (!isDuplicateMessageError(error, "messages")) {
+      throw error;
+    }
+  }
 
   return { id, receivedAt, deleteAfter };
 }
@@ -57,33 +85,37 @@ export async function insertQuarantineMessage(
   result: Extract<ClassificationResult, { kind: "quarantine" }>,
 ) {
   const id = crypto.randomUUID();
-  const receivedAt = parsed.dateHeader
-    ? new Date(parsed.dateHeader).toISOString()
-    : new Date().toISOString();
+  const receivedAt = resolveReceivedAt(parsed.dateHeader);
   const deleteAfter = addRetentionWindow(receivedAt);
 
-  await db
-    .prepare(
-      `INSERT INTO quarantine_messages (
-        id, message_id, envelope_from, envelope_to, from_header, subject,
-        text_body, extracted_code, quarantine_reason, raw_size, received_at, delete_after
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    )
-    .bind(
-      id,
-      parsed.messageId ?? id,
-      parsed.envelopeFrom,
-      parsed.envelopeTo,
-      parsed.fromHeader,
-      parsed.subject,
-      parsed.textBody,
-      result.code,
-      result.reason,
-      parsed.rawSize,
-      receivedAt,
-      deleteAfter,
-    )
-    .run();
+  try {
+    await db
+      .prepare(
+        `INSERT INTO quarantine_messages (
+          id, message_id, envelope_from, envelope_to, from_header, subject,
+          text_body, extracted_code, quarantine_reason, raw_size, received_at, delete_after
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        id,
+        parsed.messageId ?? id,
+        parsed.envelopeFrom,
+        parsed.envelopeTo,
+        parsed.fromHeader,
+        parsed.subject,
+        parsed.textBody,
+        result.code,
+        result.reason,
+        parsed.rawSize,
+        receivedAt,
+        deleteAfter,
+      )
+      .run();
+  } catch (error) {
+    if (!isDuplicateMessageError(error, "quarantine_messages")) {
+      throw error;
+    }
+  }
 
   return { id, receivedAt, deleteAfter };
 }

--- a/src/server/db/types.ts
+++ b/src/server/db/types.ts
@@ -1,6 +1,7 @@
 export type ClassificationResult =
   | {
       kind: "matched";
+      providerId: string;
       providerKey: string;
       code: string | null;
       reason: string;

--- a/src/server/domain/classify-email.ts
+++ b/src/server/domain/classify-email.ts
@@ -19,6 +19,7 @@ export async function classifyEmail(
 
   return {
     kind: "matched",
+    providerId: providerMatch.providerId,
     providerKey: providerMatch.providerKey,
     code,
     reason: code

--- a/src/server/email/handler.ts
+++ b/src/server/email/handler.ts
@@ -2,7 +2,6 @@ import {
   insertMessage,
   insertQuarantineMessage,
 } from "../db/repositories/messages";
-import { findProviderMatch } from "../db/repositories/provider-rules";
 import { classifyEmail } from "../domain/classify-email";
 import type { AppContext } from "../runtime/context";
 import { parseIncomingEmail } from "./parse";
@@ -19,24 +18,10 @@ export async function handleIncomingEmail(
     return;
   }
 
-  const providerMatch = await findProviderMatch(
-    appContext.env.DB,
-    parsed.envelopeFrom,
-  );
-  if (!providerMatch) {
-    await insertQuarantineMessage(appContext.env.DB, parsed, {
-      kind: "quarantine",
-      reason:
-        "Sender matched during classification but could not be resolved during persistence.",
-      code: classification.code,
-    });
-    return;
-  }
-
   await insertMessage(
     appContext.env.DB,
     parsed,
-    providerMatch.providerId,
+    classification.providerId,
     classification,
   );
 }

--- a/src/server/email/parse.ts
+++ b/src/server/email/parse.ts
@@ -2,6 +2,13 @@ import PostalMime from "postal-mime";
 
 import type { ParsedIncomingEmail } from "../db/types";
 
+function stripHtml(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 export async function parseIncomingEmail(
   message: ForwardableEmailMessage,
 ): Promise<ParsedIncomingEmail> {
@@ -9,6 +16,10 @@ export async function parseIncomingEmail(
   const parsed = await parser.parse(
     await new Response(message.raw).arrayBuffer(),
   );
+  const textBody =
+    parsed.text?.trim() ||
+    (parsed.html ? stripHtml(parsed.html) : "") ||
+    "[empty email body]";
 
   return {
     envelopeFrom: message.from,
@@ -23,8 +34,7 @@ export async function parseIncomingEmail(
     dateHeader:
       parsed.headers.find((header) => header.key.toLowerCase() === "date")
         ?.value ?? null,
-    textBody:
-      parsed.text?.trim() || parsed.html?.replace(/<[^>]+>/g, " ").trim() || "",
+    textBody,
     rawSize: message.rawSize,
   };
 }

--- a/test/classify-email.test.ts
+++ b/test/classify-email.test.ts
@@ -40,6 +40,7 @@ describe("classifyEmail", () => {
 
     expect(result).toEqual({
       kind: "matched",
+      providerId: "provider-1",
       providerKey: "netflix",
       code: "123456",
       reason:

--- a/test/email-handler.test.ts
+++ b/test/email-handler.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { handleIncomingEmail } from "../src/server/email/handler";
+import type { AppContext } from "../src/server/runtime/context";
+
+function createMessage(
+  raw: string,
+  overrides?: Partial<ForwardableEmailMessage>,
+) {
+  return {
+    from: "login@service.example",
+    to: "codes@example.com",
+    raw: new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(raw));
+        controller.close();
+      },
+    }),
+    rawSize: raw.length,
+    headers: new Headers(),
+    setReject() {},
+    forward() {
+      return Promise.resolve();
+    },
+    reply() {
+      return Promise.resolve();
+    },
+    ...overrides,
+  } as unknown as ForwardableEmailMessage;
+}
+
+function createDb(match: { providerId: string; providerKey: string } | null) {
+  const run = vi.fn(async () => ({ results: [] }));
+  const first = vi.fn(async () => match);
+  const bind = vi.fn(() => ({ first, run }));
+  const prepare = vi.fn(() => ({ bind, first, run }));
+
+  return {
+    db: {
+      prepare,
+      batch: vi.fn(async () => []),
+    } as unknown as D1Database,
+    prepare,
+    bind,
+    first,
+    run,
+  };
+}
+
+function createAppContext(db: D1Database): AppContext {
+  return {
+    env: {
+      DB: db,
+    } as Env,
+    executionContext: {
+      waitUntil() {},
+      passThroughOnException() {},
+      props: {},
+    } as unknown as ExecutionContext,
+  };
+}
+
+describe("handleIncomingEmail", () => {
+  it("persists a matched email to messages without a second provider lookup", async () => {
+    const db = createDb({ providerId: "provider-1", providerKey: "netflix" });
+
+    await handleIncomingEmail(
+      createMessage(
+        [
+          "From: Service <login@service.example>",
+          "To: codes@example.com",
+          "Subject: Verification code",
+          "",
+          "Your verification code is 123456",
+        ].join("\n"),
+      ),
+      createAppContext(db.db),
+    );
+
+    expect(db.run).toHaveBeenCalledTimes(1);
+    expect(db.prepare).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO messages"),
+    );
+  });
+
+  it("routes unmatched senders into quarantine", async () => {
+    const db = createDb(null);
+
+    await handleIncomingEmail(
+      createMessage(
+        [
+          "From: Unknown <unknown@example.net>",
+          "To: codes@example.com",
+          "Subject: Sign in",
+          "",
+          "Use 654321 to continue.",
+        ].join("\n"),
+        { from: "unknown@example.net" },
+      ),
+      createAppContext(db.db),
+    );
+
+    expect(db.run).toHaveBeenCalledTimes(1);
+    expect(db.prepare).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO quarantine_messages"),
+    );
+  });
+
+  it("ignores duplicate message deliveries without failing the handler", async () => {
+    const duplicateError = new Error(
+      "UNIQUE constraint failed: messages.message_id",
+    );
+    const run = vi.fn(async () => {
+      throw duplicateError;
+    });
+    const first = vi.fn(async () => ({
+      providerId: "provider-1",
+      providerKey: "netflix",
+    }));
+    const bind = vi.fn(() => ({ first, run }));
+    const prepare = vi.fn(() => ({ bind, first, run }));
+
+    const db = {
+      prepare,
+      batch: vi.fn(async () => []),
+    } as unknown as D1Database;
+
+    await expect(
+      handleIncomingEmail(
+        createMessage(
+          [
+            "From: Service <login@service.example>",
+            "To: codes@example.com",
+            "Subject: Verification code",
+            "Message-ID: <duplicate@test>",
+            "",
+            "Your verification code is 123456",
+          ].join("\n"),
+        ),
+        createAppContext(db),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(prepare).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO messages"),
+    );
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/messages-repository.test.ts
+++ b/test/messages-repository.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  insertMessage,
+  insertQuarantineMessage,
+} from "../src/server/db/repositories/messages";
+import type { ParsedIncomingEmail } from "../src/server/db/types";
+
+function createParsedEmail(
+  overrides?: Partial<ParsedIncomingEmail>,
+): ParsedIncomingEmail {
+  return {
+    envelopeFrom: "login@service.example",
+    envelopeTo: "codes@example.com",
+    fromHeader: "Service <login@service.example>",
+    subject: "Your verification code",
+    messageId: "<message-1@test>",
+    dateHeader: "2026-05-10T12:00:00Z",
+    textBody: "Your verification code is 123456",
+    rawSize: 256,
+    ...overrides,
+  };
+}
+
+function createDb(runImpl: () => Promise<unknown>) {
+  const run = vi.fn(runImpl);
+  const bind = vi.fn(() => ({ run }));
+  const prepare = vi.fn(() => ({ bind }));
+
+  return {
+    db: {
+      prepare,
+      batch: vi.fn(async () => []),
+    } as unknown as D1Database,
+    prepare,
+    bind,
+    run,
+  };
+}
+
+describe("messages repository inserts", () => {
+  it("ignores duplicate inbox message ids", async () => {
+    const db = createDb(async () => {
+      throw new Error("UNIQUE constraint failed: messages.message_id");
+    });
+
+    await expect(
+      insertMessage(db.db, createParsedEmail(), "provider-1", {
+        kind: "matched",
+        providerId: "provider-1",
+        providerKey: "netflix",
+        code: "123456",
+        reason:
+          "Sender matched a configured rule and a likely verification code was found.",
+      }),
+    ).resolves.toMatchObject({
+      receivedAt: "2026-05-10T12:00:00.000Z",
+      deleteAfter: "2026-06-09T12:00:00.000Z",
+    });
+
+    expect(db.prepare).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO messages"),
+    );
+    expect(db.run).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores duplicate quarantine message ids", async () => {
+    const db = createDb(async () => {
+      throw new Error(
+        "UNIQUE constraint failed: quarantine_messages.message_id",
+      );
+    });
+
+    await expect(
+      insertQuarantineMessage(db.db, createParsedEmail(), {
+        kind: "quarantine",
+        reason: "No sender rule matched the inbound email.",
+        code: "123456",
+      }),
+    ).resolves.toMatchObject({
+      receivedAt: "2026-05-10T12:00:00.000Z",
+      deleteAfter: "2026-06-09T12:00:00.000Z",
+    });
+
+    expect(db.prepare).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO quarantine_messages"),
+    );
+    expect(db.run).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows non-unique database failures", async () => {
+    const db = createDb(async () => {
+      throw new Error("database unavailable");
+    });
+
+    await expect(
+      insertMessage(db.db, createParsedEmail(), "provider-1", {
+        kind: "matched",
+        providerId: "provider-1",
+        providerKey: "netflix",
+        code: "123456",
+        reason:
+          "Sender matched a configured rule and a likely verification code was found.",
+      }),
+    ).rejects.toThrow("database unavailable");
+  });
+});

--- a/test/parse-email.test.ts
+++ b/test/parse-email.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { parseIncomingEmail } from "../src/server/email/parse";
+
+function createMessage(
+  raw: string,
+  overrides?: Partial<ForwardableEmailMessage>,
+) {
+  return {
+    from: "login@service.example",
+    to: "codes@example.com",
+    raw: new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(raw));
+        controller.close();
+      },
+    }),
+    rawSize: raw.length,
+    headers: new Headers(),
+    setReject() {},
+    forward() {
+      return Promise.resolve();
+    },
+    reply() {
+      return Promise.resolve();
+    },
+    ...overrides,
+  } as unknown as ForwardableEmailMessage;
+}
+
+describe("parseIncomingEmail", () => {
+  it("falls back to stripped html when text is unavailable", async () => {
+    const parsed = await parseIncomingEmail(
+      createMessage(
+        [
+          "From: Service <login@service.example>",
+          "To: codes@example.com",
+          "Subject: Sign in",
+          "Content-Type: text/html; charset=utf-8",
+          "",
+          "<html><body><p>Your verification code is <strong>123456</strong>.</p></body></html>",
+        ].join("\n"),
+      ),
+    );
+
+    expect(parsed.textBody).toContain("Your verification code is 123456");
+  });
+
+  it("uses a placeholder when both text and html bodies are empty", async () => {
+    const parsed = await parseIncomingEmail(
+      createMessage(
+        [
+          "From: Service <login@service.example>",
+          "To: codes@example.com",
+          "Subject: Empty body",
+          "",
+          "",
+        ].join("\n"),
+      ),
+    );
+
+    expect(parsed.textBody).toBe("[empty email body]");
+  });
+});


### PR DESCRIPTION
## Summary
- harden inbound email parsing for HTML-only and empty-body messages
- carry matched provider ids through classification so persistence stays single-pass
- make message/quarantine inserts idempotent for duplicate deliveries and invalid date headers

## Validation
- npm run check
- npm run typecheck
- npm run test
- npm run build

Closes #4