### PR TITLE
feat: externalize all deploy config — zero source edits for forkers

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   deploy-preview:
-    if: github.event.pull_request.head.repo.full_name == github.repository && secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != ''
+    if: github.event.pull_request.head.repo.full_name == github.repository && secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != '' && secrets.D1_DATABASE_ID_PREVIEW != ''
     runs-on: ubuntu-latest
 
     steps:
@@ -34,6 +34,11 @@ jobs:
       - name: Validate pull request
         run: npm run ci
 
+      - name: Inject preview D1 database ID into Wrangler config
+        env:
+          D1_DATABASE_ID_PREVIEW: ${{ secrets.D1_DATABASE_ID_PREVIEW }}
+        run: sed -i 's/PLACEHOLDER_PREVIEW_D1_DATABASE_ID/'"$D1_DATABASE_ID_PREVIEW"'/' wrangler.jsonc
+
       - name: Apply preview D1 migrations
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -44,7 +49,10 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npm run deploy:preview
+        run: >-
+          npx wrangler deploy --env preview
+          --var APP_URL:${{ vars.CLOUDFLARE_PREVIEW_URL }}
+          --var OWNER_EMAIL:${{ vars.OWNER_EMAIL }}
 
       - name: Comment preview status on pull request
         uses: actions/github-script@v9
@@ -85,7 +93,7 @@ jobs:
             }
 
   preview-unavailable-for-forks:
-    if: github.event.pull_request.head.repo.full_name != github.repository || secrets.CLOUDFLARE_API_TOKEN == '' || secrets.CLOUDFLARE_ACCOUNT_ID == ''
+    if: github.event.pull_request.head.repo.full_name != github.repository || secrets.CLOUDFLARE_API_TOKEN == '' || secrets.CLOUDFLARE_ACCOUNT_ID == '' || secrets.D1_DATABASE_ID_PREVIEW == ''
     runs-on: ubuntu-latest
 
     steps:
@@ -97,7 +105,7 @@ jobs:
             const fromFork = context.payload.pull_request.head.repo.full_name !== context.repo.owner + '/' + context.repo.repo;
             const body = fromFork
               ? `${marker}\n⚠️ Preview deployment was skipped for this pull request because GitHub does not expose Cloudflare deployment secrets to workflows triggered from forks.`
-              : `${marker}\n⚠️ Preview deployment was skipped because the repository is missing \`CLOUDFLARE_API_TOKEN\` and/or \`CLOUDFLARE_ACCOUNT_ID\` secrets required for Wrangler deploys.`;
+              : `${marker}\n⚠️ Preview deployment was skipped because the repository is missing one or more required secrets (\`CLOUDFLARE_API_TOKEN\`, \`CLOUDFLARE_ACCOUNT_ID\`, \`D1_DATABASE_ID_PREVIEW\`).`;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/production-d1-migrate.yml
+++ b/.github/workflows/production-d1-migrate.yml
@@ -43,6 +43,11 @@ jobs:
           echo "Running production migrations for ref: ${{ inputs.ref }}" >> "$GITHUB_STEP_SUMMARY"
           echo "Reason: ${{ inputs.reason }}" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Inject production D1 database ID into Wrangler config
+        env:
+          D1_DATABASE_ID_PRODUCTION: ${{ secrets.D1_DATABASE_ID_PRODUCTION }}
+        run: sed -i 's/PLACEHOLDER_PRODUCTION_D1_DATABASE_ID/'"$D1_DATABASE_ID_PRODUCTION"'/' wrangler.jsonc
+
       - name: Apply production D1 migrations
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_PROD }}

--- a/.github/workflows/production-d1-migrate.yml
+++ b/.github/workflows/production-d1-migrate.yml
@@ -50,12 +50,12 @@ jobs:
 
       - name: Apply production D1 migrations
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_PROD }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npm run db:apply:production
 
       - name: List production D1 migrations
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_PROD }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npx wrangler d1 migrations list mi-casa-su-casa --remote --env production

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -30,8 +30,16 @@ jobs:
       - name: Validate main before deploy
         run: npm run ci
 
