### PR TITLE
fix: apply D1 migrations in production deploy workflow

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -35,6 +35,12 @@ jobs:
           D1_DATABASE_ID_PRODUCTION: ${{ secrets.D1_DATABASE_ID_PRODUCTION }}
         run: sed -i 's/PLACEHOLDER_PRODUCTION_D1_DATABASE_ID/'"$D1_DATABASE_ID_PRODUCTION"'/' wrangler.jsonc
 
+      - name: Apply production D1 migrations
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npm run db:apply:production
+
       - name: Deploy Worker to production
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds the missing D1 migration step to the production deploy workflow, matching the existing preview deploy behavior
- Fixes 500 errors on production caused by Better Auth tables not existing in the production D1 database

The production deploy workflow deployed the Worker but never ran `npm run db:apply:production`, so all database queries failed with "Failed query" errors.