### PR TITLE
Create inbox, quarantine, and message-status experience

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,21 +1,937 @@
 import { authClient } from "@server/auth/client";
+import type { FormEvent } from "react";
+import { useEffect, useMemo, useState } from "react";
+
+type SessionData = {
+  user?: {
+    email?: string | null;
+    name?: string | null;
+    role?: string | null;
+  };
+};
+
+type ProviderSummary = {
+  provider_key: string;
+  display_name: string;
+  message_count: number;
+  new_count: number;
+  latest_received_at: string | null;
+};
+
+type InboxMessage = {
+  id: string;
+  provider_key: string;
+  provider_display_name: string;
+  subject: string | null;
+  from_header: string | null;
+  text_body: string;
+  extracted_code: string | null;
+  status: "new" | "used" | "expired";
+  received_at: string;
+};
+
+type QuarantineMessage = {
+  id: string;
+  provider_key: "quarantine";
+  provider_display_name: "Quarantine";
+  subject: string | null;
+  from_header: string | null;
+  envelope_from: string;
+  text_body: string;
+  extracted_code: string | null;
+  status: "new";
+  quarantine_reason: string;
+  received_at: string;
+};
+
+type ProviderMessagesResponse = {
+  provider: {
+    providerKey: string;
+    displayName: string;
+  };
+  messages: InboxMessage[];
+};
+
+type LoginState = {
+  email: string;
+  password: string;
+};
+
+const INITIAL_LOGIN_STATE: LoginState = {
+  email: "",
+  password: "",
+};
+
+async function fetchJson<T>(
+  input: RequestInfo,
+  init?: RequestInit,
+): Promise<T> {
+  const response = await fetch(input, {
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+    ...init,
+  });
+
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => null)) as {
+      error?: string;
+    } | null;
+
+    throw new Error(
+      payload?.error ?? `Request failed with status ${response.status}`,
+    );
+  }
+
+  return (await response.json()) as T;
+}
+
+function formatTimestamp(value: string | null): string {
+  if (!value) {
+    return "No messages yet";
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function getDisplayName(session: SessionData | null | undefined): string {
+  const name = session?.user?.name?.trim();
+  if (name) {
+    return name;
+  }
+
+  return session?.user?.email ?? "family member";
+}
+
+function getStatusTone(status: InboxMessage["status"]): string {
+  switch (status) {
+    case "used":
+      return "status-chip status-chip--used";
+    case "expired":
+      return "status-chip status-chip--expired";
+    default:
+      return "status-chip status-chip--new";
+  }
+}
 
 export function App() {
-  const session = authClient.useSession();
+  const {
+    data: session,
+    error: sessionError,
+    isPending: isSessionPending,
+    refetch,
+  } = authClient.useSession();
+  const [loginState, setLoginState] = useState<LoginState>(INITIAL_LOGIN_STATE);
+  const [loginError, setLoginError] = useState<string | null>(null);
+  const [isLoggingIn, setIsLoggingIn] = useState(false);
+  const [providers, setProviders] = useState<ProviderSummary[]>([]);
+  const [selectedProviderKey, setSelectedProviderKey] = useState<string | null>(
+    null,
+  );
+  const [messages, setMessages] = useState<InboxMessage[]>([]);
+  const [selectedMessageId, setSelectedMessageId] = useState<string | null>(
+    null,
+  );
+  const [quarantineMessages, setQuarantineMessages] = useState<
+    QuarantineMessage[]
+  >([]);
+  const [selectedQuarantineId, setSelectedQuarantineId] = useState<
+    string | null
+  >(null);
+  const [isLoadingInbox, setIsLoadingInbox] = useState(false);
+  const [isLoadingQuarantine, setIsLoadingQuarantine] = useState(false);
+  const [isSavingMessage, setIsSavingMessage] = useState(false);
+  const [isReviewingQuarantine, setIsReviewingQuarantine] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [viewError, setViewError] = useState<string | null>(null);
+  const [releaseProviderKey, setReleaseProviderKey] = useState<string>("");
+
+  const isAuthenticated = Boolean(session?.user?.email);
+  const isOwner = session?.user?.role === "admin";
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setProviders([]);
+      setMessages([]);
+      setQuarantineMessages([]);
+      setSelectedProviderKey(null);
+      setSelectedMessageId(null);
+      setSelectedQuarantineId(null);
+      setReleaseProviderKey("");
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadProviders = async () => {
+      setIsLoadingInbox(true);
+      setViewError(null);
+
+      try {
+        const response = await fetchJson<{ providers: ProviderSummary[] }>(
+          "/api/inbox/providers",
+        );
+
+        if (cancelled) {
+          return;
+        }
+
+        setProviders(response.providers);
+        setReleaseProviderKey((current) => {
+          if (
+            current &&
+            response.providers.some(
+              (provider) => provider.provider_key === current,
+            )
+          ) {
+            return current;
+          }
+
+          return response.providers[0]?.provider_key ?? "";
+        });
+        setSelectedProviderKey((current) => {
+          if (
+            current &&
+            response.providers.some(
+              (provider) => provider.provider_key === current,
+            )
+          ) {
+            return current;
+          }
+
+          return response.providers[0]?.provider_key ?? null;
+        });
+      } catch (error) {
+        if (!cancelled) {
+          setViewError(
+            error instanceof Error ? error.message : "Unable to load providers",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingInbox(false);
+        }
+      }
+    };
+
+    void loadProviders();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated]);
+
+  useEffect(() => {
+    if (!isAuthenticated || !selectedProviderKey) {
+      setMessages([]);
+      setSelectedMessageId(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadMessages = async () => {
+      setIsLoadingInbox(true);
+      setViewError(null);
+
+      try {
+        const response = await fetchJson<ProviderMessagesResponse>(
+          `/api/inbox/providers/${selectedProviderKey}`,
+        );
+
+        if (cancelled) {
+          return;
+        }
+
+        setMessages(response.messages);
+        setSelectedMessageId((current) => {
+          if (
+            current &&
+            response.messages.some((message) => message.id === current)
+          ) {
+            return current;
+          }
+
+          return response.messages[0]?.id ?? null;
+        });
+      } catch (error) {
+        if (!cancelled) {
+          setViewError(
+            error instanceof Error ? error.message : "Unable to load messages",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingInbox(false);
+        }
+      }
+    };
+
+    void loadMessages();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, selectedProviderKey]);
+
+  useEffect(() => {
+    if (!isAuthenticated || !isOwner) {
+      setQuarantineMessages([]);
+      setSelectedQuarantineId(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadQuarantine = async () => {
+      setIsLoadingQuarantine(true);
+
+      try {
+        const response = await fetchJson<{ messages: QuarantineMessage[] }>(
+          "/api/inbox/quarantine",
+        );
+
+        if (cancelled) {
+          return;
+        }
+
+        setQuarantineMessages(response.messages);
+        setSelectedQuarantineId((current) => {
+          if (
+            current &&
+            response.messages.some((message) => message.id === current)
+          ) {
+            return current;
+          }
+
+          return response.messages[0]?.id ?? null;
+        });
+      } catch (error) {
+        if (!cancelled) {
+          setViewError(
+            error instanceof Error
+              ? error.message
+              : "Unable to load quarantine",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingQuarantine(false);
+        }
+      }
+    };
+
+    void loadQuarantine();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, isOwner]);
+
+  const selectedProvider = useMemo(
+    () =>
+      providers.find(
+        (provider) => provider.provider_key === selectedProviderKey,
+      ) ?? null,
+    [providers, selectedProviderKey],
+  );
+
+  const selectedMessage = useMemo(
+    () => messages.find((message) => message.id === selectedMessageId) ?? null,
+    [messages, selectedMessageId],
+  );
+
+  const selectedQuarantineMessage = useMemo(
+    () =>
+      quarantineMessages.find(
+        (message) => message.id === selectedQuarantineId,
+      ) ?? null,
+    [quarantineMessages, selectedQuarantineId],
+  );
+
+  async function refreshProviders() {
+    if (!isAuthenticated) {
+      return;
+    }
+
+    const response = await fetchJson<{ providers: ProviderSummary[] }>(
+      "/api/inbox/providers",
+    );
+    setProviders(response.providers);
+    setReleaseProviderKey((current) => {
+      if (
+        current &&
+        response.providers.some((provider) => provider.provider_key === current)
+      ) {
+        return current;
+      }
+
+      return response.providers[0]?.provider_key ?? "";
+    });
+  }
+
+  async function refreshQuarantine() {
+    if (!isAuthenticated || !isOwner) {
+      return;
+    }
+
+    const response = await fetchJson<{ messages: QuarantineMessage[] }>(
+      "/api/inbox/quarantine",
+    );
+    setQuarantineMessages(response.messages);
+    setSelectedQuarantineId((current) => {
+      if (
+        current &&
+        response.messages.some((message) => message.id === current)
+      ) {
+        return current;
+      }
+
+      return response.messages[0]?.id ?? null;
+    });
+  }
+
+  async function handleLogin(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setLoginError(null);
+    setIsLoggingIn(true);
+
+    const { error } = await authClient.signIn.email({
+      email: loginState.email,
+      password: loginState.password,
+      rememberMe: true,
+    });
+
+    setIsLoggingIn(false);
+
+    if (error) {
+      setLoginError(error.message ?? "Unable to sign in with that account.");
+      return;
+    }
+
+    setLoginState(INITIAL_LOGIN_STATE);
+    await refetch();
+  }
+
+  async function handleLogout() {
+    setStatusMessage(null);
+    setViewError(null);
+    await authClient.signOut({});
+    await refetch();
+  }
+
+  async function handleStatusChange(nextStatus: InboxMessage["status"]) {
+    if (!selectedMessage) {
+      return;
+    }
+
+    setIsSavingMessage(true);
+    setStatusMessage(null);
+    setViewError(null);
+
+    try {
+      const response = await fetchJson<{ message: InboxMessage }>(
+        `/api/inbox/messages/${selectedMessage.id}/status`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({ status: nextStatus }),
+        },
+      );
+
+      setMessages((current) =>
+        current.map((message) =>
+          message.id === response.message.id ? response.message : message,
+        ),
+      );
+      setStatusMessage(`Marked message as ${nextStatus}.`);
+      await refreshProviders();
+    } catch (error) {
+      setViewError(
+        error instanceof Error
+          ? error.message
+          : "Unable to update the message status",
+      );
+    } finally {
+      setIsSavingMessage(false);
+    }
+  }
+
+  async function handleQuarantineReview(action: "dismiss" | "release") {
+    if (!selectedQuarantineMessage) {
+      return;
+    }
+
+    setIsReviewingQuarantine(true);
+    setStatusMessage(null);
+    setViewError(null);
+
+    try {
+      await fetchJson(
+        `/api/inbox/quarantine/${selectedQuarantineMessage.id}/review`,
+        {
+          method: "POST",
+          body: JSON.stringify(
+            action === "release"
+              ? { action, providerKey: releaseProviderKey }
+              : { action },
+          ),
+        },
+      );
+
+      setStatusMessage(
+        action === "release"
+          ? "Quarantined message released to the selected provider."
+          : "Quarantined message dismissed.",
+      );
+
+      await Promise.all([refreshQuarantine(), refreshProviders()]);
+    } catch (error) {
+      setViewError(
+        error instanceof Error ? error.message : "Unable to review quarantine",
+      );
+    } finally {
+      setIsReviewingQuarantine(false);
+    }
+  }
+
+  if (isSessionPending) {
+    return (
+      <main className="app-shell">
+        <section className="hero-card hero-card--centered">
+          <p className="eyebrow">Mi Casa Su Casa</p>
+          <h1>Loading your shared inbox…</h1>
+          <p className="lede">
+            Checking the current session and preparing the latest messages.
+          </p>
+        </section>
+      </main>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <main className="app-shell">
+        <section className="hero-card auth-card">
+          <div>
+            <p className="eyebrow">Mi Casa Su Casa</p>
+            <h1>Shared verification inbox, without the chaos.</h1>
+            <p className="lede">
+              Sign in with your invited household account to see the provider
+              groups you have access to and quickly find the latest verification
+              code.
+            </p>
+          </div>
+
+          <form className="auth-form" onSubmit={handleLogin}>
+            <label className="field-group">
+              <span>Email</span>
+              <input
+                autoComplete="email"
+                name="email"
+                type="email"
+                value={loginState.email}
+                onChange={(event) =>
+                  setLoginState((current) => ({
+                    ...current,
+                    email: event.target.value,
+                  }))
+                }
+                required
+              />
+            </label>
+
+            <label className="field-group">
+              <span>Password</span>
+              <input
+                autoComplete="current-password"
+                name="password"
+                type="password"
+                value={loginState.password}
+                onChange={(event) =>
+                  setLoginState((current) => ({
+                    ...current,
+                    password: event.target.value,
+                  }))
+                }
+                required
+              />
+            </label>
+
+            {loginError || sessionError ? (
+              <p className="inline-error">
+                {loginError ?? sessionError?.message}
+              </p>
+            ) : null}
+
+            <button
+              className="primary-button"
+              disabled={isLoggingIn}
+              type="submit"
+            >
+              {isLoggingIn ? "Signing in…" : "Sign in"}
+            </button>
+          </form>
+        </section>
+      </main>
+    );
+  }
 
   return (
-    <main className="app-shell">
-      <section className="hero-card">
-        <p className="eyebrow">Mi Casa Su Casa</p>
-        <h1>Shared verification inbox, without the chaos.</h1>
-        <p className="lede">
-          Cloudflare-native shared inbox for families, with provider-scoped
-          access and owner-only quarantine review.
-        </p>
-        <div className="status-card">
-          <p className="status-label">Auth session</p>
-          <pre>{JSON.stringify(session.data ?? null, null, 2)}</pre>
+    <main className="dashboard-shell">
+      <section className="topbar-card">
+        <div>
+          <p className="eyebrow">Mi Casa Su Casa</p>
+          <h1>Welcome back, {getDisplayName(session)}.</h1>
+          <p className="lede">
+            Scan the latest provider messages, open the code you need, and keep
+            the inbox tidy for the next person.
+          </p>
         </div>
+
+        <div className="topbar-actions">
+          <div className="session-summary">
+            <span className="session-summary__label">Access</span>
+            <strong>{isOwner ? "Owner" : "Family member"}</strong>
+            <span>{session?.user?.email}</span>
+          </div>
+
+          <button
+            className="secondary-button"
+            onClick={handleLogout}
+            type="button"
+          >
+            Sign out
+          </button>
+        </div>
+      </section>
+
+      {statusMessage || viewError ? (
+        <section className="feedback-row" aria-live="polite">
+          {statusMessage ? (
+            <p className="feedback-pill">{statusMessage}</p>
+          ) : null}
+          {viewError ? (
+            <p className="feedback-pill feedback-pill--error">{viewError}</p>
+          ) : null}
+        </section>
+      ) : null}
+
+      <section className="dashboard-grid">
+        <aside className="panel-card provider-panel">
+          <div className="panel-heading">
+            <div>
+              <p className="panel-eyebrow">Providers</p>
+              <h2>Your accessible groups</h2>
+            </div>
+            <span className="panel-meta">{providers.length} total</span>
+          </div>
+
+          <div className="provider-list">
+            {providers.map((provider) => {
+              const isSelected = provider.provider_key === selectedProviderKey;
+
+              return (
+                <button
+                  aria-pressed={isSelected}
+                  className={
+                    isSelected
+                      ? "provider-card provider-card--selected"
+                      : "provider-card"
+                  }
+                  key={provider.provider_key}
+                  onClick={() => setSelectedProviderKey(provider.provider_key)}
+                  type="button"
+                >
+                  <div>
+                    <strong>{provider.display_name}</strong>
+                    <p>{formatTimestamp(provider.latest_received_at)}</p>
+                  </div>
+                  <div className="provider-stats">
+                    <span>{provider.message_count} messages</span>
+                    <span>{provider.new_count} new</span>
+                  </div>
+                </button>
+              );
+            })}
+
+            {!providers.length && !isLoadingInbox ? (
+              <div className="empty-state">
+                <strong>No providers yet</strong>
+                <p>
+                  Once messages arrive for your household services, they’ll
+                  appear here.
+                </p>
+              </div>
+            ) : null}
+          </div>
+        </aside>
+
+        <section className="panel-card inbox-panel">
+          <div className="panel-heading">
+            <div>
+              <p className="panel-eyebrow">Inbox</p>
+              <h2>{selectedProvider?.display_name ?? "Choose a provider"}</h2>
+            </div>
+            {selectedProvider ? (
+              <span className="panel-meta">{messages.length} messages</span>
+            ) : null}
+          </div>
+
+          <div className="two-column-panel">
+            <div className="message-list">
+              {messages.map((message) => {
+                const isSelected = message.id === selectedMessageId;
+
+                return (
+                  <button
+                    aria-pressed={isSelected}
+                    className={
+                      isSelected
+                        ? "message-card message-card--selected"
+                        : "message-card"
+                    }
+                    key={message.id}
+                    onClick={() => setSelectedMessageId(message.id)}
+                    type="button"
+                  >
+                    <div className="message-card__header">
+                      <strong>{message.subject ?? "Untitled message"}</strong>
+                      <span className={getStatusTone(message.status)}>
+                        {message.status}
+                      </span>
+                    </div>
+                    <p>{message.from_header ?? "Unknown sender"}</p>
+                    <span>{formatTimestamp(message.received_at)}</span>
+                  </button>
+                );
+              })}
+
+              {!messages.length && !isLoadingInbox ? (
+                <div className="empty-state">
+                  <strong>No messages here yet</strong>
+                  <p>
+                    Select another provider or wait for the next verification
+                    email.
+                  </p>
+                </div>
+              ) : null}
+            </div>
+
+            <article className="detail-panel">
+              {selectedMessage ? (
+                <>
+                  <div className="detail-panel__header">
+                    <div>
+                      <p className="panel-eyebrow">Message detail</p>
+                      <h3>{selectedMessage.subject ?? "Untitled message"}</h3>
+                      <p>{selectedMessage.from_header ?? "Unknown sender"}</p>
+                    </div>
+                    <span className={getStatusTone(selectedMessage.status)}>
+                      {selectedMessage.status}
+                    </span>
+                  </div>
+
+                  <div className="code-card">
+                    <span className="code-card__label">Verification code</span>
+                    <strong>
+                      {selectedMessage.extracted_code ?? "No code detected"}
+                    </strong>
+                  </div>
+
+                  <div className="message-actions">
+                    <button
+                      className="secondary-button"
+                      disabled={isSavingMessage}
+                      onClick={() => handleStatusChange("new")}
+                      type="button"
+                    >
+                      Mark new
+                    </button>
+                    <button
+                      className="secondary-button"
+                      disabled={isSavingMessage}
+                      onClick={() => handleStatusChange("used")}
+                      type="button"
+                    >
+                      Mark used
+                    </button>
+                    <button
+                      className="secondary-button"
+                      disabled={isSavingMessage}
+                      onClick={() => handleStatusChange("expired")}
+                      type="button"
+                    >
+                      Mark expired
+                    </button>
+                  </div>
+
+                  <section className="message-body-card">
+                    <h4>Plain-text message</h4>
+                    <pre>{selectedMessage.text_body}</pre>
+                  </section>
+                </>
+              ) : (
+                <div className="empty-state empty-state--detail">
+                  <strong>Select a message</strong>
+                  <p>
+                    Pick the most recent message in a provider group to see the
+                    full code and body.
+                  </p>
+                </div>
+              )}
+            </article>
+          </div>
+        </section>
+
+        {isOwner ? (
+          <section className="panel-card quarantine-panel">
+            <div className="panel-heading">
+              <div>
+                <p className="panel-eyebrow">Owner tools</p>
+                <h2>Quarantine review</h2>
+              </div>
+              <span className="panel-meta">
+                {quarantineMessages.length} pending
+              </span>
+            </div>
+
+            <div className="two-column-panel">
+              <div className="message-list">
+                {quarantineMessages.map((message) => {
+                  const isSelected = message.id === selectedQuarantineId;
+
+                  return (
+                    <button
+                      aria-pressed={isSelected}
+                      className={
+                        isSelected
+                          ? "message-card message-card--selected"
+                          : "message-card"
+                      }
+                      key={message.id}
+                      onClick={() => setSelectedQuarantineId(message.id)}
+                      type="button"
+                    >
+                      <div className="message-card__header">
+                        <strong>{message.subject ?? "Untitled message"}</strong>
+                        <span className="status-chip status-chip--quarantine">
+                          review
+                        </span>
+                      </div>
+                      <p>{message.envelope_from}</p>
+                      <span>{formatTimestamp(message.received_at)}</span>
+                    </button>
+                  );
+                })}
+
+                {!quarantineMessages.length && !isLoadingQuarantine ? (
+                  <div className="empty-state">
+                    <strong>Quarantine is empty</strong>
+                    <p>
+                      Messages that need manual classification will appear here
+                      for owner review.
+                    </p>
+                  </div>
+                ) : null}
+              </div>
+
+              <article className="detail-panel">
+                {selectedQuarantineMessage ? (
+                  <>
+                    <div className="detail-panel__header">
+                      <div>
+                        <p className="panel-eyebrow">Quarantine detail</p>
+                        <h3>
+                          {selectedQuarantineMessage.subject ??
+                            "Untitled message"}
+                        </h3>
+                        <p>{selectedQuarantineMessage.envelope_from}</p>
+                      </div>
+                      <span className="status-chip status-chip--quarantine">
+                        Needs review
+                      </span>
+                    </div>
+
+                    <div className="code-card">
+                      <span className="code-card__label">Detected code</span>
+                      <strong>
+                        {selectedQuarantineMessage.extracted_code ??
+                          "No code detected"}
+                      </strong>
+                    </div>
+
+                    <section className="message-body-card message-body-card--tight">
+                      <h4>Why it was quarantined</h4>
+                      <p>{selectedQuarantineMessage.quarantine_reason}</p>
+                    </section>
+
+                    <label className="field-group">
+                      <span>Release to provider</span>
+                      <select
+                        value={releaseProviderKey}
+                        onChange={(event) =>
+                          setReleaseProviderKey(event.target.value)
+                        }
+                      >
+                        {providers.map((provider) => (
+                          <option
+                            key={provider.provider_key}
+                            value={provider.provider_key}
+                          >
+                            {provider.display_name}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+
+                    <div className="message-actions">
+                      <button
+                        className="primary-button"
+                        disabled={isReviewingQuarantine || !releaseProviderKey}
+                        onClick={() => handleQuarantineReview("release")}
+                        type="button"
+                      >
+                        Release to inbox
+                      </button>
+                      <button
+                        className="secondary-button"
+                        disabled={isReviewingQuarantine}
+                        onClick={() => handleQuarantineReview("dismiss")}
+                        type="button"
+                      >
+                        Dismiss
+                      </button>
+                    </div>
+
+                    <section className="message-body-card">
+                      <h4>Plain-text message</h4>
+                      <pre>{selectedQuarantineMessage.text_body}</pre>
+                    </section>
+                  </>
+                ) : (
+                  <div className="empty-state empty-state--detail">
+                    <strong>Select a quarantined message</strong>
+                    <p>
+                      Review the classification reason, then release it to the
+                      right provider or dismiss it.
+                    </p>
+                  </div>
+                )}
+              </article>
+            </div>
+          </section>
+        ) : null}
       </section>
     </main>
   );

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -5,6 +5,7 @@
     "Segoe UI", sans-serif;
   background: #f4efe7;
   color: #1f2937;
+  line-height: 1.5;
 }
 
 * {
@@ -15,6 +16,12 @@ body {
   margin: 0;
   min-height: 100vh;
   background: linear-gradient(180deg, #f9f4ed 0%, #efe6da 100%);
+}
+
+button,
+input,
+select {
+  font: inherit;
 }
 
 .app-shell {
@@ -31,6 +38,15 @@ body {
   border-radius: 1.5rem;
   padding: 2rem;
   box-shadow: 0 24px 80px rgba(15, 23, 42, 0.08);
+}
+
+.hero-card--centered {
+  text-align: center;
+}
+
+.auth-card {
+  display: grid;
+  gap: 1.5rem;
 }
 
 .eyebrow {
@@ -75,4 +91,380 @@ pre {
   margin: 0;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+.auth-form,
+.field-group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.auth-form {
+  margin-top: 0.5rem;
+}
+
+.field-group span {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #7c5430;
+}
+
+.field-group input,
+.field-group select {
+  width: 100%;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.9rem;
+  padding: 0.85rem 1rem;
+  background: rgba(255, 255, 255, 0.96);
+  color: #1f2937;
+}
+
+.field-group input:focus,
+.field-group select:focus {
+  outline: 2px solid rgba(154, 111, 69, 0.25);
+  border-color: rgba(154, 111, 69, 0.45);
+}
+
+.primary-button,
+.secondary-button,
+.provider-card,
+.message-card {
+  border: 0;
+  cursor: pointer;
+}
+
+.primary-button,
+.secondary-button {
+  border-radius: 999px;
+  padding: 0.8rem 1.2rem;
+  transition:
+    transform 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.primary-button {
+  background: linear-gradient(135deg, #9a6f45, #7c5430);
+  color: white;
+  box-shadow: 0 12px 24px rgba(124, 84, 48, 0.22);
+}
+
+.secondary-button {
+  background: rgba(255, 255, 255, 0.9);
+  color: #1f2937;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+}
+
+.primary-button:hover,
+.secondary-button:hover,
+.provider-card:hover,
+.message-card:hover {
+  transform: translateY(-1px);
+}
+
+.primary-button:disabled,
+.secondary-button:disabled {
+  opacity: 0.6;
+  cursor: wait;
+  transform: none;
+}
+
+.inline-error {
+  margin: 0;
+  color: #b42318;
+  font-weight: 600;
+}
+
+.dashboard-shell {
+  min-height: 100vh;
+  padding: 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.topbar-card,
+.panel-card {
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 1.4rem;
+  box-shadow: 0 18px 64px rgba(15, 23, 42, 0.08);
+}
+
+.topbar-card {
+  padding: 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.topbar-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.session-summary {
+  display: grid;
+  gap: 0.15rem;
+  color: #475569;
+}
+
+.session-summary strong {
+  color: #1f2937;
+}
+
+.session-summary__label,
+.panel-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.72rem;
+  color: #9a6f45;
+}
+
+.feedback-row {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.feedback-pill {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border-radius: 1rem;
+  background: rgba(13, 148, 136, 0.12);
+  color: #115e59;
+  font-weight: 600;
+}
+
+.feedback-pill--error {
+  background: rgba(180, 35, 24, 0.12);
+  color: #b42318;
+}
+
+.dashboard-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.panel-card {
+  padding: 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.panel-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.panel-heading h2,
+.detail-panel__header h3,
+.message-body-card h4 {
+  margin: 0;
+}
+
+.panel-heading p,
+.detail-panel__header p,
+.empty-state p,
+.message-card p,
+.provider-card p,
+.message-body-card p {
+  margin: 0;
+}
+
+.panel-meta {
+  color: #64748b;
+  font-size: 0.9rem;
+  white-space: nowrap;
+}
+
+.provider-list,
+.message-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.provider-card,
+.message-card {
+  width: 100%;
+  text-align: left;
+  border-radius: 1.1rem;
+  background: rgba(248, 250, 252, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 1rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.provider-card--selected,
+.message-card--selected {
+  border-color: rgba(154, 111, 69, 0.5);
+  box-shadow: inset 0 0 0 1px rgba(154, 111, 69, 0.28);
+  background: rgba(255, 249, 243, 0.95);
+}
+
+.provider-stats,
+.message-card span,
+.message-card p,
+.provider-card p,
+.detail-panel__header p,
+.message-body-card p,
+.empty-state p {
+  color: #64748b;
+}
+
+.provider-stats {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  font-size: 0.9rem;
+}
+
+.two-column-panel {
+  display: grid;
+  gap: 1rem;
+}
+
+.detail-panel {
+  border-radius: 1.2rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(255, 252, 248, 0.82);
+  padding: 1rem;
+  display: grid;
+  gap: 1rem;
+  align-content: start;
+}
+
+.detail-panel__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.message-card__header {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.28rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.status-chip--new {
+  background: rgba(15, 118, 110, 0.14);
+  color: #0f766e;
+}
+
+.status-chip--used {
+  background: rgba(71, 85, 105, 0.14);
+  color: #334155;
+}
+
+.status-chip--expired {
+  background: rgba(180, 83, 9, 0.14);
+  color: #b45309;
+}
+
+.status-chip--quarantine {
+  background: rgba(180, 35, 24, 0.14);
+  color: #b42318;
+}
+
+.code-card {
+  border-radius: 1.15rem;
+  padding: 1rem;
+  background: linear-gradient(
+    135deg,
+    rgba(154, 111, 69, 0.12),
+    rgba(124, 84, 48, 0.08)
+  );
+  border: 1px solid rgba(154, 111, 69, 0.16);
+  display: grid;
+  gap: 0.45rem;
+}
+
+.code-card__label {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.72rem;
+  color: #7c5430;
+}
+
+.code-card strong {
+  font-size: clamp(1.8rem, 7vw, 3rem);
+  letter-spacing: 0.18em;
+}
+
+.message-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.message-body-card {
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.message-body-card--tight {
+  gap: 0.35rem;
+}
+
+.empty-state {
+  border-radius: 1.1rem;
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  padding: 1rem;
+  background: rgba(248, 250, 252, 0.72);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.empty-state--detail {
+  min-height: 16rem;
+  place-content: center;
+  text-align: center;
+}
+
+@media (min-width: 720px) {
+  .dashboard-shell {
+    padding: 1.5rem;
+  }
+
+  .topbar-card {
+    grid-template-columns: 1fr auto;
+    align-items: center;
+  }
+
+  .topbar-actions {
+    align-items: flex-end;
+  }
+
+  .two-column-panel {
+    grid-template-columns: minmax(18rem, 22rem) minmax(0, 1fr);
+  }
+}
+
+@media (min-width: 1120px) {
+  .dashboard-grid {
+    grid-template-columns: minmax(17rem, 20rem) minmax(0, 1.2fr);
+    align-items: start;
+  }
+
+  .quarantine-panel {
+    grid-column: 1 / -1;
+  }
 }

--- a/src/server/db/repositories/messages.ts
+++ b/src/server/db/repositories/messages.ts
@@ -1,7 +1,10 @@
 import type {
   ClassificationResult,
   InboxMessageRow,
+  MessageStatus,
   ParsedIncomingEmail,
+  ProviderSummaryRow,
+  QuarantineMessageRow,
 } from "../types";
 
 const RETENTION_DAYS = 30;
@@ -126,12 +129,13 @@ export async function listMessagesForProvider(
 ): Promise<InboxMessageRow[]> {
   const result = await db
     .prepare(
-      `SELECT messages.id, providers.provider_key, messages.subject, messages.text_body,
+      `SELECT messages.id, providers.provider_key, providers.display_name AS provider_display_name,
+              messages.subject, messages.from_header, messages.text_body,
               messages.extracted_code, messages.status, messages.received_at
        FROM messages
        INNER JOIN providers ON providers.id = messages.provider_id
        WHERE providers.provider_key = ?
-       ORDER BY messages.received_at DESC`,
+        ORDER BY messages.received_at DESC`,
     )
     .bind(providerKey)
     .run<InboxMessageRow>();
@@ -139,20 +143,204 @@ export async function listMessagesForProvider(
   return result.results ?? [];
 }
 
-export async function listQuarantineMessages(
+export async function listProviderSummariesForUser(
   db: D1Database,
-): Promise<InboxMessageRow[]> {
+  userId: string,
+  role: string,
+): Promise<ProviderSummaryRow[]> {
   const result = await db
     .prepare(
-      `SELECT id, 'quarantine' AS provider_key, subject, text_body, extracted_code,
-              'new' AS status, received_at
-       FROM quarantine_messages
-       WHERE reviewed_at IS NULL
-       ORDER BY received_at DESC`,
+      `SELECT providers.provider_key,
+              providers.display_name,
+              CAST(COUNT(messages.id) AS INTEGER) AS message_count,
+              CAST(COALESCE(SUM(CASE WHEN messages.status = 'new' THEN 1 ELSE 0 END), 0) AS INTEGER) AS new_count,
+              MAX(messages.received_at) AS latest_received_at
+       FROM providers
+       LEFT JOIN user_provider_access
+         ON user_provider_access.provider_id = providers.id AND user_provider_access.user_id = ?
+       LEFT JOIN messages ON messages.provider_id = providers.id
+       WHERE ? = 'admin' OR user_provider_access.user_id IS NOT NULL
+       GROUP BY providers.id, providers.provider_key, providers.display_name, providers.created_at
+       ORDER BY COALESCE(MAX(messages.received_at), providers.created_at) DESC, providers.display_name ASC`,
     )
-    .run<InboxMessageRow>();
+    .bind(userId, role)
+    .run<ProviderSummaryRow>();
 
   return result.results ?? [];
+}
+
+export async function listQuarantineMessages(
+  db: D1Database,
+): Promise<QuarantineMessageRow[]> {
+  const result = await db
+    .prepare(
+      `SELECT id,
+              'quarantine' AS provider_key,
+              'Quarantine' AS provider_display_name,
+              subject,
+              from_header,
+              envelope_from,
+              text_body,
+              extracted_code,
+              'new' AS status,
+              quarantine_reason,
+              received_at
+       FROM quarantine_messages
+       WHERE reviewed_at IS NULL
+        ORDER BY received_at DESC`,
+    )
+    .run<QuarantineMessageRow>();
+
+  return result.results ?? [];
+}
+
+export async function updateMessageStatus(
+  db: D1Database,
+  messageId: string,
+  status: MessageStatus,
+): Promise<InboxMessageRow | null> {
+  await db
+    .prepare("UPDATE messages SET status = ? WHERE id = ?")
+    .bind(status, messageId)
+    .run();
+
+  return db
+    .prepare(
+      `SELECT messages.id, providers.provider_key, providers.display_name AS provider_display_name,
+              messages.subject, messages.from_header, messages.text_body,
+              messages.extracted_code, messages.status, messages.received_at
+       FROM messages
+       INNER JOIN providers ON providers.id = messages.provider_id
+       WHERE messages.id = ?
+       LIMIT 1`,
+    )
+    .bind(messageId)
+    .first<InboxMessageRow>();
+}
+
+export async function findMessageById(
+  db: D1Database,
+  messageId: string,
+): Promise<InboxMessageRow | null> {
+  return db
+    .prepare(
+      `SELECT messages.id, providers.provider_key, providers.display_name AS provider_display_name,
+              messages.subject, messages.from_header, messages.text_body,
+              messages.extracted_code, messages.status, messages.received_at
+       FROM messages
+       INNER JOIN providers ON providers.id = messages.provider_id
+       WHERE messages.id = ?
+       LIMIT 1`,
+    )
+    .bind(messageId)
+    .first<InboxMessageRow>();
+}
+
+type QuarantineMessageRecord = {
+  id: string;
+  message_id: string;
+  envelope_from: string;
+  envelope_to: string;
+  from_header: string | null;
+  subject: string | null;
+  text_body: string;
+  extracted_code: string | null;
+  quarantine_reason: string;
+  raw_size: number;
+  received_at: string;
+  delete_after: string;
+  reviewed_at: string | null;
+};
+
+async function findQuarantineMessageRecord(
+  db: D1Database,
+  messageId: string,
+): Promise<QuarantineMessageRecord | null> {
+  return db
+    .prepare(
+      `SELECT id, message_id, envelope_from, envelope_to, from_header, subject,
+              text_body, extracted_code, quarantine_reason, raw_size,
+              received_at, delete_after, reviewed_at
+       FROM quarantine_messages
+       WHERE id = ?
+       LIMIT 1`,
+    )
+    .bind(messageId)
+    .first<QuarantineMessageRecord>();
+}
+
+export async function reviewQuarantineMessage(
+  db: D1Database,
+  messageId: string,
+  review: { action: "dismiss" | "release"; providerId?: string },
+): Promise<{
+  reviewedAt: string;
+  releasedMessage: InboxMessageRow | null;
+} | null> {
+  const record = await findQuarantineMessageRecord(db, messageId);
+
+  if (!record || record.reviewed_at) {
+    return null;
+  }
+
+  const reviewedAt = new Date().toISOString();
+  let releasedMessage: InboxMessageRow | null = null;
+
+  if (review.action === "release") {
+    if (!review.providerId) {
+      throw new Error(
+        "Provider id is required to release a quarantined message.",
+      );
+    }
+
+    await db
+      .prepare(
+        `INSERT INTO messages (
+          id, message_id, provider_id, envelope_from, envelope_to, from_header, subject,
+          text_body, extracted_code, status, classification_reason, raw_size, received_at, delete_after
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        crypto.randomUUID(),
+        record.message_id,
+        review.providerId,
+        record.envelope_from,
+        record.envelope_to,
+        record.from_header,
+        record.subject,
+        record.text_body,
+        record.extracted_code,
+        "new",
+        `Released from quarantine by owner review. Original reason: ${record.quarantine_reason}`,
+        record.raw_size,
+        record.received_at,
+        record.delete_after,
+      )
+      .run();
+
+    const result = await db
+      .prepare(
+        `SELECT messages.id, providers.provider_key, providers.display_name AS provider_display_name,
+                messages.subject, messages.from_header, messages.text_body,
+                messages.extracted_code, messages.status, messages.received_at
+         FROM messages
+         INNER JOIN providers ON providers.id = messages.provider_id
+         WHERE messages.message_id = ?
+         ORDER BY messages.created_at DESC
+         LIMIT 1`,
+      )
+      .bind(record.message_id)
+      .first<InboxMessageRow>();
+
+    releasedMessage = result ?? null;
+  }
+
+  await db
+    .prepare("UPDATE quarantine_messages SET reviewed_at = ? WHERE id = ?")
+    .bind(reviewedAt, messageId)
+    .run();
+
+  return { reviewedAt, releasedMessage };
 }
 
 export async function purgeExpired(db: D1Database, nowIso: string) {

--- a/src/server/db/repositories/provider-rules.ts
+++ b/src/server/db/repositories/provider-rules.ts
@@ -1,3 +1,5 @@
+import type { ProviderRow } from "../types";
+
 export type SenderRuleMatch = {
   providerId: string;
   providerKey: string;
@@ -56,4 +58,19 @@ export async function userHasProviderAccess(
     .first<{ allowed: number }>();
 
   return Boolean(row?.allowed);
+}
+
+export async function getProviderByKey(
+  db: D1Database,
+  providerKey: string,
+): Promise<ProviderRow | null> {
+  return db
+    .prepare(
+      `SELECT id, provider_key, display_name
+       FROM providers
+       WHERE provider_key = ?
+       LIMIT 1`,
+    )
+    .bind(providerKey)
+    .first<ProviderRow>();
 }

--- a/src/server/db/types.ts
+++ b/src/server/db/types.ts
@@ -26,9 +26,41 @@ export type ParsedIncomingEmail = {
 export type InboxMessageRow = {
   id: string;
   provider_key: string;
+  provider_display_name: string;
   subject: string | null;
+  from_header: string | null;
   text_body: string;
   extracted_code: string | null;
   status: "new" | "used" | "expired";
   received_at: string;
 };
+
+export type ProviderSummaryRow = {
+  provider_key: string;
+  display_name: string;
+  message_count: number;
+  new_count: number;
+  latest_received_at: string | null;
+};
+
+export type QuarantineMessageRow = {
+  id: string;
+  provider_key: "quarantine";
+  provider_display_name: "Quarantine";
+  subject: string | null;
+  from_header: string | null;
+  envelope_from: string;
+  text_body: string;
+  extracted_code: string | null;
+  status: "new";
+  quarantine_reason: string;
+  received_at: string;
+};
+
+export type ProviderRow = {
+  id: string;
+  provider_key: string;
+  display_name: string;
+};
+
+export type MessageStatus = InboxMessageRow["status"];

--- a/src/server/routes/inbox.ts
+++ b/src/server/routes/inbox.ts
@@ -6,18 +6,51 @@ import {
   requireOwner,
 } from "../auth/middleware";
 import {
+  findMessageById,
   listMessagesForProvider,
+  listProviderSummariesForUser,
   listQuarantineMessages,
+  reviewQuarantineMessage,
+  updateMessageStatus,
 } from "../db/repositories/messages";
-import { userHasProviderAccess } from "../db/repositories/provider-rules";
+import {
+  getProviderByKey,
+  userHasProviderAccess,
+} from "../db/repositories/provider-rules";
+
+const VALID_MESSAGE_STATUSES = new Set(["new", "used", "expired"]);
+
+function isValidMessageStatus(
+  status: string,
+): status is "new" | "used" | "expired" {
+  return VALID_MESSAGE_STATUSES.has(status);
+}
 
 export const inboxRoutes = new Hono<{
   Bindings: Env;
   Variables: AppVariables;
 }>();
 
+inboxRoutes.use("/providers", requireAuthenticatedUser);
 inboxRoutes.use("/providers/:providerKey", requireAuthenticatedUser);
+inboxRoutes.use("/messages/:messageId/status", requireAuthenticatedUser);
 inboxRoutes.use("/quarantine", requireOwner);
+inboxRoutes.use("/quarantine/:messageId/review", requireOwner);
+
+inboxRoutes.get("/providers", async (c) => {
+  const user = c.get("user");
+
+  if (!user) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const providers = await listProviderSummariesForUser(
+    c.env.DB,
+    user.id,
+    user.role,
+  );
+  return c.json({ providers });
+});
 
 inboxRoutes.get("/providers/:providerKey", async (c) => {
   const providerKey = c.req.param("providerKey");
@@ -34,11 +67,123 @@ inboxRoutes.get("/providers/:providerKey", async (c) => {
     }
   }
 
+  const provider = await getProviderByKey(c.env.DB, providerKey);
+
+  if (!provider) {
+    return c.json({ error: "Provider not found" }, 404);
+  }
+
   const messages = await listMessagesForProvider(c.env.DB, providerKey);
-  return c.json({ messages });
+  return c.json({
+    provider: {
+      providerKey: provider.provider_key,
+      displayName: provider.display_name,
+    },
+    messages,
+  });
+});
+
+inboxRoutes.patch("/messages/:messageId/status", async (c) => {
+  const user = c.get("user");
+  const messageId = c.req.param("messageId");
+
+  if (!user) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const existingMessage = await findMessageById(c.env.DB, messageId);
+
+  if (!existingMessage) {
+    return c.json({ error: "Message not found" }, 404);
+  }
+
+  if (user.role !== "admin") {
+    const allowed = await userHasProviderAccess(
+      c.env.DB,
+      user.id,
+      existingMessage.provider_key,
+    );
+
+    if (!allowed) {
+      return c.json({ error: "Forbidden" }, 403);
+    }
+  }
+
+  let payload: { status?: string };
+
+  try {
+    payload = await c.req.json<{ status?: string }>();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+
+  if (!payload.status || !isValidMessageStatus(payload.status)) {
+    return c.json({ error: "Invalid message status" }, 400);
+  }
+
+  const message = await updateMessageStatus(
+    c.env.DB,
+    messageId,
+    payload.status,
+  );
+
+  if (!message) {
+    return c.json({ error: "Message not found" }, 404);
+  }
+
+  return c.json({ message });
 });
 
 inboxRoutes.get("/quarantine", async (c) => {
   const messages = await listQuarantineMessages(c.env.DB);
   return c.json({ messages });
+});
+
+inboxRoutes.post("/quarantine/:messageId/review", async (c) => {
+  const messageId = c.req.param("messageId");
+
+  let payload: { action?: "dismiss" | "release"; providerKey?: string };
+
+  try {
+    payload = await c.req.json<{
+      action?: "dismiss" | "release";
+      providerKey?: string;
+    }>();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+
+  if (payload.action !== "dismiss" && payload.action !== "release") {
+    return c.json({ error: "Invalid review action" }, 400);
+  }
+
+  let providerId: string | undefined;
+
+  if (payload.action === "release") {
+    if (!payload.providerKey) {
+      return c.json(
+        { error: "providerKey is required to release a message" },
+        400,
+      );
+    }
+
+    const provider = await getProviderByKey(c.env.DB, payload.providerKey);
+
+    if (!provider) {
+      return c.json({ error: "Provider not found" }, 404);
+    }
+
+    providerId = provider.id;
+  }
+
+  const result = await reviewQuarantineMessage(c.env.DB, messageId, {
+    action: payload.action,
+    providerId,
+  });
+
+  if (!result) {
+    return c.json({ error: "Quarantine message not found" }, 404);
+  }
+
+  return c.json(result);
 });

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -1,0 +1,81 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+const authState = vi.hoisted(() => ({
+  session: null as {
+    user: {
+      email: string;
+      role: string;
+      name?: string | null;
+    };
+  } | null,
+  isPending: false,
+  error: null as { message: string } | null,
+}));
+
+vi.mock("@server/auth/client", () => ({
+  authClient: {
+    useSession: () => ({
+      data: authState.session,
+      isPending: authState.isPending,
+      error: authState.error,
+      refetch: vi.fn(async () => undefined),
+    }),
+    signIn: {
+      email: vi.fn(async () => ({ data: null, error: null })),
+    },
+    signOut: vi.fn(async () => ({ data: null, error: null })),
+  },
+}));
+
+const { App } = await import("../src/client/App");
+
+describe("App", () => {
+  it("renders the invite-only sign-in experience when signed out", () => {
+    authState.session = null;
+    authState.isPending = false;
+    authState.error = null;
+
+    const html = renderToStaticMarkup(<App />);
+
+    expect(html).toContain("Shared verification inbox, without the chaos.");
+    expect(html).toContain("Sign in");
+    expect(html).not.toContain("Quarantine review");
+  });
+
+  it("renders the inbox shell for a signed-in member", () => {
+    authState.session = {
+      user: {
+        email: "member@example.com",
+        role: "member",
+        name: "Alex",
+      },
+    };
+    authState.isPending = false;
+    authState.error = null;
+
+    const html = renderToStaticMarkup(<App />);
+
+    expect(html).toContain("Welcome back, Alex.");
+    expect(html).toContain("Your accessible groups");
+    expect(html).toContain("Choose a provider");
+    expect(html).not.toContain("Quarantine review");
+  });
+
+  it("renders owner-only quarantine tools for admins", () => {
+    authState.session = {
+      user: {
+        email: "owner@example.com",
+        role: "admin",
+      },
+    };
+    authState.isPending = false;
+    authState.error = null;
+
+    const html = renderToStaticMarkup(<App />);
+
+    expect(html).toContain("Owner tools");
+    expect(html).toContain("Quarantine review");
+    expect(html).toContain("Release to provider");
+  });
+});

--- a/test/inbox-routes.test.ts
+++ b/test/inbox-routes.test.ts
@@ -1,22 +1,59 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import worker from "../src/index";
+type SessionUser = {
+  id: string;
+  email: string;
+  role: string;
+};
+
+type DbRunner = {
+  first?: () => Promise<unknown>;
+  run?: () => Promise<{ results: unknown[] }>;
+};
+
+type DbResolver = (sql: string, params: unknown[]) => DbRunner;
+
+const sessionState = vi.hoisted(() => ({
+  current: null as {
+    user: SessionUser;
+    session: { id: string; userId: string };
+  } | null,
+}));
+
+vi.mock("../src/server/auth/auth", () => ({
+  authForEnv: () => ({
+    handler: () => new Response("auth"),
+    api: {
+      getSession: async () => sessionState.current,
+    },
+  }),
+}));
+
+const { default: worker } = await import("../src/index");
 
 type WorkerFetch = NonNullable<typeof worker.fetch>;
 
-function createEnv(overrides?: Partial<Env>): Env {
-  const db = {
-    prepare: () => ({
-      bind: () => ({
-        first: async () => ({ ok: 1 }),
-        run: async () => ({ results: [] }),
-      }),
-      first: async () => ({ ok: 1 }),
-      run: async () => ({ results: [] }),
-    }),
+function createDbStub(resolve: DbResolver): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          const runner = resolve(sql, params);
+
+          return {
+            first: async () => runner.first?.(),
+            run: async () => runner.run?.() ?? { results: [] },
+          };
+        },
+        first: async () => resolve(sql, []).first?.(),
+        run: async () => resolve(sql, []).run?.() ?? { results: [] },
+      };
+    },
     batch: async () => [],
   } as unknown as D1Database;
+}
 
+function createEnv(db: D1Database): Env {
   const assets = {
     fetch: async () => new Response("spa"),
   } as unknown as Fetcher;
@@ -34,7 +71,6 @@ function createEnv(overrides?: Partial<Env>): Env {
     DB: db,
     EMAIL: email,
     ENVIRONMENT: "test",
-    ...overrides,
   };
 }
 
@@ -54,20 +90,297 @@ function getWorkerFetch(): WorkerFetch {
   return worker.fetch;
 }
 
-describe("worker routes", () => {
-  it("returns liveness health", async () => {
-    const fetchHandler = getWorkerFetch();
-    const request = new Request(
-      "http://localhost:8787/api/health/live",
-    ) as Parameters<WorkerFetch>[0];
+async function invokeWorker(
+  path: string,
+  options: RequestInit | undefined,
+  db: D1Database,
+) {
+  const fetchHandler = getWorkerFetch();
+  const request = new Request(
+    `http://localhost:8787${path}`,
+    options,
+  ) as Parameters<WorkerFetch>[0];
 
-    const response = await fetchHandler(
-      request,
-      createEnv(),
-      createExecutionContext(),
-    );
+  return fetchHandler(request, createEnv(db), createExecutionContext());
+}
+
+describe("worker routes", () => {
+  beforeEach(() => {
+    sessionState.current = null;
+  });
+
+  it("returns liveness health", async () => {
+    const db = createDbStub((sql) => {
+      if (sql.includes("SELECT 1 AS ok")) {
+        return {
+          first: async () => ({ ok: 1 }),
+        };
+      }
+
+      return {};
+    });
+
+    const response = await invokeWorker("/api/health/live", undefined, db);
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ status: "ok" });
+  });
+
+  it("lists providers available to the signed-in user", async () => {
+    sessionState.current = {
+      user: { id: "user-1", email: "member@example.com", role: "member" },
+      session: { id: "session-1", userId: "user-1" },
+    };
+
+    const db = createDbStub((sql) => {
+      if (sql.includes("GROUP BY providers.id")) {
+        return {
+          run: async () => ({
+            results: [
+              {
+                provider_key: "netflix",
+                display_name: "Netflix",
+                message_count: 2,
+                new_count: 1,
+                latest_received_at: "2026-05-10T12:00:00.000Z",
+              },
+            ],
+          }),
+        };
+      }
+
+      return {};
+    });
+
+    const response = await invokeWorker("/api/inbox/providers", undefined, db);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      providers: [
+        {
+          provider_key: "netflix",
+          display_name: "Netflix",
+          message_count: 2,
+          new_count: 1,
+          latest_received_at: "2026-05-10T12:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it("updates message status for a permitted provider member", async () => {
+    sessionState.current = {
+      user: { id: "user-1", email: "member@example.com", role: "member" },
+      session: { id: "session-1", userId: "user-1" },
+    };
+
+    const db = createDbStub((sql, params) => {
+      if (sql.includes("WHERE messages.id = ?") && sql.includes("LIMIT 1")) {
+        return {
+          first: async () => ({
+            id: params[0],
+            provider_key: "netflix",
+            provider_display_name: "Netflix",
+            subject: "Your latest code",
+            from_header: "Netflix <login@netflix.example>",
+            text_body: "Use 123456 to continue",
+            extracted_code: "123456",
+            status: "used",
+            received_at: "2026-05-10T12:00:00.000Z",
+          }),
+        };
+      }
+
+      if (sql.includes("SELECT 1 AS allowed")) {
+        return {
+          first: async () => ({ allowed: 1 }),
+        };
+      }
+
+      if (sql.startsWith("UPDATE messages SET status = ?")) {
+        return {
+          run: async () => ({ results: [] }),
+        };
+      }
+
+      return {};
+    });
+
+    const response = await invokeWorker(
+      "/api/inbox/messages/msg-1/status",
+      {
+        method: "PATCH",
+        body: JSON.stringify({ status: "used" }),
+      },
+      db,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      message: {
+        id: "msg-1",
+        provider_key: "netflix",
+        provider_display_name: "Netflix",
+        subject: "Your latest code",
+        from_header: "Netflix <login@netflix.example>",
+        text_body: "Use 123456 to continue",
+        extracted_code: "123456",
+        status: "used",
+        received_at: "2026-05-10T12:00:00.000Z",
+      },
+    });
+  });
+
+  it("rejects invalid status payloads", async () => {
+    sessionState.current = {
+      user: { id: "admin-1", email: "owner@example.com", role: "admin" },
+      session: { id: "session-1", userId: "admin-1" },
+    };
+
+    const db = createDbStub((sql, params) => {
+      if (sql.includes("WHERE messages.id = ?") && sql.includes("LIMIT 1")) {
+        return {
+          first: async () => ({
+            id: params[0],
+            provider_key: "netflix",
+            provider_display_name: "Netflix",
+            subject: "Your latest code",
+            from_header: "Netflix <login@netflix.example>",
+            text_body: "Use 123456 to continue",
+            extracted_code: "123456",
+            status: "new",
+            received_at: "2026-05-10T12:00:00.000Z",
+          }),
+        };
+      }
+
+      return {};
+    });
+
+    const response = await invokeWorker(
+      "/api/inbox/messages/msg-1/status",
+      {
+        method: "PATCH",
+        body: JSON.stringify({ status: "archived" }),
+      },
+      db,
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid message status",
+    });
+  });
+
+  it("allows an owner to release a quarantined message to a provider", async () => {
+    sessionState.current = {
+      user: { id: "admin-1", email: "owner@example.com", role: "admin" },
+      session: { id: "session-1", userId: "admin-1" },
+    };
+
+    const db = createDbStub((sql, params) => {
+      if (
+        sql.includes("FROM providers") &&
+        sql.includes("WHERE provider_key = ?")
+      ) {
+        return {
+          first: async () => ({
+            id: "provider-1",
+            provider_key: "netflix",
+            display_name: "Netflix",
+          }),
+        };
+      }
+
+      if (
+        sql.includes("FROM quarantine_messages") &&
+        sql.includes("WHERE id = ?")
+      ) {
+        return {
+          first: async () => ({
+            id: params[0],
+            message_id: "message-123",
+            envelope_from: "login@netflix.example",
+            envelope_to: "codes@example.com",
+            from_header: "Netflix <login@netflix.example>",
+            subject: "Netflix code",
+            text_body: "Use 123456",
+            extracted_code: "123456",
+            quarantine_reason: "No sender rule matched",
+            raw_size: 512,
+            received_at: "2026-05-10T12:00:00.000Z",
+            delete_after: "2026-06-09T12:00:00.000Z",
+            reviewed_at: null,
+          }),
+        };
+      }
+
+      if (sql.startsWith("INSERT INTO messages")) {
+        return {
+          run: async () => ({ results: [] }),
+        };
+      }
+
+      if (sql.includes("WHERE messages.message_id = ?")) {
+        return {
+          first: async () => ({
+            id: "released-1",
+            provider_key: "netflix",
+            provider_display_name: "Netflix",
+            subject: "Netflix code",
+            from_header: "Netflix <login@netflix.example>",
+            text_body: "Use 123456",
+            extracted_code: "123456",
+            status: "new",
+            received_at: "2026-05-10T12:00:00.000Z",
+          }),
+        };
+      }
+
+      if (sql.startsWith("UPDATE quarantine_messages SET reviewed_at = ?")) {
+        return {
+          run: async () => ({ results: [] }),
+        };
+      }
+
+      return {};
+    });
+
+    const response = await invokeWorker(
+      "/api/inbox/quarantine/quarantine-1/review",
+      {
+        method: "POST",
+        body: JSON.stringify({ action: "release", providerKey: "netflix" }),
+      },
+      db,
+    );
+
+    expect(response.status).toBe(200);
+
+    const payload = (await response.json()) as {
+      reviewedAt: string;
+      releasedMessage: { id: string; provider_key: string; status: string };
+    };
+
+    expect(payload.reviewedAt).toMatch(/T/);
+    expect(payload.releasedMessage).toMatchObject({
+      id: "released-1",
+      provider_key: "netflix",
+      status: "new",
+    });
+  });
+
+  it("keeps quarantine owner-only", async () => {
+    sessionState.current = {
+      user: { id: "user-1", email: "member@example.com", role: "member" },
+      session: { id: "session-1", userId: "user-1" },
+    };
+
+    const db = createDbStub(() => ({}));
+
+    const response = await invokeWorker("/api/inbox/quarantine", undefined, db);
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "Forbidden" });
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,19 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
+const clientPath = new URL("./src/client", import.meta.url).pathname;
+const serverPath = new URL("./src/server", import.meta.url).pathname;
+const testPath = new URL("./test", import.meta.url).pathname;
+
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      "@client": clientPath,
+      "@server": serverPath,
+      "@test": testPath,
+    },
+  },
   root: "src/client",
   build: {
     outDir: "../../dist/client",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,17 @@
 import { defineConfig } from "vitest/config";
 
+const clientPath = new URL("./src/client", import.meta.url).pathname;
+const serverPath = new URL("./src/server", import.meta.url).pathname;
+const testPath = new URL("./test", import.meta.url).pathname;
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@client": clientPath,
+      "@server": serverPath,
+      "@test": testPath,
+    },
+  },
   test: {
     environment: "node",
     include: ["test/**/*.test.ts"],


### PR DESCRIPTION
## Summary
- build the signed-in inbox and owner quarantine dashboard with mobile-first provider, message, and code views
- add inbox API support for provider summaries, message status updates, and owner quarantine review/release flows
- add route and UI tests, plus local alias config so app and tests resolve shared modules consistently

## Testing
- npm run ci