### PR TITLE
fix: remove invalid baseURL from auth client

### DIFF
--- a/src/server/auth/client.ts
+++ b/src/server/auth/client.ts
@@ -2,7 +2,6 @@ import { adminClient } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 
 export const authClient = createAuthClient({
-  baseURL: "/",
   plugins: [adminClient()],
   sessionOptions: {
     refetchInterval: 0,


### PR DESCRIPTION
## Summary

- Removes hardcoded `baseURL: "/"` from the BetterAuth client configuration that caused `BetterAuthError: Invalid base URL` at runtime
- Since the API and frontend are served from the same Cloudflare Worker origin, omitting `baseURL` lets BetterAuth default to `window.location.origin` — which is the correct behavior for same-origin apps