### PR TITLE
Add first-run setup and deploy onboarding

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,3 +1,4 @@
 BETTER_AUTH_SECRET=replace-with-a-long-random-secret
 OWNER_EMAIL=owner@example.com
+SETUP_SECRET=replace-with-a-long-random-setup-secret
 BETTER_AUTH_URL=http://localhost:8787

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Fill in:
 
 - `BETTER_AUTH_SECRET`
 - `OWNER_EMAIL`
+- `SETUP_SECRET`
 
 Update `wrangler.jsonc` with your real D1 `database_id`.
 
@@ -177,6 +178,18 @@ The repository now includes a Cloudflare-focused CI/CD baseline for issue #8:
 - `Production D1 Migrate` is a separate, manually approved workflow for production schema changes
 
 See [`docs/ci-cd-architecture.md`](./docs/ci-cd-architecture.md) for the required GitHub secrets, Cloudflare setup, repository variables, environment protection rules, and the production migration workflow.
+
+## Deploy to Cloudflare onboarding
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/andersro93/mi-casa-su-casa)
+
+The deploy button can provision the Worker and D1 resources defined in this repository, but you still need to finish the first-run and email onboarding steps yourself:
+
+1. complete the Cloudflare deploy flow and provide the requested secrets/variables
+2. visit `/setup` on the new deployment and create the initial owner account using `OWNER_EMAIL` and `SETUP_SECRET`
+3. onboard your email-routing domain in Cloudflare and configure the inbound rules for the shared inbox address
+
+The first-run `/setup` flow closes permanently after the initial owner account is created.
 
 ## Testing strategy
 

--- a/docs/ci-cd-architecture.md
+++ b/docs/ci-cd-architecture.md
@@ -159,6 +159,34 @@ This issue adds the repository-side CI/CD wiring, but operators still need to:
 4. enable branch protection on `main` so `CI` stays required
 5. configure required reviewers for the `production-migrations` environment
 
+## Deploy to Cloudflare onboarding for issue #9
+
+Use this repository button for the Cloudflare-native deploy entry point:
+
+```markdown
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/andersro93/mi-casa-su-casa)
+```
+
+What the Deploy to Cloudflare flow handles well:
+
+- creating the Worker deployment
+- provisioning D1 resources defined in Wrangler
+- prompting for environment variables and secrets needed at deploy time
+
+What still remains manual after deployment:
+
+- visit `/setup` to create the first owner account
+- provide the configured `OWNER_EMAIL` and `SETUP_SECRET`
+- onboard the email-routing domain in Cloudflare and create the inbound rules for the shared inbox address
+
+Recommended first-run secrets for onboarding:
+
+- `BETTER_AUTH_SECRET`
+- `OWNER_EMAIL`
+- `SETUP_SECRET`
+
+The app-level setup route is intentionally one-time only. After the owner account is created, `/setup` is locked server-side and normal invite-only sign-in remains the only public auth path.
+
 ## References
 
 - Cloudflare Workers GitHub Actions: https://developers.cloudflare.com/workers/ci-cd/external-cicd/github-actions/

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -83,9 +83,30 @@ type LoginState = {
   password: string;
 };
 
