### PR TITLE
fix: log actual error on setup completion failure

### DIFF
--- a/src/server/routes/setup.ts
+++ b/src/server/routes/setup.ts
@@ -146,6 +146,8 @@ setupRoutes.post("/complete", async (c) => {
 
     return response;
   } catch (error) {
+    console.error("Setup completion failed:", error);
+
     await resetInstallationSetup(c.env.DB);
 
     if (isAPIError(error)) {


### PR DESCRIPTION
## Summary

- Adds `console.error` before the catch-all handler in `/api/setup/complete` so the actual error appears in Cloudflare Workers logs
- Previously, all non-BetterAuth errors returned a generic 500 with no logging, making production debugging impossible

## Context

Setup completion is returning 500 in production with no visibility into the root cause. This change surfaces the error in Cloudflare real-time logs / `wrangler tail`.