### PR TITLE
fix: add missing admin plugin fields to user and session tables

### DIFF
--- a/migrations/0003_admin_plugin_fields.sql
+++ b/migrations/0003_admin_plugin_fields.sql
@@ -1,0 +1,8 @@
+-- Add Better Auth admin plugin fields to user and session tables.
+-- These columns are required by the admin plugin for ban management and impersonation.
+
+ALTER TABLE user ADD COLUMN banned INTEGER DEFAULT 0;
+ALTER TABLE user ADD COLUMN banReason TEXT;
+ALTER TABLE user ADD COLUMN banExpires INTEGER;
+
+ALTER TABLE session ADD COLUMN impersonatedBy TEXT;

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -17,6 +17,9 @@ export const user = sqliteTable("user", {
     .notNull(),
   image: text("image"),
   role: text("role").default("user"),
+  banned: integer("banned", { mode: "boolean" }).default(false),
+  banReason: text("banReason"),
+  banExpires: integer("banExpires", { mode: "timestamp_ms" }),
   createdAt: integer("createdAt", { mode: "timestamp_ms" }).notNull(),
   updatedAt: integer("updatedAt", { mode: "timestamp_ms" }).notNull(),
 });
@@ -34,6 +37,7 @@ export const session = sqliteTable(
     userId: text("userId")
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
+    impersonatedBy: text("impersonatedBy"),
   },
   (table) => [index("session_userId_idx").on(table.userId)],
 );


### PR DESCRIPTION
## Summary
- Adds `banned`, `banReason`, `banExpires` columns to `user` table in Drizzle schema
- Adds `impersonatedBy` column to `session` table in Drizzle schema
- Includes migration `0003_admin_plugin_fields.sql` with ALTER TABLE statements

## Why
Better Auth's admin plugin requires these fields. Without them, `auth.api.createUser()` fails with:
```
BetterAuthError: The field "banned" does not exist in the "user" Drizzle schema
```
This blocks the initial `/setup` flow from completing.