### PR TITLE
chore: enable Worker observability logs

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -79,5 +79,11 @@
   },
   "triggers": {
     "crons": ["0 3 * * *"]
+  },
+  "observability": {
+    "logs": {
+      "enabled": true,
+      "invocation_logs": true
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Enables Cloudflare Worker observability at the top level of `wrangler.jsonc`, inherited by all environments (preview + production)
- Turns on both `logs` and `invocation_logs` for runtime visibility into Worker executions