### PR TITLE
Add grouped Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "13:00"
+      timezone: "Europe/Oslo"
+    groups:
+      all-npm-updates:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "13:00"
+      timezone: "Europe/Oslo"
+    groups:
+      all-action-updates:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- add Dependabot configuration for weekly grouped npm dependency updates
- add Dependabot configuration for weekly grouped GitHub Actions updates
- schedule automated checks for Sundays at 13:00 Europe/Oslo