+      - name: Inject production D1 database ID into Wrangler config
+        env:
+          D1_DATABASE_ID_PRODUCTION: ${{ secrets.D1_DATABASE_ID_PRODUCTION }}
+        run: sed -i 's/PLACEHOLDER_PRODUCTION_D1_DATABASE_ID/'"$D1_DATABASE_ID_PRODUCTION"'/' wrangler.jsonc
+
       - name: Deploy Worker to production
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_PROD }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npm run deploy:production
+        run: >-
+          npx wrangler deploy --env production
+          --var APP_URL:${{ vars.CLOUDFLARE_PRODUCTION_URL }}
+          --var OWNER_EMAIL:${{ vars.OWNER_EMAIL }}

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Deploy Worker to production
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_PROD }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: >-
           npx wrangler deploy --env production

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Fill in:
 - `AUTH_SECRET`
 - `SETUP_SECRET`
 
-Update `wrangler.jsonc` with your real D1 `database_id` and set `OWNER_EMAIL` to your email address.
+Set `OWNER_EMAIL` in the top-level `vars` section of `wrangler.jsonc` to your email address for local development. For CI/CD deployments, all environment-specific values (D1 database IDs, URLs, owner email) are injected automatically from GitHub secrets and variables — see [`docs/ci-cd-architecture.md`](./docs/ci-cd-architecture.md).
 
 ### Apply local migrations
 
@@ -194,17 +194,81 @@ The repository now includes a Cloudflare-focused CI/CD baseline for issue #8:
 
 See [`docs/ci-cd-architecture.md`](./docs/ci-cd-architecture.md) for the required GitHub secrets, Cloudflare setup, repository variables, environment protection rules, and the production migration workflow.
 
-## Deploy to Cloudflare onboarding
+## Deploy your own instance
 
-[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/andersro93/mi-casa-su-casa)
+Fork this repository and follow the steps below. No source edits are needed — every environment-specific value is injected through GitHub secrets, GitHub variables, and the Cloudflare dashboard.
 
-The deploy button can provision the Worker and D1 resources defined in this repository, but you still need to finish the first-run and email onboarding steps yourself:
+### 1. Create Cloudflare resources
 
