### PR TITLE
Add owner household access management

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -44,6 +44,32 @@ type QuarantineMessage = {
   received_at: string;
 };
 
+type MemberSummary = {
+  id: string;
+  email: string;
+  name: string;
+  role: string;
+  createdAt: string;
+  updatedAt: string;
+  providerAccess: Array<{
+    providerKey: string;
+    displayName: string;
+  }>;
+};
+
+type ProviderOption = {
+  id: string;
+  provider_key: string;
+  display_name: string;
+};
+
+type MemberFormState = {
+  email: string;
+  name: string;
+  password: string;
+  role: "member" | "admin";
+};
+
 type ProviderMessagesResponse = {
   provider: {
     providerKey: string;
@@ -60,6 +86,13 @@ type LoginState = {
 const INITIAL_LOGIN_STATE: LoginState = {
   email: "",
   password: "",
+};
+
+const INITIAL_MEMBER_FORM_STATE: MemberFormState = {
+  email: "",
+  name: "",
+  password: "",
+  role: "member",
 };
 
 async function fetchJson<T>(
@@ -153,6 +186,14 @@ export function App() {
   const [isLoadingQuarantine, setIsLoadingQuarantine] = useState(false);
   const [isSavingMessage, setIsSavingMessage] = useState(false);
   const [isReviewingQuarantine, setIsReviewingQuarantine] = useState(false);
+  const [members, setMembers] = useState<MemberSummary[]>([]);
+  const [providerOptions, setProviderOptions] = useState<ProviderOption[]>([]);
+  const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
+  const [memberFormState, setMemberFormState] = useState<MemberFormState>(
+    INITIAL_MEMBER_FORM_STATE,
+  );
+  const [isLoadingMembers, setIsLoadingMembers] = useState(false);
+  const [isSavingMember, setIsSavingMember] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [viewError, setViewError] = useState<string | null>(null);
   const [releaseProviderKey, setReleaseProviderKey] = useState<string>("");
@@ -165,10 +206,14 @@ export function App() {
       setProviders([]);
       setMessages([]);
       setQuarantineMessages([]);
+      setMembers([]);
+      setProviderOptions([]);
       setSelectedProviderKey(null);
       setSelectedMessageId(null);
       setSelectedQuarantineId(null);
+      setSelectedMemberId(null);
       setReleaseProviderKey("");
+      setMemberFormState(INITIAL_MEMBER_FORM_STATE);
       return;
     }
 
@@ -339,6 +384,61 @@ export function App() {
     };
   }, [isAuthenticated, isOwner]);
 
+  useEffect(() => {
+    if (!isAuthenticated || !isOwner) {
+      setMembers([]);
+      setProviderOptions([]);
+      setSelectedMemberId(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadMembers = async () => {
+      setIsLoadingMembers(true);
+
+      try {
+        const response = await fetchJson<{
+          members: MemberSummary[];
+          providers: ProviderOption[];
+        }>("/api/admin/members");
+
+        if (cancelled) {
+          return;
+        }
+
+        setMembers(response.members);
+        setProviderOptions(response.providers);
+        setSelectedMemberId((current) => {
+          if (
+            current &&
+            response.members.some((member) => member.id === current)
+          ) {
+            return current;
+          }
+
+          return response.members[0]?.id ?? null;
+        });
+      } catch (error) {
+        if (!cancelled) {
+          setViewError(
+            error instanceof Error ? error.message : "Unable to load members",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingMembers(false);
+        }
+      }
+    };
+
+    void loadMembers();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, isOwner]);
+
   const selectedProvider = useMemo(
     () =>
       providers.find(
@@ -358,6 +458,11 @@ export function App() {
         (message) => message.id === selectedQuarantineId,
       ) ?? null,
     [quarantineMessages, selectedQuarantineId],
+  );
+
+  const selectedMember = useMemo(
+    () => members.find((member) => member.id === selectedMemberId) ?? null,
+    [members, selectedMemberId],
   );
 
   async function refreshProviders() {
@@ -399,6 +504,27 @@ export function App() {
       }
 
       return response.messages[0]?.id ?? null;
+    });
+  }
+
+  async function refreshMembers() {
+    if (!isAuthenticated || !isOwner) {
+      return;
+    }
+
+    const response = await fetchJson<{
+      members: MemberSummary[];
+      providers: ProviderOption[];
+    }>("/api/admin/members");
+
+    setMembers(response.members);
+    setProviderOptions(response.providers);
+    setSelectedMemberId((current) => {
+      if (current && response.members.some((member) => member.id === current)) {
+        return current;
+      }
+
+      return response.members[0]?.id ?? null;
     });
   }
 
@@ -502,6 +628,86 @@ export function App() {
       );
     } finally {
       setIsReviewingQuarantine(false);
+    }
+  }
+
+  async function handleCreateMember(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsSavingMember(true);
+    setStatusMessage(null);
+    setViewError(null);
+
+    try {
+      await fetchJson<{ member: unknown }>("/api/admin/members", {
+        method: "POST",
+        body: JSON.stringify(memberFormState),
+      });
+
+      setMemberFormState(INITIAL_MEMBER_FORM_STATE);
+      setStatusMessage("Household member created.");
+      await refreshMembers();
+    } catch (error) {
+      setViewError(
+        error instanceof Error
+          ? error.message
+          : "Unable to create household member",
+      );
+    } finally {
+      setIsSavingMember(false);
+    }
+  }
+
+  async function handleMemberRoleChange(
+    userId: string,
+    role: MemberSummary["role"],
+  ) {
+    setStatusMessage(null);
+    setViewError(null);
+
+    try {
+      await fetchJson<{ ok: boolean }>(`/api/admin/members/${userId}/role`, {
+        method: "PATCH",
+        body: JSON.stringify({ role }),
+      });
+
+      setStatusMessage(`Updated member role to ${role}.`);
+      await refreshMembers();
+      await refetch();
+    } catch (error) {
+      setViewError(
+        error instanceof Error ? error.message : "Unable to update member role",
+      );
+    }
+  }
+
+  async function handleProviderAccessToggle(
+    userId: string,
+    providerKey: string,
+    hasAccess: boolean,
+  ) {
+    setStatusMessage(null);
+    setViewError(null);
+
+    try {
+      await fetchJson<{ ok: boolean }>(
+        `/api/admin/members/${userId}/provider-access`,
+        {
+          method: hasAccess ? "DELETE" : "POST",
+          body: JSON.stringify({ providerKey }),
+        },
+      );
+
+      setStatusMessage(
+        hasAccess ? "Provider access revoked." : "Provider access granted.",
+      );
+      await refreshMembers();
+      await refreshProviders();
+    } catch (error) {
+      setViewError(
+        error instanceof Error
+          ? error.message
+          : "Unable to update provider access",
+      );
     }
   }
 
@@ -793,6 +999,223 @@ export function App() {
             </article>
           </div>
         </section>
+
+        {isOwner ? (
+          <section className="panel-card owner-admin-panel">
+            <div className="panel-heading">
+              <div>
+                <p className="panel-eyebrow">Owner tools</p>
+                <h2>Household access</h2>
+              </div>
+              <span className="panel-meta">{members.length} members</span>
+            </div>
+
+            <div className="owner-admin-grid">
+              <form
+                className="detail-panel admin-form-panel"
+                onSubmit={handleCreateMember}
+              >
+                <div className="detail-panel__header">
+                  <div>
+                    <p className="panel-eyebrow">Invite-only onboarding</p>
+                    <h3>Create a household member</h3>
+                    <p>
+                      Provision a member directly, then share the generated
+                      login details privately with them.
+                    </p>
+                  </div>
+                </div>
+
+                <label className="field-group">
+                  <span>Name</span>
+                  <input
+                    value={memberFormState.name}
+                    onChange={(event) =>
+                      setMemberFormState((current) => ({
+                        ...current,
+                        name: event.target.value,
+                      }))
+                    }
+                    required
+                  />
+                </label>
+
+                <label className="field-group">
+                  <span>Email</span>
+                  <input
+                    type="email"
+                    value={memberFormState.email}
+                    onChange={(event) =>
+                      setMemberFormState((current) => ({
+                        ...current,
+                        email: event.target.value,
+                      }))
+                    }
+                    required
+                  />
+                </label>
+
+                <label className="field-group">
+                  <span>Temporary password</span>
+                  <input
+                    type="password"
+                    value={memberFormState.password}
+                    onChange={(event) =>
+                      setMemberFormState((current) => ({
+                        ...current,
+                        password: event.target.value,
+                      }))
+                    }
+                    minLength={12}
+                    required
+                  />
+                </label>
+
+                <label className="field-group">
+                  <span>Role</span>
+                  <select
+                    value={memberFormState.role}
+                    onChange={(event) =>
+                      setMemberFormState((current) => ({
+                        ...current,
+                        role:
+                          event.target.value === "admin" ? "admin" : "member",
+                      }))
+                    }
+                  >
+                    <option value="member">Member</option>
+                    <option value="admin">Owner</option>
+                  </select>
+                </label>
+
+                <button
+                  className="primary-button"
+                  disabled={isSavingMember}
+                  type="submit"
+                >
+                  {isSavingMember ? "Creating member…" : "Create member"}
+                </button>
+              </form>
+
+              <div className="two-column-panel owner-members-panel">
+                <div className="message-list">
+                  {members.map((member) => {
+                    const isSelected = member.id === selectedMemberId;
+
+                    return (
+                      <button
+                        aria-pressed={isSelected}
+                        className={
+                          isSelected
+                            ? "message-card message-card--selected"
+                            : "message-card"
+                        }
+                        key={member.id}
+                        onClick={() => setSelectedMemberId(member.id)}
+                        type="button"
+                      >
+                        <div className="message-card__header">
+                          <strong>{member.name}</strong>
+                          <span
+                            className={getStatusTone(
+                              member.role === "admin" ? "used" : "new",
+                            )}
+                          >
+                            {member.role}
+                          </span>
+                        </div>
+                        <p>{member.email}</p>
+                        <span>
+                          {member.providerAccess.length} provider
+                          {member.providerAccess.length === 1 ? "" : "s"}
+                        </span>
+                      </button>
+                    );
+                  })}
+
+                  {!members.length && !isLoadingMembers ? (
+                    <div className="empty-state">
+                      <strong>No members yet</strong>
+                      <p>
+                        Create the first invited household member to get
+                        started.
+                      </p>
+                    </div>
+                  ) : null}
+                </div>
+
+                <article className="detail-panel">
+                  {selectedMember ? (
+                    <>
+                      <div className="detail-panel__header">
+                        <div>
+                          <p className="panel-eyebrow">Member detail</p>
+                          <h3>{selectedMember.name}</h3>
+                          <p>{selectedMember.email}</p>
+                        </div>
+                      </div>
+
+                      <label className="field-group">
+                        <span>Role</span>
+                        <select
+                          value={selectedMember.role}
+                          onChange={(event) =>
+                            void handleMemberRoleChange(
+                              selectedMember.id,
+                              event.target.value,
+                            )
+                          }
+                        >
+                          <option value="member">Member</option>
+                          <option value="admin">Owner</option>
+                        </select>
+                      </label>
+
+                      <section className="message-body-card message-body-card--tight">
+                        <h4>Provider access</h4>
+                        <div className="access-grid">
+                          {providerOptions.map((provider) => {
+                            const hasAccess =
+                              selectedMember.providerAccess.some(
+                                (access) =>
+                                  access.providerKey === provider.provider_key,
+                              );
+
+                            return (
+                              <button
+                                className={
+                                  hasAccess
+                                    ? "access-pill access-pill--active"
+                                    : "access-pill"
+                                }
+                                key={provider.id}
+                                onClick={() =>
+                                  void handleProviderAccessToggle(
+                                    selectedMember.id,
+                                    provider.provider_key,
+                                    hasAccess,
+                                  )
+                                }
+                                type="button"
+                              >
+                                {provider.display_name}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </section>
+                    </>
+                  ) : (
+                    <div className="empty-state empty-state--detail">
+                      <strong>Select a household member</strong>
+                      <p>Choose a member to adjust role or provider access.</p>
+                    </div>
+                  )}
+                </article>
+              </div>
+            </div>
+          </section>
+        ) : null}
 
         {isOwner ? (
           <section className="panel-card quarantine-panel">

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -424,6 +424,36 @@ pre {
   gap: 0.35rem;
 }
 
+.owner-admin-panel,
+.admin-form-panel,
+.owner-members-panel {
+  align-content: start;
+}
+
+.owner-admin-grid,
+.access-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.access-grid {
+  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+}
+
+.access-pill {
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(248, 250, 252, 0.88);
+  border-radius: 999px;
+  padding: 0.75rem 1rem;
+  color: #334155;
+}
+
+.access-pill--active {
+  background: rgba(154, 111, 69, 0.14);
+  border-color: rgba(154, 111, 69, 0.36);
+  color: #7c5430;
+}
+
 .empty-state {
   border-radius: 1.1rem;
   border: 1px dashed rgba(148, 163, 184, 0.35);
@@ -455,6 +485,10 @@ pre {
 
   .two-column-panel {
     grid-template-columns: minmax(18rem, 22rem) minmax(0, 1fr);
+  }
+
+  .owner-admin-grid {
+    grid-template-columns: minmax(20rem, 25rem) minmax(0, 1fr);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { authForEnv } from "./server/auth/auth";
 import { loadAuthSession } from "./server/auth/middleware";
 import { handleIncomingEmail } from "./server/email/handler";
 import { purgeExpiredMessages } from "./server/jobs/retention";
+import { adminRoutes } from "./server/routes/admin";
 import { healthRoutes } from "./server/routes/health";
 import { inboxRoutes } from "./server/routes/inbox";
 import { createAppContext } from "./server/runtime/context";
@@ -22,12 +23,14 @@ app.use(
 );
 
 app.use("/api/inbox/*", loadAuthSession);
+app.use("/api/admin/*", loadAuthSession);
 
 app.on(["GET", "POST"], "/api/auth/*", (c) =>
   authForEnv(c.env).handler(c.req.raw),
 );
 app.route("/api/health", healthRoutes);
 app.route("/api/inbox", inboxRoutes);
+app.route("/api/admin", adminRoutes);
 
 app.get("*", async (c) => {
   return c.env.ASSETS.fetch(c.req.raw);

--- a/src/server/auth/auth.ts
+++ b/src/server/auth/auth.ts
@@ -18,7 +18,7 @@ export function authForEnv(env: Env) {
         role: {
           type: "string",
           required: false,
-          defaultValue: "member",
+          defaultValue: "user",
           input: false,
         },
       },
@@ -31,7 +31,7 @@ export function authForEnv(env: Env) {
     plugins: [
       admin({
         adminRoles: ["admin"],
-        defaultRole: "member",
+        defaultRole: "user",
       }),
     ],
   });

--- a/src/server/auth/middleware.ts
+++ b/src/server/auth/middleware.ts
@@ -8,12 +8,30 @@ export const loadAuthSession: MiddlewareHandler<{
   Bindings: Env;
   Variables: AppVariables;
 }> = async (c, next) => {
-  const result = await authForEnv(c.env).api.getSession({
+  const auth = authForEnv(c.env);
+  const result = await auth.api.getSession({
     headers: c.req.raw.headers,
   });
 
-  const role =
-    typeof result?.user?.role === "string" ? result.user.role : "member";
+  const storedRole =
+    typeof result?.user?.role === "string" ? result.user.role : "user";
+  let role = storedRole === "admin" ? "admin" : "member";
+
+  if (
+    result?.user &&
+    c.env.OWNER_EMAIL &&
+    result.user.email.toLowerCase() === c.env.OWNER_EMAIL.toLowerCase() &&
+    storedRole !== "admin"
+  ) {
+    await auth.api.setRole({
+      body: {
+        userId: result.user.id,
+        role: "admin",
+      },
+      headers: c.req.raw.headers,
+    });
+    role = "admin";
+  }
 
   c.set(
     "user",

--- a/src/server/db/repositories/member-access.ts
+++ b/src/server/db/repositories/member-access.ts
@@ -1,0 +1,74 @@
+import type { MemberAccessRow, MemberRecord, ProviderRow } from "../types";
+
+export async function listMembers(db: D1Database): Promise<MemberRecord[]> {
+  const result = await db
+    .prepare(
+      `SELECT id, email, name, role, createdAt, updatedAt
+       FROM user
+       ORDER BY createdAt ASC`,
+    )
+    .run<MemberRecord>();
+
+  return result.results ?? [];
+}
+
+export async function listMemberProviderAccess(
+  db: D1Database,
+): Promise<MemberAccessRow[]> {
+  const result = await db
+    .prepare(
+      `SELECT user.id,
+              user.email,
+              user.name,
+              user.role,
+              providers.provider_key,
+              providers.display_name AS provider_display_name
+       FROM user
+       LEFT JOIN user_provider_access ON user_provider_access.user_id = user.id
+       LEFT JOIN providers ON providers.id = user_provider_access.provider_id
+       ORDER BY user.createdAt ASC, providers.display_name ASC`,
+    )
+    .run<MemberAccessRow>();
+
+  return result.results ?? [];
+}
+
+export async function listProviders(db: D1Database): Promise<ProviderRow[]> {
+  const result = await db
+    .prepare(
+      `SELECT id, provider_key, display_name
+       FROM providers
+       ORDER BY display_name ASC`,
+    )
+    .run<ProviderRow>();
+
+  return result.results ?? [];
+}
+
+export async function grantProviderAccess(
+  db: D1Database,
+  userId: string,
+  providerId: string,
+) {
+  await db
+    .prepare(
+      `INSERT OR IGNORE INTO user_provider_access (id, user_id, provider_id)
+       VALUES (?, ?, ?)`,
+    )
+    .bind(crypto.randomUUID(), userId, providerId)
+    .run();
+}
+
+export async function revokeProviderAccess(
+  db: D1Database,
+  userId: string,
+  providerId: string,
+) {
+  await db
+    .prepare(
+      `DELETE FROM user_provider_access
+       WHERE user_id = ? AND provider_id = ?`,
+    )
+    .bind(userId, providerId)
+    .run();
+}

--- a/src/server/db/types.ts
+++ b/src/server/db/types.ts
@@ -64,3 +64,21 @@ export type ProviderRow = {
 };
 
 export type MessageStatus = InboxMessageRow["status"];
+
+export type MemberRecord = {
+  id: string;
+  email: string;
+  name: string;
+  role: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type MemberAccessRow = {
+  id: string;
+  email: string;
+  name: string;
+  role: string | null;
+  provider_key: string | null;
+  provider_display_name: string | null;
+};

--- a/src/server/routes/admin.ts
+++ b/src/server/routes/admin.ts
@@ -1,0 +1,204 @@
+import { Hono } from "hono";
+
+import { authForEnv } from "../auth/auth";
+import { type AppVariables, requireOwner } from "../auth/middleware";
+import {
+  grantProviderAccess,
+  listMemberProviderAccess,
+  listMembers,
+  listProviders,
+  revokeProviderAccess,
+} from "../db/repositories/member-access";
+import { getProviderByKey } from "../db/repositories/provider-rules";
+
+type AccessPayload = {
+  providerKey?: string;
+};
+
+type CreateMemberPayload = {
+  email?: string;
+  name?: string;
+  password?: string;
+  role?: string;
+};
+
+export const adminRoutes = new Hono<{
+  Bindings: Env;
+  Variables: AppVariables;
+}>();
+
+function mapStoredRoleToAppRole(role: string | null | undefined) {
+  return role === "admin" ? "admin" : "member";
+}
+
+adminRoutes.use("*", requireOwner);
+
+adminRoutes.get("/members", async (c) => {
+  const [members, accessRows, providers] = await Promise.all([
+    listMembers(c.env.DB),
+    listMemberProviderAccess(c.env.DB),
+    listProviders(c.env.DB),
+  ]);
+
+  const accessByUserId = new Map<
+    string,
+    Array<{ providerKey: string; displayName: string }>
+  >();
+
+  for (const row of accessRows) {
+    if (!row.provider_key || !row.provider_display_name) {
+      continue;
+    }
+
+    const current = accessByUserId.get(row.id) ?? [];
+    current.push({
+      providerKey: row.provider_key,
+      displayName: row.provider_display_name,
+    });
+    accessByUserId.set(row.id, current);
+  }
+
+  return c.json({
+    members: members.map((member) => ({
+      ...member,
+      role: mapStoredRoleToAppRole(member.role),
+      providerAccess: accessByUserId.get(member.id) ?? [],
+    })),
+    providers,
+  });
+});
+
+adminRoutes.post("/members", async (c) => {
+  let payload: CreateMemberPayload;
+
+  try {
+    payload = await c.req.json<CreateMemberPayload>();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+
+  if (!payload.email || !payload.name || !payload.password) {
+    return c.json({ error: "email, name, and password are required" }, 400);
+  }
+
+  const role = payload.role === "admin" ? "admin" : "user";
+  const headers = new Headers(c.req.raw.headers);
+
+  const created = await authForEnv(c.env).api.createUser({
+    body: {
+      email: payload.email,
+      name: payload.name,
+      password: payload.password,
+      role,
+    },
+    headers,
+  });
+
+  return c.json(
+    {
+      member: {
+        ...created.user,
+        role: mapStoredRoleToAppRole(created.user.role),
+      },
+    },
+    201,
+  );
+});
+
+adminRoutes.patch("/members/:userId/role", async (c) => {
+  const userId = c.req.param("userId");
+  let payload: { role?: string };
+
+  try {
+    payload = await c.req.json<{ role?: string }>();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+
+  if (payload.role !== "admin" && payload.role !== "member") {
+    return c.json({ error: "role must be admin or member" }, 400);
+  }
+
+  await authForEnv(c.env).api.setRole({
+    body: {
+      userId,
+      role: payload.role === "admin" ? "admin" : "user",
+    },
+    headers: new Headers(c.req.raw.headers),
+  });
+
+  return c.json({ ok: true });
+});
+
+adminRoutes.patch("/members/:userId/password", async (c) => {
+  const userId = c.req.param("userId");
+  let payload: { password?: string };
+
+  try {
+    payload = await c.req.json<{ password?: string }>();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+
+  if (!payload.password) {
+    return c.json({ error: "password is required" }, 400);
+  }
+
+  await authForEnv(c.env).api.setUserPassword({
+    body: {
+      userId,
+      newPassword: payload.password,
+    },
+    headers: new Headers(c.req.raw.headers),
+  });
+
+  return c.json({ ok: true });
+});
+
+adminRoutes.post("/members/:userId/provider-access", async (c) => {
+  const userId = c.req.param("userId");
+  let payload: AccessPayload;
+
+  try {
+    payload = await c.req.json<AccessPayload>();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+
+  if (!payload.providerKey) {
+    return c.json({ error: "providerKey is required" }, 400);
+  }
+
+  const provider = await getProviderByKey(c.env.DB, payload.providerKey);
+
+  if (!provider) {
+    return c.json({ error: "Provider not found" }, 404);
+  }
+
+  await grantProviderAccess(c.env.DB, userId, provider.id);
+  return c.json({ ok: true });
+});
+
+adminRoutes.delete("/members/:userId/provider-access", async (c) => {
+  const userId = c.req.param("userId");
+  let payload: AccessPayload;
+
+  try {
+    payload = await c.req.json<AccessPayload>();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+
+  if (!payload.providerKey) {
+    return c.json({ error: "providerKey is required" }, 400);
+  }
+
+  const provider = await getProviderByKey(c.env.DB, payload.providerKey);
+
+  if (!provider) {
+    return c.json({ error: "Provider not found" }, 404);
+  }
+
+  await revokeProviderAccess(c.env.DB, userId, provider.id);
+  return c.json({ ok: true });
+});

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -75,6 +75,8 @@ describe("App", () => {
     const html = renderToStaticMarkup(<App />);
 
     expect(html).toContain("Owner tools");
+    expect(html).toContain("Household access");
+    expect(html).toContain("Create a household member");
     expect(html).toContain("Quarantine review");
     expect(html).toContain("Release to provider");
   });

--- a/test/inbox-routes.test.ts
+++ b/test/inbox-routes.test.ts
@@ -20,11 +20,37 @@ const sessionState = vi.hoisted(() => ({
   } | null,
 }));
 
+const authApiState = vi.hoisted(() => ({
+  createUserCalls: [] as unknown[],
+  setRoleCalls: [] as unknown[],
+  setPasswordCalls: [] as unknown[],
+}));
+
 vi.mock("../src/server/auth/auth", () => ({
   authForEnv: () => ({
     handler: () => new Response("auth"),
     api: {
       getSession: async () => sessionState.current,
+      createUser: async (input: unknown) => {
+        authApiState.createUserCalls.push(input);
+
+        return {
+          user: {
+            id: "created-user-1",
+            email: "new@example.com",
+            name: "New Person",
+            role: "member",
+          },
+        };
+      },
+      setRole: async (input: unknown) => {
+        authApiState.setRoleCalls.push(input);
+        return { ok: true };
+      },
+      setUserPassword: async (input: unknown) => {
+        authApiState.setPasswordCalls.push(input);
+        return { ok: true };
+      },
     },
   }),
 }));
@@ -53,7 +79,7 @@ function createDbStub(resolve: DbResolver): D1Database {
   } as unknown as D1Database;
 }
 
-function createEnv(db: D1Database): Env {
+function createEnv(db: D1Database, overrides?: Partial<Env>): Env {
   const assets = {
     fetch: async () => new Response("spa"),
   } as unknown as Fetcher;
@@ -71,6 +97,7 @@ function createEnv(db: D1Database): Env {
     DB: db,
     EMAIL: email,
     ENVIRONMENT: "test",
+    ...overrides,
   };
 }
 
@@ -94,6 +121,7 @@ async function invokeWorker(
   path: string,
   options: RequestInit | undefined,
   db: D1Database,
+  envOverrides?: Partial<Env>,
 ) {
   const fetchHandler = getWorkerFetch();
   const request = new Request(
@@ -101,12 +129,19 @@ async function invokeWorker(
     options,
   ) as Parameters<WorkerFetch>[0];
 
-  return fetchHandler(request, createEnv(db), createExecutionContext());
+  return fetchHandler(
+    request,
+    createEnv(db, envOverrides),
+    createExecutionContext(),
+  );
 }
 
 describe("worker routes", () => {
   beforeEach(() => {
     sessionState.current = null;
+    authApiState.createUserCalls = [];
+    authApiState.setRoleCalls = [];
+    authApiState.setPasswordCalls = [];
   });
 
   it("returns liveness health", async () => {
@@ -379,6 +414,214 @@ describe("worker routes", () => {
     const db = createDbStub(() => ({}));
 
     const response = await invokeWorker("/api/inbox/quarantine", undefined, db);
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "Forbidden" });
+  });
+
+  it("bootstraps OWNER_EMAIL to admin on session load", async () => {
+    sessionState.current = {
+      user: { id: "user-1", email: "owner@example.com", role: "member" },
+      session: { id: "session-1", userId: "user-1" },
+    };
+
+    const db = createDbStub((sql) => {
+      if (sql.includes("GROUP BY providers.id")) {
+        return {
+          run: async () => ({ results: [] }),
+        };
+      }
+
+      return {};
+    });
+
+    const response = await invokeWorker("/api/inbox/providers", undefined, db, {
+      OWNER_EMAIL: "owner@example.com",
+    });
+
+    expect(response.status).toBe(200);
+    expect(authApiState.setRoleCalls).toHaveLength(1);
+    expect(authApiState.setRoleCalls[0]).toMatchObject({
+      body: {
+        userId: "user-1",
+        role: "admin",
+      },
+    });
+  });
+
+  it("lists members and provider access for owners", async () => {
+    sessionState.current = {
+      user: { id: "admin-1", email: "owner@example.com", role: "admin" },
+      session: { id: "session-1", userId: "admin-1" },
+    };
+
+    const db = createDbStub((sql) => {
+      if (sql.includes("FROM user\n       ORDER BY createdAt ASC")) {
+        return {
+          run: async () => ({
+            results: [
+              {
+                id: "member-1",
+                email: "member@example.com",
+                name: "Family Member",
+                role: "member",
+                createdAt: "2026-05-10T12:00:00.000Z",
+                updatedAt: "2026-05-10T12:00:00.000Z",
+              },
+            ],
+          }),
+        };
+      }
+
+      if (sql.includes("LEFT JOIN user_provider_access")) {
+        return {
+          run: async () => ({
+            results: [
+              {
+                id: "member-1",
+                email: "member@example.com",
+                name: "Family Member",
+                role: "member",
+                provider_key: "netflix",
+                provider_display_name: "Netflix",
+              },
+            ],
+          }),
+        };
+      }
+
+      if (sql.includes("FROM providers\n       ORDER BY display_name ASC")) {
+        return {
+          run: async () => ({
+            results: [
+              {
+                id: "provider-1",
+                provider_key: "netflix",
+                display_name: "Netflix",
+              },
+            ],
+          }),
+        };
+      }
+
+      return {};
+    });
+
+    const response = await invokeWorker("/api/admin/members", undefined, db);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      members: [
+        {
+          id: "member-1",
+          email: "member@example.com",
+          name: "Family Member",
+          role: "member",
+          createdAt: "2026-05-10T12:00:00.000Z",
+          updatedAt: "2026-05-10T12:00:00.000Z",
+          providerAccess: [
+            {
+              providerKey: "netflix",
+              displayName: "Netflix",
+            },
+          ],
+        },
+      ],
+      providers: [
+        {
+          id: "provider-1",
+          provider_key: "netflix",
+          display_name: "Netflix",
+        },
+      ],
+    });
+  });
+
+  it("creates a household member from the admin route", async () => {
+    sessionState.current = {
+      user: { id: "admin-1", email: "owner@example.com", role: "admin" },
+      session: { id: "session-1", userId: "admin-1" },
+    };
+
+    const db = createDbStub(() => ({}));
+
+    const response = await invokeWorker(
+      "/api/admin/members",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          email: "new@example.com",
+          name: "New Person",
+          password: "temporary-password-123",
+          role: "member",
+        }),
+      },
+      db,
+    );
+
+    expect(response.status).toBe(201);
+    expect(authApiState.createUserCalls).toHaveLength(1);
+    expect(authApiState.createUserCalls[0]).toMatchObject({
+      body: {
+        email: "new@example.com",
+        name: "New Person",
+        password: "temporary-password-123",
+        role: "user",
+      },
+    });
+  });
+
+  it("grants provider access from the admin route", async () => {
+    sessionState.current = {
+      user: { id: "admin-1", email: "owner@example.com", role: "admin" },
+      session: { id: "session-1", userId: "admin-1" },
+    };
+
+    const db = createDbStub((sql) => {
+      if (
+        sql.includes("FROM providers") &&
+        sql.includes("WHERE provider_key = ?")
+      ) {
+        return {
+          first: async () => ({
+            id: "provider-1",
+            provider_key: "netflix",
+            display_name: "Netflix",
+          }),
+        };
+      }
+
+      if (sql.startsWith("INSERT OR IGNORE INTO user_provider_access")) {
+        return {
+          run: async () => ({ results: [] }),
+        };
+      }
+
+      return {};
+    });
+
+    const response = await invokeWorker(
+      "/api/admin/members/member-1/provider-access",
+      {
+        method: "POST",
+        body: JSON.stringify({ providerKey: "netflix" }),
+      },
+      db,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+
+  it("keeps admin routes owner-only", async () => {
+    sessionState.current = {
+      user: { id: "user-1", email: "member@example.com", role: "member" },
+      session: { id: "session-1", userId: "user-1" },
+    };
+
+    const db = createDbStub(() => ({}));
+
+    const response = await invokeWorker("/api/admin/members", undefined, db);
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({ error: "Forbidden" });


### PR DESCRIPTION
## Summary
- add owner-only admin APIs for creating household members, managing roles, and granting provider access
- add a household access panel to the dashboard so the owner can manage members and provider permissions
- extend UI and worker tests to cover owner bootstrap, admin flows, and access management

## Testing
- npm run ci

Closes #6