+type SetupStatus = {
+  needsSetup: boolean;
+  setupLocked: boolean;
+  isConfigured: boolean;
+  status: "pending" | "in_progress" | "complete";
+};
+
+type SetupFormState = {
+  email: string;
+  name: string;
+  password: string;
+  setupSecret: string;
+};
+
 const INITIAL_LOGIN_STATE: LoginState = {
   email: "",
   password: "",
+};
+
+const INITIAL_SETUP_FORM_STATE: SetupFormState = {
+  email: "",
+  name: "",
+  password: "",
+  setupSecret: "",
 };
 
 const INITIAL_MEMBER_FORM_STATE: MemberFormState = {
@@ -165,6 +186,18 @@ export function App() {
     isPending: isSessionPending,
     refetch,
   } = authClient.useSession();
+  const [setupStatus, setSetupStatus] = useState<SetupStatus | null>(null);
+  const [setupFormState, setSetupFormState] = useState<SetupFormState>(
+    INITIAL_SETUP_FORM_STATE,
+  );
+  const [setupError, setSetupError] = useState<string | null>(null);
+  const [isCompletingSetup, setIsCompletingSetup] = useState(false);
+  const [isCheckingSetup, setIsCheckingSetup] = useState(
+    typeof window !== "undefined",
+  );
+  const [isSetupPath, setIsSetupPath] = useState(
+    typeof window !== "undefined" && window.location.pathname === "/setup",
+  );
   const [loginState, setLoginState] = useState<LoginState>(INITIAL_LOGIN_STATE);
   const [loginError, setLoginError] = useState<string | null>(null);
   const [isLoggingIn, setIsLoggingIn] = useState(false);
@@ -200,6 +233,80 @@ export function App() {
 
   const isAuthenticated = Boolean(session?.user?.email);
   const isOwner = session?.user?.role === "admin";
+
+  async function refreshSetupStatus() {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const status = await fetchJson<SetupStatus>("/api/setup/status");
+    setSetupStatus(status);
+
+    if (status.needsSetup && window.location.pathname !== "/setup") {
+      window.history.replaceState({}, "", "/setup");
+      setIsSetupPath(true);
+      return;
+    }
+
+    if (!status.needsSetup && window.location.pathname === "/setup") {
+      window.history.replaceState({}, "", "/");
+      setIsSetupPath(false);
+      return;
+    }
+
+    setIsSetupPath(window.location.pathname === "/setup");
+  }
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadSetupStatus = async () => {
+      try {
+        const status = await fetchJson<SetupStatus>("/api/setup/status");
+
+        if (cancelled) {
+          return;
+        }
+
+        setSetupStatus(status);
+
+        if (status.needsSetup && window.location.pathname !== "/setup") {
+          window.history.replaceState({}, "", "/setup");
+          setIsSetupPath(true);
+        } else if (
+          !status.needsSetup &&
+          window.location.pathname === "/setup"
+        ) {
+          window.history.replaceState({}, "", "/");
+          setIsSetupPath(false);
+        } else {
+          setIsSetupPath(window.location.pathname === "/setup");
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setSetupError(
+            error instanceof Error
+              ? error.message
+              : "Unable to check setup status",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setIsCheckingSetup(false);
+        }
+      }
+    };
+
+    void loadSetupStatus();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (!isAuthenticated) {
@@ -557,6 +664,30 @@ export function App() {
     await refetch();
   }
 
+  async function handleSetupComplete(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsCompletingSetup(true);
+    setSetupError(null);
+    setStatusMessage(null);
+
+    try {
+      await fetchJson<{ member: { email: string } }>("/api/setup/complete", {
+        method: "POST",
+        body: JSON.stringify(setupFormState),
+      });
+
+      setSetupFormState(INITIAL_SETUP_FORM_STATE);
+      setStatusMessage("Owner account created. You are now signed in.");
+      await Promise.all([refetch(), refreshSetupStatus()]);
+    } catch (error) {
+      setSetupError(
+        error instanceof Error ? error.message : "Unable to complete setup",
+      );
+    } finally {
+      setIsCompletingSetup(false);
+    }
+  }
+
   async function handleStatusChange(nextStatus: InboxMessage["status"]) {
     if (!selectedMessage) {
       return;
@@ -711,7 +842,7 @@ export function App() {
     }
   }
 
-  if (isSessionPending) {
+  if (isSessionPending || isCheckingSetup) {
     return (
       <main className="app-shell">
         <section className="hero-card hero-card--centered">
@@ -720,6 +851,117 @@ export function App() {
           <p className="lede">
             Checking the current session and preparing the latest messages.
           </p>
+        </section>
+      </main>
+    );
+  }
+
+  if (!isAuthenticated && setupStatus?.needsSetup && isSetupPath) {
+    return (
+      <main className="app-shell">
+        <section className="hero-card auth-card">
+          <div>
+            <p className="eyebrow">First-run setup</p>
+            <h1>Finish setting up your household inbox.</h1>
+            <p className="lede">
+              Create the initial owner account after your Cloudflare deployment
+              completes. This screen closes automatically after the first
+              successful setup.
+            </p>
+          </div>
+
+          <div className="status-card">
+            <p className="status-label">What you need</p>
+            <ul>
+              <li>
+                The owner email configured as <code>OWNER_EMAIL</code>
+              </li>
+              <li>
+                Your one-time <code>SETUP_SECRET</code>
+              </li>
+              <li>A strong password for the initial owner account</li>
+            </ul>
+          </div>
+
+          <form className="auth-form" onSubmit={handleSetupComplete}>
+            <label className="field-group">
+              <span>Owner email</span>
+              <input
+                autoComplete="email"
+                name="setup-email"
+                type="email"
+                value={setupFormState.email}
+                onChange={(event) =>
+                  setSetupFormState((current) => ({
+                    ...current,
+                    email: event.target.value,
+                  }))
+                }
+                required
+              />
+            </label>
+
+            <label className="field-group">
+              <span>Owner display name</span>
+              <input
+                autoComplete="name"
+                name="setup-name"
+                value={setupFormState.name}
+                onChange={(event) =>
+                  setSetupFormState((current) => ({
+                    ...current,
+                    name: event.target.value,
+                  }))
+                }
+                required
+              />
+            </label>
+
+            <label className="field-group">
+              <span>Password</span>
+              <input
+                autoComplete="new-password"
+                minLength={12}
+                name="setup-password"
+                type="password"
+                value={setupFormState.password}
+                onChange={(event) =>
+                  setSetupFormState((current) => ({
+                    ...current,
+                    password: event.target.value,
+                  }))
+                }
+                required
+              />
+            </label>
+
+            <label className="field-group">
+              <span>Setup secret</span>
+              <input
+                autoComplete="off"
+                name="setup-secret"
+                type="password"
+                value={setupFormState.setupSecret}
+                onChange={(event) =>
+                  setSetupFormState((current) => ({
+                    ...current,
+                    setupSecret: event.target.value,
+                  }))
+                }
+                required
+              />
+            </label>
+
+            {setupError ? <p className="inline-error">{setupError}</p> : null}
+
+            <button
+              className="primary-button"
+              disabled={isCompletingSetup}
+              type="submit"
+            >
+              {isCompletingSetup ? "Creating owner…" : "Complete setup"}
+            </button>
+          </form>
         </section>
       </main>
     );
@@ -778,6 +1020,10 @@ export function App() {
               <p className="inline-error">
                 {loginError ?? sessionError?.message}
               </p>
+            ) : null}
+
+            {setupError && !setupStatus?.isConfigured ? (
+              <p className="inline-error">{setupError}</p>
             ) : null}
 
             <button

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -12,6 +12,7 @@ interface Env {
   EMAIL: SendEmail;
   ENVIRONMENT: string;
   OWNER_EMAIL?: string;
+  SETUP_SECRET?: string;
 }
 
 declare module "*.css" {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { purgeExpiredMessages } from "./server/jobs/retention";
 import { adminRoutes } from "./server/routes/admin";
 import { healthRoutes } from "./server/routes/health";
 import { inboxRoutes } from "./server/routes/inbox";
+import { setupRoutes } from "./server/routes/setup";
 import { createAppContext } from "./server/runtime/context";
 
 const app = new Hono<{ Bindings: Env }>();
@@ -31,6 +32,7 @@ app.on(["GET", "POST"], "/api/auth/*", (c) =>
 app.route("/api/health", healthRoutes);
 app.route("/api/inbox", inboxRoutes);
 app.route("/api/admin", adminRoutes);
+app.route("/api/setup", setupRoutes);
 
 app.get("*", async (c) => {
   return c.env.ASSETS.fetch(c.req.raw);

--- a/src/server/db/repositories/installation-state.ts
+++ b/src/server/db/repositories/installation-state.ts
@@ -1,0 +1,77 @@
+import type { InstallationStateRow } from "../types";
+
+const INSTALLATION_SEED_SQL = `
+  INSERT INTO app_installation (id, status)
+  VALUES (1, 'pending')
+  ON CONFLICT(id) DO NOTHING
+`;
+
+export async function ensureInstallationState(db: D1Database) {
+  await db.prepare(INSTALLATION_SEED_SQL).run();
+}
+
+export async function getInstallationState(
+  db: D1Database,
+): Promise<InstallationStateRow> {
+  await ensureInstallationState(db);
+
+  const row = await db
+    .prepare(
+      `SELECT id, status, owner_user_id, owner_email, completed_at, created_at, updated_at
+       FROM app_installation
+       WHERE id = 1
+       LIMIT 1`,
+    )
+    .first<InstallationStateRow>();
+
+  if (!row) {
+    throw new Error("Installation state is unavailable");
+  }
+
+  return row;
+}
+
+export async function beginInstallationSetup(db: D1Database) {
+  await ensureInstallationState(db);
+
+  const result = await db
+    .prepare(
+      `UPDATE app_installation
+       SET status = 'in_progress',
+           updated_at = CURRENT_TIMESTAMP
+       WHERE id = 1 AND status = 'pending'`,
+    )
+    .run();
+
+  return Number(result.meta.changes ?? 0) > 0;
+}
+
+export async function completeInstallationSetup(
+  db: D1Database,
+  ownerUserId: string,
+  ownerEmail: string,
+) {
+  await db
+    .prepare(
+      `UPDATE app_installation
+       SET status = 'complete',
+           owner_user_id = ?,
+           owner_email = ?,
+           completed_at = CURRENT_TIMESTAMP,
+           updated_at = CURRENT_TIMESTAMP
+       WHERE id = 1`,
+    )
+    .bind(ownerUserId, ownerEmail.toLowerCase())
+    .run();
+}
+
+export async function resetInstallationSetup(db: D1Database) {
+  await db
+    .prepare(
+      `UPDATE app_installation
+       SET status = 'pending',
+           updated_at = CURRENT_TIMESTAMP
+       WHERE id = 1 AND status = 'in_progress' AND owner_user_id IS NULL`,
+    )
+    .run();
+}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -71,6 +71,20 @@ CREATE TABLE IF NOT EXISTS audit_events (
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE IF NOT EXISTS app_installation (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  status TEXT NOT NULL CHECK (status IN ('pending', 'in_progress', 'complete')),
+  owner_user_id TEXT,
+  owner_email TEXT,
+  completed_at TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO app_installation (id, status)
+VALUES (1, 'pending')
+ON CONFLICT(id) DO NOTHING;
+
 CREATE INDEX IF NOT EXISTS idx_messages_provider_received ON messages(provider_id, received_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_delete_after ON messages(delete_after);
 CREATE INDEX IF NOT EXISTS idx_quarantine_delete_after ON quarantine_messages(delete_after);

--- a/src/server/db/types.ts
+++ b/src/server/db/types.ts
@@ -82,3 +82,13 @@ export type MemberAccessRow = {
   provider_key: string | null;
   provider_display_name: string | null;
 };
+
+export type InstallationStateRow = {
+  id: number;
+  status: "pending" | "in_progress" | "complete";
+  owner_user_id: string | null;
+  owner_email: string | null;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+};

--- a/src/server/routes/setup.ts
+++ b/src/server/routes/setup.ts
@@ -1,0 +1,164 @@
+import { isAPIError } from "better-auth/api";
+import { Hono } from "hono";
+
+import { authForEnv } from "../auth/auth";
+import {
+  beginInstallationSetup,
+  completeInstallationSetup,
+  getInstallationState,
+  resetInstallationSetup,
+} from "../db/repositories/installation-state";
+
+type SetupPayload = {
+  email?: string;
+  name?: string;
+  password?: string;
+  setupSecret?: string;
+};
+
+export const setupRoutes = new Hono<{ Bindings: Env }>();
+
+function normalizeEmail(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function mapInstallationStatus(
+  row: Awaited<ReturnType<typeof getInstallationState>>,
+  env: Env,
+) {
+  const isConfigured = Boolean(env.OWNER_EMAIL && env.SETUP_SECRET);
+  const needsSetup = isConfigured && row.status !== "complete";
+
+  return {
+    needsSetup,
+    setupLocked: row.status === "complete",
+    isConfigured,
+    status: row.status,
+    ownerEmail: row.owner_email,
+  };
+}
+
+setupRoutes.get("/status", async (c) => {
+  const state = await getInstallationState(c.env.DB);
+  return c.json(mapInstallationStatus(state, c.env));
+});
+
+setupRoutes.post("/complete", async (c) => {
+  if (!c.env.OWNER_EMAIL || !c.env.SETUP_SECRET) {
+    return c.json(
+      {
+        error:
+          "Setup is unavailable until OWNER_EMAIL and SETUP_SECRET are configured",
+      },
+      503,
+    );
+  }
+
+  let payload: SetupPayload;
+
+  try {
+    payload = await c.req.json<SetupPayload>();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+
+  if (
+    !payload.email ||
+    !payload.name ||
+    !payload.password ||
+    !payload.setupSecret
+  ) {
+    return c.json(
+      { error: "email, name, password, and setupSecret are required" },
+      400,
+    );
+  }
+
+  const requestedEmail = normalizeEmail(payload.email);
+  const ownerEmail = normalizeEmail(c.env.OWNER_EMAIL);
+
+  if (payload.setupSecret !== c.env.SETUP_SECRET) {
+    return c.json({ error: "Invalid setup secret" }, 403);
+  }
+
+  if (requestedEmail !== ownerEmail) {
+    return c.json({ error: "Setup email must match OWNER_EMAIL" }, 403);
+  }
+
+  if (payload.password.length < 12) {
+    return c.json({ error: "Password must be at least 12 characters" }, 400);
+  }
+
+  const state = await getInstallationState(c.env.DB);
+
+  if (state.status === "complete") {
+    return c.json({ error: "Setup has already been completed" }, 409);
+  }
+
+  const claimed = await beginInstallationSetup(c.env.DB);
+
+  if (!claimed) {
+    return c.json(
+      { error: "Setup is already in progress or has been completed" },
+      409,
+    );
+  }
+
+  const auth = authForEnv(c.env);
+
+  try {
+    const created = await auth.api.createUser({
+      body: {
+        email: requestedEmail,
+        name: payload.name.trim(),
+        password: payload.password,
+        role: "admin",
+      },
+    });
+
+    await completeInstallationSetup(c.env.DB, created.user.id, requestedEmail);
+
+    const signInResult = await auth.api.signInEmail({
+      body: {
+        email: requestedEmail,
+        password: payload.password,
+      },
+      headers: new Headers(c.req.raw.headers),
+      returnHeaders: true,
+    });
+
+    const response = c.json(
+      {
+        member: {
+          id: created.user.id,
+          email: created.user.email,
+          name: created.user.name,
+          role: "admin",
+        },
+        session: signInResult.response,
+      },
+      201,
+    );
+
+    for (const cookie of signInResult.headers.getSetCookie()) {
+      response.headers.append("set-cookie", cookie);
+    }
+
+    return response;
+  } catch (error) {
+    await resetInstallationSetup(c.env.DB);
+
+    if (isAPIError(error)) {
+      const status = typeof error.status === "number" ? error.status : 400;
+
+      return new Response(JSON.stringify({ error: error.message }), {
+        status,
+        headers: {
+          "content-type": "application/json",
+        },
+      });
+    }
+
+    return c.json({ error: "Unable to complete setup" }, 500);
+  }
+});

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -1,5 +1,5 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const authState = vi.hoisted(() => ({
   session: null as {
@@ -13,34 +13,108 @@ const authState = vi.hoisted(() => ({
   error: null as { message: string } | null,
 }));
 
+const setupStatusState = vi.hoisted(() => ({
+  current: {
+    needsSetup: false,
+    setupLocked: true,
+    isConfigured: true,
+    status: "complete",
+    ownerEmail: null,
+  },
+}));
+
+const refetchMock = vi.hoisted(() => vi.fn(async () => undefined));
+const signInEmailMock = vi.hoisted(() =>
+  vi.fn(async () => ({ data: null, error: null })),
+);
+const signOutMock = vi.hoisted(() =>
+  vi.fn(async () => ({ data: null, error: null })),
+);
+
 vi.mock("@server/auth/client", () => ({
   authClient: {
     useSession: () => ({
       data: authState.session,
       isPending: authState.isPending,
       error: authState.error,
-      refetch: vi.fn(async () => undefined),
+      refetch: refetchMock,
     }),
     signIn: {
-      email: vi.fn(async () => ({ data: null, error: null })),
+      email: signInEmailMock,
     },
-    signOut: vi.fn(async () => ({ data: null, error: null })),
+    signOut: signOutMock,
   },
 }));
 
 const { App } = await import("../src/client/App");
 
 describe("App", () => {
-  it("renders the invite-only sign-in experience when signed out", () => {
+  beforeEach(() => {
     authState.session = null;
     authState.isPending = false;
     authState.error = null;
+    setupStatusState.current = {
+      needsSetup: false,
+      setupLocked: true,
+      isConfigured: true,
+      status: "complete",
+      ownerEmail: null,
+    };
+    refetchMock.mockClear();
+    signInEmailMock.mockClear();
+    signOutMock.mockClear();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify(setupStatusState.current), {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+            },
+          }),
+      ),
+    );
+    vi.stubGlobal("window", {
+      location: {
+        pathname: "/",
+      },
+      history: {
+        replaceState: vi.fn(),
+      },
+    } as unknown as Window & typeof globalThis);
+  });
 
+  it("renders the invite-only sign-in experience when signed out", () => {
     const html = renderToStaticMarkup(<App />);
 
     expect(html).toContain("Shared verification inbox, without the chaos.");
     expect(html).toContain("Sign in");
     expect(html).not.toContain("Quarantine review");
+  });
+
+  it("renders the first-run setup experience when setup is required", () => {
+    setupStatusState.current = {
+      needsSetup: true,
+      setupLocked: false,
+      isConfigured: true,
+      status: "pending",
+      ownerEmail: null,
+    };
+    vi.stubGlobal("window", {
+      location: {
+        pathname: "/setup",
+      },
+      history: {
+        replaceState: vi.fn(),
+      },
+    } as unknown as Window & typeof globalThis);
+
+    const html = renderToStaticMarkup(<App />);
+
+    expect(html).toContain("Finish setting up your household inbox.");
+    expect(html).toContain("Complete setup");
+    expect(html).toContain("SETUP_SECRET");
   });
 
   it("renders the inbox shell for a signed-in member", () => {

--- a/test/inbox-routes.test.ts
+++ b/test/inbox-routes.test.ts
@@ -22,8 +22,14 @@ const sessionState = vi.hoisted(() => ({
 
 const authApiState = vi.hoisted(() => ({
   createUserCalls: [] as unknown[],
+  listUsersCalls: [] as unknown[],
+  signInEmailCalls: [] as unknown[],
   setRoleCalls: [] as unknown[],
   setPasswordCalls: [] as unknown[],
+  listUsersResponse: {
+    users: [] as Array<{ id: string; email: string; role: string }>,
+    total: 0,
+  },
 }));
 
 vi.mock("../src/server/auth/auth", () => ({
@@ -46,6 +52,25 @@ vi.mock("../src/server/auth/auth", () => ({
       setRole: async (input: unknown) => {
         authApiState.setRoleCalls.push(input);
         return { ok: true };
+      },
+      listUsers: async (input: unknown) => {
+        authApiState.listUsersCalls.push(input);
+        return authApiState.listUsersResponse;
+      },
+      signInEmail: async (input: unknown) => {
+        authApiState.signInEmailCalls.push(input);
+        return {
+          response: {
+            session: {
+              id: "setup-session-1",
+              userId: "created-user-1",
+            },
+          },
+          headers: new Headers({
+            "set-cookie":
+              "better-auth.session_token=test-token; Path=/; HttpOnly",
+          }),
+        };
       },
       setUserPassword: async (input: unknown) => {
         authApiState.setPasswordCalls.push(input);
@@ -140,8 +165,14 @@ describe("worker routes", () => {
   beforeEach(() => {
     sessionState.current = null;
     authApiState.createUserCalls = [];
+    authApiState.listUsersCalls = [];
+    authApiState.signInEmailCalls = [];
     authApiState.setRoleCalls = [];
     authApiState.setPasswordCalls = [];
+    authApiState.listUsersResponse = {
+      users: [],
+      total: 0,
+    };
   });
 
   it("returns liveness health", async () => {
@@ -625,5 +656,254 @@ describe("worker routes", () => {
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({ error: "Forbidden" });
+  });
+
+  it("reports that first-run setup is still needed", async () => {
+    const db = createDbStub((sql) => {
+      if (sql.startsWith("INSERT INTO app_installation")) {
+        return {
+          run: async () => ({ results: [] }),
+        };
+      }
+
+      if (sql.includes("FROM app_installation")) {
+        return {
+          first: async () => ({
+            id: 1,
+            status: "pending",
+            owner_user_id: null,
+            owner_email: null,
+            completed_at: null,
+            created_at: "2026-05-10T12:00:00.000Z",
+            updated_at: "2026-05-10T12:00:00.000Z",
+          }),
+        };
+      }
+
+      return {};
+    });
+
+    const response = await invokeWorker("/api/setup/status", undefined, db, {
+      OWNER_EMAIL: "owner@example.com",
+      SETUP_SECRET: "setup-secret",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      needsSetup: true,
+      setupLocked: false,
+      isConfigured: true,
+      status: "pending",
+      ownerEmail: null,
+    });
+  });
+
+  it("creates the initial owner through the one-time setup flow", async () => {
+    const db = createDbStub((sql) => {
+      if (sql.startsWith("INSERT INTO app_installation")) {
+        return {
+          run: async () => ({ results: [] }),
+        };
+      }
+
+      if (
+        sql.startsWith("UPDATE app_installation") &&
+        sql.includes("status = 'in_progress'")
+      ) {
+        return {
+          run: async () => ({
+            results: [],
+            meta: { changes: 1 },
+          }),
+        };
+      }
+
+      if (
+        sql.startsWith("UPDATE app_installation") &&
+        sql.includes("status = 'complete'")
+      ) {
+        return {
+          run: async () => ({ results: [] }),
+        };
+      }
+
+      if (sql.includes("FROM app_installation")) {
+        return {
+          first: async () => ({
+            id: 1,
+            status: "pending",
+            owner_user_id: null,
+            owner_email: null,
+            completed_at: null,
+            created_at: "2026-05-10T12:00:00.000Z",
+            updated_at: "2026-05-10T12:00:00.000Z",
+          }),
+        };
+      }
+
+      return {};
+    });
+
+    const response = await invokeWorker(
+      "/api/setup/complete",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          email: "owner@example.com",
+          name: "Owner Person",
+          password: "super-secure-password",
+          setupSecret: "setup-secret",
+        }),
+      },
+      db,
+      {
+        OWNER_EMAIL: "owner@example.com",
+        SETUP_SECRET: "setup-secret",
+      },
+    );
+
+    expect(response.status).toBe(201);
+    expect(authApiState.createUserCalls).toHaveLength(1);
+    expect(authApiState.createUserCalls[0]).toMatchObject({
+      body: {
+        email: "owner@example.com",
+        name: "Owner Person",
+        password: "super-secure-password",
+        role: "admin",
+      },
+    });
+    expect(authApiState.signInEmailCalls).toHaveLength(1);
+    expect(authApiState.signInEmailCalls[0]).toMatchObject({
+      body: {
+        email: "owner@example.com",
+        password: "super-secure-password",
+      },
+    });
+
+    const payload = (await response.json()) as {
+      member: { email: string; role: string };
+      session: { session: { userId: string } };
+    };
+
+    expect(payload.member).toEqual({
+      id: "created-user-1",
+      email: "new@example.com",
+      name: "New Person",
+      role: "admin",
+    });
+    expect(payload.session.session.userId).toBe("created-user-1");
+    expect(response.headers.get("set-cookie")).toContain(
+      "better-auth.session_token",
+    );
+  });
+
+  it("rejects setup when the secret is wrong", async () => {
+    const db = createDbStub((sql) => {
+      if (sql.startsWith("INSERT INTO app_installation")) {
+        return {
+          run: async () => ({ results: [] }),
+        };
+      }
+
+      if (sql.includes("FROM app_installation")) {
+        return {
+          first: async () => ({
+            id: 1,
+            status: "pending",
+            owner_user_id: null,
+            owner_email: null,
+            completed_at: null,
+            created_at: "2026-05-10T12:00:00.000Z",
+            updated_at: "2026-05-10T12:00:00.000Z",
+          }),
+        };
+      }
+
+      return {};
+    });
+
+    const response = await invokeWorker(
+      "/api/setup/complete",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          email: "owner@example.com",
+          name: "Owner Person",
+          password: "super-secure-password",
+          setupSecret: "wrong-secret",
+        }),
+      },
+      db,
+      {
+        OWNER_EMAIL: "owner@example.com",
+        SETUP_SECRET: "setup-secret",
+      },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid setup secret",
+    });
+  });
+
+  it("keeps setup closed after completion", async () => {
+    const db = createDbStub((sql) => {
+      if (sql.startsWith("INSERT INTO app_installation")) {
+        return {
+          run: async () => ({ results: [] }),
+        };
+      }
+
+      if (sql.includes("FROM app_installation")) {
+        return {
+          first: async () => ({
+            id: 1,
+            status: "complete",
+            owner_user_id: "owner-1",
+            owner_email: "owner@example.com",
+            completed_at: "2026-05-10T12:30:00.000Z",
+            created_at: "2026-05-10T12:00:00.000Z",
+            updated_at: "2026-05-10T12:30:00.000Z",
+          }),
+        };
+      }
+
+      if (
+        sql.startsWith("UPDATE app_installation") &&
+        sql.includes("status = 'in_progress'")
+      ) {
+        return {
+          run: async () => ({
+            results: [],
+            meta: { changes: 0 },
+          }),
+        };
+      }
+
+      return {};
+    });
+
+    const response = await invokeWorker(
+      "/api/setup/complete",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          email: "owner@example.com",
+          name: "Owner Person",
+          password: "super-secure-password",
+          setupSecret: "setup-secret",
+        }),
+      },
+      db,
+      {
+        OWNER_EMAIL: "owner@example.com",
+        SETUP_SECRET: "setup-secret",
+      },
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Setup has already been completed",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add one-time installation state and setup endpoints to bootstrap the initial owner account safely
- add a first-run /setup experience in the client that locks after the initial owner is created
- document the Deploy to Cloudflare onboarding path and manual email-routing follow-up, and extend test coverage for setup behavior

## Testing
- npm run ci

Closes #9