-1. complete the Cloudflare deploy flow and provide the requested secrets/variables
-2. visit `/setup` on the new deployment and create the initial owner account using `OWNER_EMAIL` and `SETUP_SECRET`
-3. onboard your email-routing domain in Cloudflare and configure the inbound rules for the shared inbox address
+```bash
+# Install Wrangler and authenticate
+npm i -g wrangler && wrangler login
 
-The first-run `/setup` flow closes permanently after the initial owner account is created.
+# Create preview and production D1 databases
+wrangler d1 create mi-casa-su-casa-preview
+wrangler d1 create mi-casa-su-casa
+```
+
+Save the database UUIDs from the output — you will need them in the next step.
+
+### 2. Add GitHub secrets
+
+Go to your fork → **Settings → Secrets and variables → Actions → Secrets** and add:
+
+| Secret | Value |
+| --- | --- |
+| `CLOUDFLARE_ACCOUNT_ID` | Your Cloudflare account ID |
+| `CLOUDFLARE_API_TOKEN` | API token for preview deploys (Workers + D1 scope) |
+| `CLOUDFLARE_API_TOKEN_PROD` | API token for production deploys and migrations (Workers + D1 scope) |
+| `D1_DATABASE_ID_PREVIEW` | UUID from `wrangler d1 create mi-casa-su-casa-preview` |
+| `D1_DATABASE_ID_PRODUCTION` | UUID from `wrangler d1 create mi-casa-su-casa` |
+
+### 3. Add GitHub variables
+
+Go to **Settings → Secrets and variables → Actions → Variables** and add:
+
+| Variable | Value |
+| --- | --- |
+| `CLOUDFLARE_PREVIEW_URL` | URL of your preview Worker (e.g. `https://mi-casa-su-casa-preview.<your-subdomain>.workers.dev`) |
+| `CLOUDFLARE_PRODUCTION_URL` | URL of your production deployment (e.g. `https://mi-casa-su-casa.<your-domain>.com`) |
+| `OWNER_EMAIL` | Email address for the initial owner account |
+
+### 4. Set Cloudflare dashboard secrets
+
+In the Cloudflare dashboard, go to **Workers & Pages → mi-casa-su-casa → Settings → Variables and Secrets** and add as encrypted secrets:
+
+| Secret | Purpose |
+| --- | --- |
+| `AUTH_SECRET` | Random string used by Better Auth to sign sessions (generate with `openssl rand -base64 32`) |
+| `SETUP_SECRET` | One-time setup passphrase you choose for the initial owner account creation |
+
+Repeat for the preview Worker (`mi-casa-su-casa-preview`) if you want setup to work in preview environments.
+
+### 5. Configure repository protection
+
+- Enable branch protection on `main` requiring the `CI` workflow to pass
+- Create a `production-migrations` environment under **Settings → Environments** with required reviewers so production schema changes need explicit approval
+
+### 6. Set up email routing
+
+In the Cloudflare dashboard:
+
+1. Go to your domain → **Email → Email Routing**
+2. Create a routing rule that forwards your shared inbox address (e.g. `codes@yourdomain.com`) to the Worker
+
+### 7. Deploy and run first-time setup
+
+Push to `main` or open a pull request — the GitHub Actions workflows will handle deployment automatically.
+
+After the first successful deploy:
+
+1. Visit `https://<your-production-url>/setup`
+2. Enter the `OWNER_EMAIL` and `SETUP_SECRET` you configured
+3. The initial owner account is created and the `/setup` route locks permanently
+
+You're done. Invite family members through the app.
+
+For full CI/CD details, see [`docs/ci-cd-architecture.md`](./docs/ci-cd-architecture.md).
 
 ## Testing strategy
 

--- a/README.md
+++ b/README.md
@@ -211,20 +211,26 @@ wrangler d1 create mi-casa-su-casa
 
 Save the database UUIDs from the output — you will need them in the next step.
 
-### 2. Create Cloudflare API tokens
+### 2. Create a Cloudflare API token
 
-You need API tokens so GitHub Actions can deploy on your behalf. Create one token for preview and one for production (or reuse a single token if you prefer).
+You need an API token so GitHub Actions can deploy on your behalf. A single token is used for preview deploys, production deploys, and production migrations.
 
-1. Open [**API Tokens** in the Cloudflare dashboard](https://dash.cloudflare.com/profile/api-tokens)
-2. Select **Create Token**
-3. Choose the **Edit Cloudflare Workers** template and click **Use template**
-4. Add one more permission: **Account → D1 → Edit** (required for database migrations)
-5. Under **Account Resources**, select your account
-6. Under **Zone Resources**, select **All zones** (or the specific zone for your domain)
-7. Click **Continue to summary** → **Create Token**
-8. Copy the token — it is only shown once
+**Account-owned tokens** (recommended — survives team changes, requires Super Administrator):
 
-Repeat this process if you want separate tokens for preview and production environments.
+1. Open the [Cloudflare dashboard](https://dash.cloudflare.com) → select your account → **Manage Account → Account API Tokens → Create Token**
+
+**User-owned tokens** (fallback for non-Super-Admins):
+
+1. Open [**API Tokens** in your profile](https://dash.cloudflare.com/profile/api-tokens) → **Create Token**
+
+Then for either type:
+
+2. Choose the **Edit Cloudflare Workers** template and click **Use template**
+3. Add one more permission: **Account → D1 → Edit** (required for database migrations)
+4. Under **Account Resources**, select your account
+5. Under **Zone Resources**, select **All zones** (or the specific zone for your domain)
+6. Click **Continue to summary** → **Create Token**
+7. Copy the token — it is only shown once
 
 > **Where to find your Account ID**: open the [Cloudflare dashboard](https://dash.cloudflare.com), go to **Workers & Pages** — your Account ID is shown in the right sidebar.
 
@@ -235,8 +241,7 @@ Go to your fork → **Settings → Secrets and variables → Actions → Secrets
 | Secret | Value |
 | --- | --- |
 | `CLOUDFLARE_ACCOUNT_ID` | Your Cloudflare account ID (see above) |
-| `CLOUDFLARE_API_TOKEN` | API token for preview deploys (from step 2) |
-| `CLOUDFLARE_API_TOKEN_PROD` | API token for production deploys and migrations (from step 2) |
+| `CLOUDFLARE_API_TOKEN` | API token from step 2 |
 | `D1_DATABASE_ID_PREVIEW` | UUID from `wrangler d1 create mi-casa-su-casa-preview` |
 | `D1_DATABASE_ID_PRODUCTION` | UUID from `wrangler d1 create mi-casa-su-casa` |
 

--- a/README.md
+++ b/README.md
@@ -211,19 +211,36 @@ wrangler d1 create mi-casa-su-casa
 
 Save the database UUIDs from the output — you will need them in the next step.
 
-### 2. Add GitHub secrets
+### 2. Create Cloudflare API tokens
+
+You need API tokens so GitHub Actions can deploy on your behalf. Create one token for preview and one for production (or reuse a single token if you prefer).
+
+1. Open [**API Tokens** in the Cloudflare dashboard](https://dash.cloudflare.com/profile/api-tokens)
+2. Select **Create Token**
+3. Choose the **Edit Cloudflare Workers** template and click **Use template**
+4. Add one more permission: **Account → D1 → Edit** (required for database migrations)
+5. Under **Account Resources**, select your account
+6. Under **Zone Resources**, select **All zones** (or the specific zone for your domain)
+7. Click **Continue to summary** → **Create Token**
+8. Copy the token — it is only shown once
+
+Repeat this process if you want separate tokens for preview and production environments.
+
+> **Where to find your Account ID**: open the [Cloudflare dashboard](https://dash.cloudflare.com), go to **Workers & Pages** — your Account ID is shown in the right sidebar.
+
+### 3. Add GitHub secrets
 
 Go to your fork → **Settings → Secrets and variables → Actions → Secrets** and add:
 
 | Secret | Value |
 | --- | --- |
-| `CLOUDFLARE_ACCOUNT_ID` | Your Cloudflare account ID |
-| `CLOUDFLARE_API_TOKEN` | API token for preview deploys (Workers + D1 scope) |
-| `CLOUDFLARE_API_TOKEN_PROD` | API token for production deploys and migrations (Workers + D1 scope) |
+| `CLOUDFLARE_ACCOUNT_ID` | Your Cloudflare account ID (see above) |
+| `CLOUDFLARE_API_TOKEN` | API token for preview deploys (from step 2) |
+| `CLOUDFLARE_API_TOKEN_PROD` | API token for production deploys and migrations (from step 2) |
 | `D1_DATABASE_ID_PREVIEW` | UUID from `wrangler d1 create mi-casa-su-casa-preview` |
 | `D1_DATABASE_ID_PRODUCTION` | UUID from `wrangler d1 create mi-casa-su-casa` |
 
-### 3. Add GitHub variables
+### 4. Add GitHub variables
 
 Go to **Settings → Secrets and variables → Actions → Variables** and add:
 
@@ -233,7 +250,7 @@ Go to **Settings → Secrets and variables → Actions → Variables** and add:
 | `CLOUDFLARE_PRODUCTION_URL` | URL of your production deployment (e.g. `https://mi-casa-su-casa.<your-domain>.com`) |
 | `OWNER_EMAIL` | Email address for the initial owner account |
 
-### 4. Set Cloudflare dashboard secrets
+### 5. Set Cloudflare dashboard secrets
 
 In the Cloudflare dashboard, go to **Workers & Pages → mi-casa-su-casa → Settings → Variables and Secrets** and add as encrypted secrets:
 
@@ -244,19 +261,19 @@ In the Cloudflare dashboard, go to **Workers & Pages → mi-casa-su-casa → Set
 
 Repeat for the preview Worker (`mi-casa-su-casa-preview`) if you want setup to work in preview environments.
 
-### 5. Configure repository protection
+### 6. Configure repository protection
 
 - Enable branch protection on `main` requiring the `CI` workflow to pass
 - Create a `production-migrations` environment under **Settings → Environments** with required reviewers so production schema changes need explicit approval
 
-### 6. Set up email routing
+### 7. Set up email routing
 
 In the Cloudflare dashboard:
 
 1. Go to your domain → **Email → Email Routing**
 2. Create a routing rule that forwards your shared inbox address (e.g. `codes@yourdomain.com`) to the Worker
 
-### 7. Deploy and run first-time setup
+### 8. Deploy and run first-time setup
 
 Push to `main` or open a pull request — the GitHub Actions workflows will handle deployment automatically.
 

--- a/docs/ci-cd-architecture.md
+++ b/docs/ci-cd-architecture.md
@@ -72,40 +72,45 @@ This is the explicit production schema step required by issue #8.
 
 ## Wrangler environment model
 
-`wrangler.jsonc` now separates preview and production bindings:
+`wrangler.jsonc` separates preview and production bindings:
 
-- top-level config is still local-development oriented
+- top-level config is local-development oriented
 - `env.preview` deploys `mi-casa-su-casa-preview`
 - `env.production` deploys `mi-casa-su-casa`
-- preview and production use different D1 bindings and URLs
+- preview and production use different D1 bindings
 
-Replace the placeholder values before using these workflows:
+D1 `database_id` values and runtime variables (`APP_URL`, `OWNER_EMAIL`) are **not hardcoded** in `wrangler.jsonc`. They are injected at deploy time by the GitHub Actions workflows:
 
-- preview D1 database id: `11111111-1111-1111-1111-111111111111`
-- production D1 database id: `22222222-2222-2222-2222-222222222222`
-- preview URL placeholder in `APP_URL`
-- production URL placeholder in `APP_URL`
+- D1 database IDs are replaced via `sed` from GitHub secrets before Wrangler runs
+- `APP_URL` and `OWNER_EMAIL` are passed to Wrangler with `--var KEY:VALUE` at deploy time
+
+This design means forkers never need to edit `wrangler.jsonc` — just add the required secrets and variables to their GitHub repository.
 
 ## Required GitHub secrets
 
-Add these repository secrets under **Settings → Secrets and variables → Actions**:
+Add these repository secrets under **Settings → Secrets and variables → Actions → Secrets**:
 
 | Secret | Purpose |
 | --- | --- |
 | `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account used by Wrangler |
-| `CLOUDFLARE_API_TOKEN` | Preview deploy token scoped to Workers + D1 for the preview account |
-| `CLOUDFLARE_API_TOKEN_PROD` | Production deploy and migration token scoped to Workers + D1 for production |
+| `CLOUDFLARE_API_TOKEN` | Preview deploy token scoped to Workers + D1 |
+| `CLOUDFLARE_API_TOKEN_PROD` | Production deploy and migration token scoped to Workers + D1 |
+| `D1_DATABASE_ID_PREVIEW` | UUID of the preview D1 database (from `wrangler d1 create`) |
+| `D1_DATABASE_ID_PRODUCTION` | UUID of the production D1 database (from `wrangler d1 create`) |
 
 Cloudflare recommends scoping API tokens to the single account they need to manage.
 
-## Recommended GitHub variables
+## Required GitHub variables
 
-Add these repository variables if you want richer workflow output:
+Add these repository variables under **Settings → Secrets and variables → Actions → Variables**:
 
 | Variable | Purpose |
 | --- | --- |
-| `CLOUDFLARE_PREVIEW_URL` | URL that the preview workflow comments on pull requests |
-| `CLOUDFLARE_PRODUCTION_URL` | URL shown on the protected migration environment |
+| `CLOUDFLARE_PREVIEW_URL` | Full URL of the preview deployment (e.g. `https://mi-casa-su-casa-preview.example.workers.dev`) |
+| `CLOUDFLARE_PRODUCTION_URL` | Full URL of the production deployment (e.g. `https://mi-casa-su-casa.example.com`) |
+| `OWNER_EMAIL` | Email address for the initial owner account |
+
+`CLOUDFLARE_PREVIEW_URL` and `CLOUDFLARE_PRODUCTION_URL` are injected as the `APP_URL` binding in the respective environments. `OWNER_EMAIL` is injected as the `OWNER_EMAIL` binding.
 
 The preview workflow still deploys without `CLOUDFLARE_PREVIEW_URL`, but the pull request comment will only report status instead of a direct link.
 
@@ -156,39 +161,14 @@ npm run db:apply:production
 
 This issue adds the repository-side CI/CD wiring, but operators still need to:
 
-1. create the preview and production D1 databases in Cloudflare
-2. replace placeholder IDs and URLs in `wrangler.jsonc`
-3. create the GitHub secrets and variables listed above
-4. enable branch protection on `main` so `CI` stays required
-5. configure required reviewers for the `production-migrations` environment
+1. create the preview and production D1 databases in Cloudflare (`wrangler d1 create mi-casa-su-casa-preview` and `wrangler d1 create mi-casa-su-casa`)
+2. add the GitHub secrets listed above (including the D1 database UUIDs from step 1)
+3. add the GitHub variables listed above
+4. set `AUTH_SECRET` and `SETUP_SECRET` as encrypted secrets in the Cloudflare dashboard for the Worker
+5. enable branch protection on `main` so `CI` stays required
+6. configure required reviewers for the `production-migrations` environment
 
-## Deploy to Cloudflare onboarding for issue #9
-
-Use this repository button for the Cloudflare-native deploy entry point:
-
-```markdown
-[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/andersro93/mi-casa-su-casa)
-```
-
-What the Deploy to Cloudflare flow handles well:
-
-- creating the Worker deployment
-- provisioning D1 resources defined in Wrangler
-- prompting for environment variables and secrets needed at deploy time
-
-What still remains manual after deployment:
-
-- visit `/setup` to create the first owner account
-- provide the configured `OWNER_EMAIL` and `SETUP_SECRET`
-- onboard the email-routing domain in Cloudflare and create the inbound rules for the shared inbox address
-
-Recommended first-run secrets for onboarding:
-
-- `AUTH_SECRET`
-- `OWNER_EMAIL`
-- `SETUP_SECRET`
-
-The app-level setup route is intentionally one-time only. After the owner account is created, `/setup` is locked server-side and normal invite-only sign-in remains the only public auth path.
+No edits to `wrangler.jsonc` are needed — all environment-specific values are injected by the workflows.
 
 ## References
 

--- a/docs/ci-cd-architecture.md
+++ b/docs/ci-cd-architecture.md
@@ -93,25 +93,24 @@ Add these repository secrets under **Settings → Secrets and variables → Acti
 | Secret | Purpose |
 | --- | --- |
 | `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account used by Wrangler (found on the Workers & Pages overview sidebar) |
-| `CLOUDFLARE_API_TOKEN` | Preview deploy token — see [Creating an API token](#creating-an-api-token) below |
-| `CLOUDFLARE_API_TOKEN_PROD` | Production deploy and migration token — see [Creating an API token](#creating-an-api-token) below |
+| `CLOUDFLARE_API_TOKEN` | API token for all deployments and migrations — see [Creating an API token](#creating-an-api-token) below |
 | `D1_DATABASE_ID_PREVIEW` | UUID of the preview D1 database (from `wrangler d1 create`) |
 | `D1_DATABASE_ID_PRODUCTION` | UUID of the production D1 database (from `wrangler d1 create`) |
 
-Cloudflare recommends scoping API tokens to the single account they need to manage.
+A single token is used for preview deploys, production deploys, and production migrations. Cloudflare recommends scoping API tokens to the single account they need to manage.
 
 ### Creating an API token
 
-1. Open [**API Tokens** in the Cloudflare dashboard](https://dash.cloudflare.com/profile/api-tokens)
-2. Select **Create Token**
+Create an **account-owned** token so CI/CD survives team changes (requires Super Administrator). If you are not a Super Administrator, create a user-owned token instead — both work the same way, but user tokens are revoked if the creating user loses access.
+
+1. For an **account-owned token**: open the [Cloudflare dashboard](https://dash.cloudflare.com) → select your account → **Manage Account → Account API Tokens → Create Token**
+2. For a **user-owned token**: open [**API Tokens** in your profile](https://dash.cloudflare.com/profile/api-tokens) → **Create Token**
 3. Choose the **Edit Cloudflare Workers** template and click **Use template**
 4. Add one more permission: **Account → D1 → Edit** (required for `wrangler d1 migrations apply`)
 5. Under **Account Resources**, select only the account that owns your Workers
 6. Under **Zone Resources**, select **All zones** (or the specific zone for your domain)
 7. Click **Continue to summary** → **Create Token**
 8. Copy the token — it is only shown once
-
-You can create two separate tokens (one for preview, one for production) for tighter scoping, or reuse a single token for both.
 
 ## Required GitHub variables
 

--- a/docs/ci-cd-architecture.md
+++ b/docs/ci-cd-architecture.md
@@ -92,13 +92,26 @@ Add these repository secrets under **Settings → Secrets and variables → Acti
 
 | Secret | Purpose |
 | --- | --- |
-| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account used by Wrangler |
-| `CLOUDFLARE_API_TOKEN` | Preview deploy token scoped to Workers + D1 |
-| `CLOUDFLARE_API_TOKEN_PROD` | Production deploy and migration token scoped to Workers + D1 |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account used by Wrangler (found on the Workers & Pages overview sidebar) |
+| `CLOUDFLARE_API_TOKEN` | Preview deploy token — see [Creating an API token](#creating-an-api-token) below |
+| `CLOUDFLARE_API_TOKEN_PROD` | Production deploy and migration token — see [Creating an API token](#creating-an-api-token) below |
 | `D1_DATABASE_ID_PREVIEW` | UUID of the preview D1 database (from `wrangler d1 create`) |
 | `D1_DATABASE_ID_PRODUCTION` | UUID of the production D1 database (from `wrangler d1 create`) |
 
 Cloudflare recommends scoping API tokens to the single account they need to manage.
+
+### Creating an API token
+
+1. Open [**API Tokens** in the Cloudflare dashboard](https://dash.cloudflare.com/profile/api-tokens)
+2. Select **Create Token**
+3. Choose the **Edit Cloudflare Workers** template and click **Use template**
+4. Add one more permission: **Account → D1 → Edit** (required for `wrangler d1 migrations apply`)
+5. Under **Account Resources**, select only the account that owns your Workers
+6. Under **Zone Resources**, select **All zones** (or the specific zone for your domain)
+7. Click **Continue to summary** → **Create Token**
+8. Copy the token — it is only shown once
+
+You can create two separate tokens (one for preview, one for production) for tighter scoping, or reuse a single token for both.
 
 ## Required GitHub variables
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -10,11 +10,12 @@
     "not_found_handling": "single-page-application",
     "run_worker_first": ["/api/*"]
   },
+  // Local development uses a local D1 file database — the database_id below is ignored.
   "d1_databases": [
     {
       "binding": "DB",
       "database_name": "mi-casa-su-casa",
-      "database_id": "00000000-0000-0000-0000-000000000000",
+      "database_id": "local-dev-unused",
       "preview_database_id": "DB",
       "migrations_dir": "migrations"
     }
@@ -33,11 +34,12 @@
   "env": {
     "preview": {
       "name": "mi-casa-su-casa-preview",
+      // D1 database_id is injected at deploy time from the GitHub secret D1_DATABASE_ID_PREVIEW.
       "d1_databases": [
         {
           "binding": "DB",
           "database_name": "mi-casa-su-casa-preview",
-          "database_id": "11111111-1111-1111-1111-111111111111",
+          "database_id": "PLACEHOLDER_PREVIEW_D1_DATABASE_ID",
           "migrations_dir": "migrations"
         }
       ],
@@ -46,20 +48,20 @@
           "name": "EMAIL"
         }
       ],
+      // APP_URL and OWNER_EMAIL are injected at deploy time via --var from GitHub variables.
       "vars": {
         "APP_NAME": "Mi Casa Su Casa (Preview)",
-        "APP_URL": "https://REPLACE_WITH_PREVIEW_URL",
-        "ENVIRONMENT": "preview",
-        "OWNER_EMAIL": "owner@example.com"
+        "ENVIRONMENT": "preview"
       }
     },
     "production": {
       "name": "mi-casa-su-casa",
+      // D1 database_id is injected at deploy time from the GitHub secret D1_DATABASE_ID_PRODUCTION.
       "d1_databases": [
         {
           "binding": "DB",
           "database_name": "mi-casa-su-casa",
-          "database_id": "22222222-2222-2222-2222-222222222222",
+          "database_id": "PLACEHOLDER_PRODUCTION_D1_DATABASE_ID",
           "migrations_dir": "migrations"
         }
       ],
@@ -68,11 +70,10 @@
           "name": "EMAIL"
         }
       ],
+      // APP_URL and OWNER_EMAIL are injected at deploy time via --var from GitHub variables.
       "vars": {
         "APP_NAME": "Mi Casa Su Casa",
-        "APP_URL": "https://REPLACE_WITH_PRODUCTION_URL",
-        "ENVIRONMENT": "production",
-        "OWNER_EMAIL": "owner@example.com"
+        "ENVIRONMENT": "production"
       }
     }
   },


### PR DESCRIPTION
## Summary

Makes the repo trivially forkable by externalizing **all** Cloudflare-specific values (D1 database IDs, URLs, email) into GitHub Secrets and Variables. Forkers never need to edit source files — just configure their GitHub repo settings and push.

## Changes

- **`wrangler.jsonc`**: Replaced hardcoded D1 database UUIDs with placeholder tokens (`PLACEHOLDER_PREVIEW_D1_DATABASE_ID`, `PLACEHOLDER_PRODUCTION_D1_DATABASE_ID`); removed `APP_URL`/`OWNER_EMAIL` from env-specific vars (now injected at deploy time)
- **GitHub Actions workflows** (`preview-deploy.yml`, `production-deploy.yml`, `production-d1-migrate.yml`): Added `sed` steps to replace placeholder tokens with secrets, and `--var` flags to inject `APP_URL` and `OWNER_EMAIL` at deploy time
- **`README.md`**: Replaced broken deploy button with comprehensive 7-step "Deploy your own instance" guide
- **`docs/ci-cd-architecture.md`**: Rewrote secrets/variables tables to match new config; removed stale onboarding section

## Required GitHub Configuration

### Secrets
| Name | Description |
|------|-------------|
| `CLOUDFLARE_API_TOKEN` | Preview environment API token |
| `CLOUDFLARE_API_TOKEN_PROD` | Production environment API token |
| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account ID |
| `D1_DATABASE_ID_PREVIEW` | Preview D1 database UUID |
| `D1_DATABASE_ID_PRODUCTION` | Production D1 database UUID |

### Variables
| Name | Description |
|------|-------------|
| `CLOUDFLARE_PREVIEW_URL` | Preview URL (e.g. `https://preview.example.com`) |
| `CLOUDFLARE_PRODUCTION_URL` | Production URL (e.g. `https://example.com`) |
| `OWNER_EMAIL` | Admin email for the instance owner |

### Dashboard Secrets (set in Cloudflare)
- `AUTH_SECRET` — random 32+ char string for session signing
- `SETUP_SECRET` — random string for first-time setup endpoint

## Verification

- `grep -r` confirms zero hardcoded UUIDs or `.workers.dev` URLs in source
- All `database_id` entries use placeholder tokens
- Workflows inject real values at build time via `sed` + `--var`