### PR TITLE
feat: MUI polish — icons, members table, color palette

### DIFF
--- a/src/client/components/InboxView.tsx
+++ b/src/client/components/InboxView.tsx
@@ -1,21 +1,69 @@
 import {
+  CheckCircleOutlined,
+  ContentCopyOutlined,
+  EmailOutlined,
+  HistoryOutlined,
+  InboxOutlined,
+  MailOutlined,
+  MarkEmailReadOutlined,
+  ScheduleOutlined,
+} from "@mui/icons-material";
+import {
+  Avatar,
+  Badge,
   Box,
   Button,
   Card,
   CardContent,
   Chip,
   Divider,
+  IconButton,
   List,
   ListItem,
   ListItemButton,
   ListItemText,
   Paper,
-  Stack,
+  Tooltip,
   Typography,
 } from "@mui/material";
-import React from "react";
+import React, { useState } from "react";
 import type { InboxMessage, ProviderSummary } from "../types";
 import { formatTimestamp } from "../utils";
+
+const avatarColors = [
+  "#6366F1", // Indigo
+  "#8B5CF6", // Violet
+  "#A855F7", // Purple
+  "#EC4899", // Fuchsia
+  "#3B82F6", // Blue
+  "#0EA5E9", // Light Blue
+  "#14B8A6", // Sky
+  "#06B6D4", // Cyan
+];
+
+function stringToColor(string: string) {
+  let hash = 0;
+  for (let i = 0; i < string.length; i += 1) {
+    hash = string.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return avatarColors[Math.abs(hash) % avatarColors.length];
+}
+
+function stringAvatar(name: string) {
+  const safeName = name || "?";
+  const parts = safeName.split(" ");
+  const initials =
+    parts.length > 1 ? `${parts[0][0]}${parts[1][0]}` : safeName[0];
+
+  return {
+    sx: {
+      bgcolor: stringToColor(safeName),
+      color: "#fff",
+      fontWeight: "bold",
+    },
+    children: initials.toUpperCase(),
+  };
+}
 
 interface InboxViewProps {
   providers: ProviderSummary[];
@@ -40,10 +88,22 @@ export function InboxView({
   isSavingMessage,
   onStatusChange,
 }: InboxViewProps) {
+  const [copiedCodeId, setCopiedCodeId] = useState<string | null>(null);
+
   const selectedProvider = providers.find(
     (p) => p.provider_key === selectedProviderKey,
   );
   const selectedMessage = messages.find((m) => m.id === selectedMessageId);
+
+  const handleCopyCode = async (code: string, id: string) => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopiedCodeId(id);
+      setTimeout(() => setCopiedCodeId(null), 2000);
+    } catch (err) {
+      console.error("Failed to copy text: ", err);
+    }
+  };
 
   const getStatusColor = (status: InboxMessage["status"]) => {
     switch (status) {
@@ -108,25 +168,42 @@ export function InboxView({
                           <Box
                             sx={{
                               display: "flex",
-                              justifyContent: "space-between",
+                              alignItems: "center",
+                              gap: 2,
                               mb: 0.5,
                             }}
                           >
+                            <Badge
+                              color="primary"
+                              badgeContent={provider.new_count}
+                              invisible={provider.new_count === 0}
+                              sx={{
+                                "& .MuiBadge-badge": {
+                                  fontWeight: "bold",
+                                },
+                              }}
+                            >
+                              <Avatar
+                                {...stringAvatar(provider.display_name)}
+                                sx={{
+                                  ...stringAvatar(provider.display_name).sx,
+                                  width: 32,
+                                  height: 32,
+                                  fontSize: "0.875rem",
+                                }}
+                              />
+                            </Badge>
                             <Typography
                               variant="subtitle1"
                               sx={{
                                 fontWeight: isSelected ? "bold" : "medium",
+                                color: isSelected
+                                  ? "primary.main"
+                                  : "text.primary",
                               }}
                             >
                               {provider.display_name}
                             </Typography>
-                            {provider.new_count > 0 && (
-                              <Chip
-                                label={`${provider.new_count} new`}
-                                size="small"
-                                color="primary"
-                              />
-                            )}
                           </Box>
                         }
                         secondary={
@@ -154,6 +231,9 @@ export function InboxView({
 
             {!providers.length && !isLoadingInbox && (
               <Box sx={{ p: 4, textAlign: "center" }}>
+                <InboxOutlined
+                  sx={{ fontSize: 48, color: "text.disabled", mb: 2 }}
+                />
                 <Typography
                   variant="subtitle1"
                   sx={{ fontWeight: "bold" }}
@@ -258,8 +338,14 @@ export function InboxView({
                             <Typography
                               variant="caption"
                               color="text.disabled"
-                              sx={{ mt: 0.5, display: "block" }}
+                              sx={{
+                                mt: 0.5,
+                                display: "flex",
+                                alignItems: "center",
+                                gap: 0.5,
+                              }}
                             >
+                              <ScheduleOutlined sx={{ fontSize: 14 }} />
                               {formatTimestamp(message.received_at)}
                             </Typography>
                           </>
@@ -273,6 +359,9 @@ export function InboxView({
 
             {!messages.length && !isLoadingInbox && (
               <Box sx={{ p: 4, textAlign: "center" }}>
+                <MailOutlined
+                  sx={{ fontSize: 48, color: "text.disabled", mb: 2 }}
+                />
                 <Typography
                   variant="subtitle1"
                   sx={{ fontWeight: "bold" }}
@@ -335,33 +424,82 @@ export function InboxView({
               elevation={0}
               sx={{
                 border: 1,
-                borderColor: "divider",
+                borderColor: "primary.light",
                 borderRadius: 2,
-                bgcolor: "background.default",
+                bgcolor: "primary.main",
+                color: "primary.contrastText",
               }}
             >
-              <CardContent sx={{ p: 4, textAlign: "center" }}>
+              <CardContent
+                sx={{ p: 4, textAlign: "center", position: "relative" }}
+              >
                 <Typography
                   variant="overline"
-                  color="text.secondary"
-                  sx={{ display: "block", mb: 1, fontWeight: "bold" }}
+                  sx={{
+                    display: "block",
+                    mb: 1,
+                    fontWeight: "bold",
+                    opacity: 0.9,
+                  }}
                 >
                   Verification code
                 </Typography>
-                <Typography
-                  variant="h3"
-                  sx={{ fontWeight: "bold", letterSpacing: 2 }}
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    gap: 2,
+                  }}
                 >
-                  {selectedMessage.extracted_code ?? "No code detected"}
-                </Typography>
+                  <Typography
+                    variant="h3"
+                    sx={{ fontWeight: "bold", letterSpacing: 2 }}
+                  >
+                    {selectedMessage.extracted_code ?? "No code detected"}
+                  </Typography>
+                  {selectedMessage.extracted_code && (
+                    <Tooltip
+                      title={
+                        copiedCodeId === selectedMessage.id
+                          ? "Copied!"
+                          : "Copy code"
+                      }
+                      placement="top"
+                    >
+                      <IconButton
+                        onClick={() => {
+                          if (selectedMessage.extracted_code) {
+                            handleCopyCode(
+                              selectedMessage.extracted_code,
+                              selectedMessage.id,
+                            );
+                          }
+                        }}
+                        sx={{
+                          color: "primary.contrastText",
+                          opacity: 0.9,
+                          "&:hover": { opacity: 1 },
+                        }}
+                      >
+                        {copiedCodeId === selectedMessage.id ? (
+                          <CheckCircleOutlined />
+                        ) : (
+                          <ContentCopyOutlined />
+                        )}
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                </Box>
               </CardContent>
             </Card>
 
-            <Stack direction="row" spacing={2}>
+            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
               <Button
                 variant="outlined"
                 disabled={isSavingMessage}
                 onClick={() => onStatusChange("new")}
+                startIcon={<EmailOutlined />}
               >
                 Mark new
               </Button>
@@ -369,6 +507,7 @@ export function InboxView({
                 variant="outlined"
                 disabled={isSavingMessage}
                 onClick={() => onStatusChange("used")}
+                startIcon={<MarkEmailReadOutlined />}
               >
                 Mark used
               </Button>
@@ -376,10 +515,11 @@ export function InboxView({
                 variant="outlined"
                 disabled={isSavingMessage}
                 onClick={() => onStatusChange("expired")}
+                startIcon={<HistoryOutlined />}
               >
                 Mark expired
               </Button>
-            </Stack>
+            </Box>
 
             <Paper variant="outlined" sx={{ p: 3, borderRadius: 2 }}>
               <Typography
@@ -412,6 +552,9 @@ export function InboxView({
               borderStyle: "dashed",
             }}
           >
+            <EmailOutlined
+              sx={{ fontSize: 64, color: "text.disabled", mb: 2 }}
+            />
             <Typography variant="h6" sx={{ fontWeight: "bold", mb: 1 }}>
               Select a message
             </Typography>

--- a/src/client/components/MembersView.tsx
+++ b/src/client/components/MembersView.tsx
@@ -1,19 +1,42 @@
 import {
+  AdminPanelSettingsOutlined,
+  ChevronRightOutlined,
+  EmailOutlined,
+  GroupOutlined,
+  KeyOutlined,
+  PersonAddOutlined,
+  ShieldOutlined,
+  VpnKeyOutlined,
+} from "@mui/icons-material";
+import {
+  Alert,
+  Avatar,
+  Badge,
   Box,
   Button,
+  Card,
+  CardActions,
+  CardContent,
+  CardHeader,
   Chip,
   Divider,
   FormControl,
+  IconButton,
   InputLabel,
   List,
   ListItem,
-  ListItemButton,
   ListItemText,
   MenuItem,
-  Paper,
   Select,
-  Stack,
+  Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
   TextField,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import React, { type FormEvent } from "react";
@@ -37,6 +60,41 @@ interface MembersViewProps {
   ) => void;
 }
 
+const avatarColors = [
+  "#6366F1", // Indigo
+  "#8B5CF6", // Violet
+  "#A855F7", // Purple
+  "#EC4899", // Fuchsia
+  "#3B82F6", // Blue
+  "#0EA5E9", // Light Blue
+  "#14B8A6", // Sky
+  "#06B6D4", // Cyan
+];
+
+function stringToColor(string: string) {
+  let hash = 0;
+  for (let i = 0; i < string.length; i += 1) {
+    hash = string.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return avatarColors[Math.abs(hash) % avatarColors.length];
+}
+
+function stringAvatar(name: string) {
+  const safeName = name || "?";
+  const parts = safeName.split(" ");
+  const initials =
+    parts.length > 1 ? `${parts[0][0]}${parts[1][0]}` : safeName[0];
+
+  return {
+    sx: {
+      bgcolor: stringToColor(safeName),
+      color: "#fff",
+      fontWeight: "bold",
+    },
+    children: initials.toUpperCase(),
+  };
+}
+
 export function MembersView({
   members,
   providerOptions,
@@ -56,89 +114,93 @@ export function MembersView({
     <Box
       sx={{ display: "flex", flexDirection: "column", gap: 4, height: "100%" }}
     >
-      <Paper variant="outlined" sx={{ p: 3, borderRadius: 2 }}>
-        <Typography
-          variant="overline"
-          color="text.secondary"
-          sx={{ fontWeight: "bold" }}
-        >
-          Invite-only onboarding
-        </Typography>
-        <Typography
-          variant="h5"
-          component="h2"
-          sx={{ fontWeight: "bold", mb: 1 }}
-        >
-          Create a household member
-        </Typography>
-        <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
-          Provision a member directly, then share the generated login details
-          privately with them.
-        </Typography>
-
-        <Box
-          component="form"
-          onSubmit={onCreateMember}
-          sx={{
-            display: "flex",
-            flexDirection: { xs: "column", md: "row" },
-            gap: 2,
-            alignItems: { xs: "stretch", md: "flex-start" },
-          }}
-        >
-          <TextField
-            label="Name"
-            size="small"
-            value={memberFormState.name}
-            onChange={(e) => onMemberFormChange({ name: e.target.value })}
-            required
-            fullWidth
+      <Card variant="outlined" sx={{ borderRadius: 2, borderColor: "divider" }}>
+        <Box component="form" onSubmit={onCreateMember}>
+          <CardHeader
+            avatar={
+              <Avatar
+                sx={{ bgcolor: "primary.light", color: "primary.contrastText" }}
+              >
+                <PersonAddOutlined />
+              </Avatar>
+            }
+            title="Create a household member"
+            subheader="Invite-only onboarding"
+            titleTypographyProps={{ variant: "h6", fontWeight: "bold" }}
           />
-          <TextField
-            label="Email"
-            type="email"
-            size="small"
-            value={memberFormState.email}
-            onChange={(e) => onMemberFormChange({ email: e.target.value })}
-            required
-            fullWidth
-          />
-          <TextField
-            label="Temporary password"
-            type="password"
-            size="small"
-            value={memberFormState.password}
-            onChange={(e) => onMemberFormChange({ password: e.target.value })}
-            slotProps={{ htmlInput: { minLength: 12 } }}
-            required
-            fullWidth
-          />
-          <FormControl size="small" fullWidth>
-            <InputLabel id="role-select-label">Role</InputLabel>
-            <Select
-              labelId="role-select-label"
-              value={memberFormState.role}
-              label="Role"
-              onChange={(e) =>
-                onMemberFormChange({
-                  role: e.target.value as "member" | "admin",
-                })
-              }
+          <Divider />
+          <CardContent>
+            <Alert severity="info" sx={{ mb: 3 }} icon={<KeyOutlined />}>
+              Provision a member directly, then share the generated login
+              details privately with them.
+            </Alert>
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: { xs: "column", md: "row" },
+                gap: 2,
+                alignItems: "flex-start",
+              }}
             >
-              <MenuItem value="member">Member</MenuItem>
-              <MenuItem value="admin">Owner</MenuItem>
-            </Select>
-          </FormControl>
-          <Button
-            type="submit"
-            variant="contained"
-            disabled={isSavingMember}
-            sx={{ minWidth: 160, py: 1 }}
-          >
-            {isSavingMember ? "Creating…" : "Create member"}
-          </Button>
+              <TextField
+                label="Name"
+                size="small"
+                value={memberFormState.name}
+                onChange={(e) => onMemberFormChange({ name: e.target.value })}
+                required
+                fullWidth
+              />
+              <TextField
+                label="Email"
+                type="email"
+                size="small"
+                value={memberFormState.email}
+                onChange={(e) => onMemberFormChange({ email: e.target.value })}
+                required
+                fullWidth
+              />
+              <TextField
+                label="Temporary password"
+                type="password"
+                size="small"
+                value={memberFormState.password}
+                onChange={(e) =>
+                  onMemberFormChange({ password: e.target.value })
+                }
+                slotProps={{ htmlInput: { minLength: 12 } }}
+                required
+                fullWidth
+              />
+              <FormControl size="small" fullWidth>
+                <InputLabel id="role-select-label">Role</InputLabel>
+                <Select
+                  labelId="role-select-label"
+                  value={memberFormState.role}
+                  label="Role"
+                  onChange={(e) =>
+                    onMemberFormChange({
+                      role: e.target.value as "member" | "admin",
+                    })
+                  }
+                >
+                  <MenuItem value="member">Member</MenuItem>
+                  <MenuItem value="admin">Owner</MenuItem>
+                </Select>
+              </FormControl>
+            </Box>
+          </CardContent>
+          <CardActions sx={{ justifyContent: "flex-end", px: 3, pb: 3, pt: 0 }}>
+            <Button
+              type="submit"
+              variant="contained"
+              disabled={isSavingMember}
+              sx={{ minWidth: 160 }}
+            >
+              {isSavingMember ? "Creating…" : "Create member"}
+            </Button>
+          </CardActions>
         </Box>
-      </Paper>
+      </Card>
 
       <Box
         sx={{
@@ -146,218 +208,386 @@ export function MembersView({
           flexDirection: { xs: "column", md: "row" },
           gap: 3,
           flexGrow: 1,
+          minHeight: 0,
+          alignItems: "flex-start",
         }}
       >
-        <Box sx={{ width: { xs: "100%", md: 360 }, flexShrink: 0 }}>
-          <Box
-            sx={{
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "baseline",
-              mb: 2,
-            }}
-          >
-            <Typography variant="h5" component="h2" sx={{ fontWeight: "bold" }}>
-              Household access
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              {members.length} members
-            </Typography>
-          </Box>
-
-          <Paper
-            variant="outlined"
-            sx={{ borderRadius: 2, overflow: "hidden" }}
-          >
-            <List disablePadding>
-              {members.map((member, index) => {
+        <TableContainer
+          component={Card}
+          variant="outlined"
+          sx={{
+            flexGrow: 1,
+            borderRadius: 2,
+            minWidth: 0,
+            overflowX: "auto",
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          <Table sx={{ minWidth: 500 }} aria-label="members table">
+            <TableHead sx={{ bgcolor: "background.default" }}>
+              <TableRow>
+                <TableCell sx={{ fontWeight: "bold", color: "text.secondary" }}>
+                  Member
+                </TableCell>
+                <TableCell
+                  sx={{
+                    fontWeight: "bold",
+                    color: "text.secondary",
+                    display: { xs: "none", sm: "table-cell" },
+                  }}
+                >
+                  Email
+                </TableCell>
+                <TableCell sx={{ fontWeight: "bold", color: "text.secondary" }}>
+                  Role
+                </TableCell>
+                <TableCell
+                  sx={{
+                    fontWeight: "bold",
+                    color: "text.secondary",
+                    display: { xs: "none", md: "table-cell" },
+                  }}
+                >
+                  Provider Access
+                </TableCell>
+                <TableCell
+                  align="right"
+                  sx={{ fontWeight: "bold", color: "text.secondary" }}
+                >
+                  Actions
+                </TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {members.map((member) => {
                 const isSelected = member.id === selectedMemberId;
 
                 return (
-                  <React.Fragment key={member.id}>
-                    {index > 0 && <Divider />}
-                    <ListItem disablePadding>
-                      <ListItemButton
-                        selected={isSelected}
-                        onClick={() => onSelectMember(member.id)}
-                        sx={{ py: 2 }}
+                  <TableRow
+                    key={member.id}
+                    hover
+                    selected={isSelected}
+                    onClick={() => onSelectMember(member.id)}
+                    sx={{
+                      cursor: "pointer",
+                      transition: "background-color 0.2s",
+                      "&.Mui-selected": {
+                        bgcolor: "action.selected",
+                        "&:hover": { bgcolor: "action.hover" },
+                      },
+                    }}
+                  >
+                    <TableCell>
+                      <Box
+                        sx={{ display: "flex", alignItems: "center", gap: 2 }}
                       >
-                        <ListItemText
-                          primary={
-                            <Box
-                              sx={{
-                                display: "flex",
-                                justifyContent: "space-between",
-                                mb: 0.5,
-                              }}
-                            >
-                              <Typography
-                                variant="subtitle2"
-                                sx={{
-                                  fontWeight: isSelected ? "bold" : "medium",
-                                }}
-                              >
-                                {member.name}
-                              </Typography>
-                              <Chip
-                                label={member.role}
-                                size="small"
-                                color={
-                                  member.role === "admin"
-                                    ? "primary"
-                                    : "default"
-                                }
-                                variant="outlined"
-                                sx={{ height: 20 }}
-                              />
-                            </Box>
+                        <Badge
+                          overlap="circular"
+                          anchorOrigin={{
+                            vertical: "bottom",
+                            horizontal: "right",
+                          }}
+                          badgeContent={
+                            member.role === "admin" ? (
+                              <Tooltip title="Household Owner" placement="top">
+                                <AdminPanelSettingsOutlined
+                                  sx={{
+                                    fontSize: 16,
+                                    color: "primary.main",
+                                    bgcolor: "background.paper",
+                                    borderRadius: "50%",
+                                  }}
+                                />
+                              </Tooltip>
+                            ) : null
                           }
-                          secondary={
-                            <>
-                              <Typography
-                                variant="body2"
-                                color="text.secondary"
-                              >
-                                {member.email}
-                              </Typography>
-                              <Typography
-                                variant="caption"
-                                color="text.disabled"
-                                sx={{ mt: 0.5, display: "block" }}
-                              >
-                                {member.providerAccess.length} provider
-                                {member.providerAccess.length === 1 ? "" : "s"}
-                              </Typography>
-                            </>
-                          }
-                        />
-                      </ListItemButton>
-                    </ListItem>
-                  </React.Fragment>
+                        >
+                          <Avatar {...stringAvatar(member.name)} />
+                        </Badge>
+                        <Typography
+                          variant="subtitle2"
+                          sx={{
+                            fontWeight: isSelected ? "bold" : "medium",
+                            color: isSelected ? "primary.main" : "text.primary",
+                          }}
+                        >
+                          {member.name}
+                        </Typography>
+                      </Box>
+                    </TableCell>
+                    <TableCell
+                      sx={{ display: { xs: "none", sm: "table-cell" } }}
+                    >
+                      <Typography variant="body2" color="text.secondary">
+                        {member.email}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Chip
+                        label={member.role === "admin" ? "Owner" : "Member"}
+                        color={member.role === "admin" ? "primary" : "default"}
+                        size="small"
+                        sx={{ fontWeight: "bold" }}
+                      />
+                    </TableCell>
+                    <TableCell
+                      sx={{ display: { xs: "none", md: "table-cell" } }}
+                    >
+                      <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap" }}>
+                        {member.providerAccess.slice(0, 2).map((access) => (
+                          <Chip
+                            key={access.providerKey}
+                            label={access.displayName}
+                            size="small"
+                            variant="outlined"
+                          />
+                        ))}
+                        {member.providerAccess.length > 2 && (
+                          <Chip
+                            label={`+${member.providerAccess.length - 2}`}
+                            size="small"
+                            variant="outlined"
+                          />
+                        )}
+                        {member.providerAccess.length === 0 && (
+                          <Typography variant="body2" color="text.disabled">
+                            None
+                          </Typography>
+                        )}
+                      </Box>
+                    </TableCell>
+                    <TableCell align="right">
+                      <IconButton
+                        size="small"
+                        color={isSelected ? "primary" : "default"}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onSelectMember(member.id);
+                        }}
+                      >
+                        <ChevronRightOutlined />
+                      </IconButton>
+                    </TableCell>
+                  </TableRow>
                 );
               })}
 
               {!members.length && !isLoadingMembers && (
-                <Box sx={{ p: 4, textAlign: "center" }}>
-                  <Typography
-                    variant="subtitle1"
-                    sx={{ fontWeight: "bold" }}
-                    gutterBottom
-                  >
-                    No members yet
-                  </Typography>
-                  <Typography variant="body2" color="text.secondary">
-                    Create the first invited household member to get started.
-                  </Typography>
-                </Box>
+                <TableRow>
+                  <TableCell colSpan={5} sx={{ borderBottom: "none", py: 8 }}>
+                    <Box sx={{ textAlign: "center" }}>
+                      <GroupOutlined
+                        sx={{ fontSize: 48, color: "text.disabled", mb: 2 }}
+                      />
+                      <Typography
+                        variant="subtitle1"
+                        sx={{ fontWeight: "bold" }}
+                        gutterBottom
+                      >
+                        No members yet
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        Create the first invited household member to get
+                        started.
+                      </Typography>
+                    </Box>
+                  </TableCell>
+                </TableRow>
               )}
-            </List>
-          </Paper>
-        </Box>
+            </TableBody>
+          </Table>
+        </TableContainer>
 
-        <Box sx={{ flexGrow: 1, minWidth: 0 }}>
-          <Typography
-            variant="h5"
-            component="h2"
-            sx={{ fontWeight: "bold", mb: 2, visibility: "hidden" }}
+        {selectedMember && (
+          <Card
+            variant="outlined"
+            sx={{
+              width: { xs: "100%", md: 400 },
+              flexShrink: 0,
+              borderRadius: 2,
+              display: "flex",
+              flexDirection: "column",
+            }}
           >
-            Detail
-          </Typography>
-
-          {selectedMember ? (
-            <Box sx={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            <CardHeader
+              avatar={
+                <Avatar
+                  {...stringAvatar(selectedMember.name)}
+                  sx={{
+                    width: 56,
+                    height: 56,
+                    fontSize: "1.25rem",
+                    ...stringAvatar(selectedMember.name).sx,
+                  }}
+                />
+              }
+              title={selectedMember.name}
+              subheader={
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 1,
+                    mt: 0.5,
+                  }}
+                >
+                  <EmailOutlined sx={{ fontSize: 16 }} />
+                  {selectedMember.email}
+                </Box>
+              }
+              titleTypographyProps={{ variant: "h6", fontWeight: "bold" }}
+              subheaderTypographyProps={{
+                variant: "body2",
+                color: "text.secondary",
+              }}
+              action={
+                <Tooltip title="Send email">
+                  <IconButton
+                    href={`mailto:${selectedMember.email}`}
+                    color="primary"
+                  >
+                    <EmailOutlined />
+                  </IconButton>
+                </Tooltip>
+              }
+              sx={{ p: 3 }}
+            />
+            <Divider />
+            <CardContent
+              sx={{
+                p: 3,
+                display: "flex",
+                flexDirection: "column",
+                gap: 4,
+              }}
+            >
               <Box>
                 <Typography
                   variant="overline"
                   color="text.secondary"
-                  sx={{ fontWeight: "bold" }}
+                  sx={{
+                    fontWeight: "bold",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 1,
+                    mb: 2,
+                  }}
                 >
-                  Member detail
+                  <ShieldOutlined fontSize="small" />
+                  Role & Permissions
                 </Typography>
-                <Typography variant="h4" sx={{ fontWeight: "bold", mb: 0.5 }}>
-                  {selectedMember.name}
-                </Typography>
-                <Typography variant="body1" color="text.secondary">
-                  {selectedMember.email}
-                </Typography>
+                <Card variant="outlined" sx={{ borderRadius: 2, p: 2 }}>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ mb: 2 }}
+                  >
+                    Owners can invite members and configure provider access.
+                  </Typography>
+                  <FormControl fullWidth size="small">
+                    <InputLabel id="role-change-label">
+                      Household Role
+                    </InputLabel>
+                    <Select
+                      labelId="role-change-label"
+                      value={selectedMember.role}
+                      label="Household Role"
+                      onChange={(e) =>
+                        onRoleChange(
+                          selectedMember.id,
+                          e.target.value as "admin" | "member",
+                        )
+                      }
+                    >
+                      <MenuItem value="member">Member</MenuItem>
+                      <MenuItem value="admin">Owner</MenuItem>
+                    </Select>
+                  </FormControl>
+                </Card>
               </Box>
 
               <Box>
-                <FormControl sx={{ minWidth: 200 }}>
-                  <InputLabel id="update-role-label">Role</InputLabel>
-                  <Select
-                    labelId="update-role-label"
-                    value={selectedMember.role}
-                    label="Role"
-                    onChange={(e) =>
-                      onRoleChange(selectedMember.id, e.target.value)
-                    }
-                  >
-                    <MenuItem value="member">Member</MenuItem>
-                    <MenuItem value="admin">Owner</MenuItem>
-                  </Select>
-                </FormControl>
-              </Box>
-
-              <Paper variant="outlined" sx={{ p: 3, borderRadius: 2 }}>
                 <Typography
-                  variant="subtitle2"
-                  sx={{ mb: 2, fontWeight: "bold" }}
+                  variant="overline"
+                  color="text.secondary"
+                  sx={{
+                    fontWeight: "bold",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 1,
+                    mb: 2,
+                  }}
                 >
-                  Provider access
+                  <VpnKeyOutlined fontSize="small" />
+                  Provider Access
                 </Typography>
-                <Stack
-                  direction="row"
-                  spacing={1}
-                  sx={{ flexWrap: "wrap", gap: 1 }}
-                >
-                  {providerOptions.map((provider) => {
-                    const hasAccess = selectedMember.providerAccess.some(
-                      (access) => access.providerKey === provider.provider_key,
-                    );
+                <Card variant="outlined" sx={{ borderRadius: 2 }}>
+                  <List disablePadding>
+                    {providerOptions.map((provider, i) => {
+                      const hasAccess = selectedMember.providerAccess.some(
+                        (access) =>
+                          access.providerKey === provider.provider_key,
+                      );
 
-                    return (
-                      <Chip
-                        key={provider.id}
-                        label={provider.display_name}
-                        color={hasAccess ? "primary" : "default"}
-                        variant={hasAccess ? "filled" : "outlined"}
-                        onClick={() =>
-                          onProviderAccessToggle(
-                            selectedMember.id,
-                            provider.provider_key,
-                            hasAccess,
-                          )
-                        }
-                        sx={{
-                          fontWeight: hasAccess ? "bold" : "regular",
-                          borderRadius: 1,
-                        }}
-                      />
-                    );
-                  })}
-                </Stack>
-              </Paper>
-            </Box>
-          ) : (
-            <Paper
-              variant="outlined"
-              sx={{
-                p: 6,
-                textAlign: "center",
-                borderRadius: 2,
-                borderStyle: "dashed",
-              }}
-            >
-              <Typography variant="h6" sx={{ fontWeight: "bold", mb: 1 }}>
-                Select a household member
-              </Typography>
-              <Typography variant="body1" color="text.secondary">
-                Choose a member to adjust role or provider access.
-              </Typography>
-            </Paper>
-          )}
-        </Box>
+                      return (
+                        <React.Fragment key={provider.id}>
+                          {i > 0 && <Divider />}
+                          <ListItem sx={{ p: 2 }}>
+                            <ListItemText
+                              disableTypography
+                              primary={
+                                <Typography
+                                  variant="subtitle2"
+                                  sx={{ fontWeight: "bold" }}
+                                >
+                                  {provider.display_name}
+                                </Typography>
+                              }
+                              secondary={
+                                <Typography
+                                  variant="body2"
+                                  color="text.secondary"
+                                  sx={{ mt: 0.5 }}
+                                >
+                                  {hasAccess ? "Access granted" : "No access"}
+                                </Typography>
+                              }
+                            />
+                            <Tooltip
+                              title={
+                                hasAccess ? "Revoke access" : "Grant access"
+                              }
+                            >
+                              <Switch
+                                checked={hasAccess}
+                                onChange={(e) =>
+                                  onProviderAccessToggle(
+                                    selectedMember.id,
+                                    provider.provider_key,
+                                    e.target.checked,
+                                  )
+                                }
+                                color="primary"
+                              />
+                            </Tooltip>
+                          </ListItem>
+                        </React.Fragment>
+                      );
+                    })}
+                    {!providerOptions.length && (
+                      <ListItem sx={{ p: 3, justifyContent: "center" }}>
+                        <Typography variant="body2" color="text.disabled">
+                          No providers configured yet.
+                        </Typography>
+                      </ListItem>
+                    )}
+                  </List>
+                </Card>
+              </Box>
+            </CardContent>
+          </Card>
+        )}
       </Box>
     </Box>
   );

--- a/src/client/components/QuarantineView.tsx
+++ b/src/client/components/QuarantineView.tsx
@@ -1,5 +1,14 @@
 import {
+  CheckCircleOutlined,
+  ContentCopyOutlined,
+  DeleteOutlined,
+  MoveToInboxOutlined,
+  ShieldOutlined,
+  WarningAmberOutlined,
+} from "@mui/icons-material";
+import {
   Alert,
+  Avatar,
   Box,
   Button,
   Card,
@@ -7,6 +16,7 @@ import {
   Chip,
   Divider,
   FormControl,
+  IconButton,
   InputLabel,
   List,
   ListItem,
@@ -16,11 +26,47 @@ import {
   Paper,
   Select,
   Stack,
+  Tooltip,
   Typography,
 } from "@mui/material";
-import React from "react";
+import React, { useState } from "react";
 import type { ProviderSummary, QuarantineMessage } from "../types";
 import { formatTimestamp } from "../utils";
+
+const avatarColors = [
+  "#6366F1", // Indigo
+  "#8B5CF6", // Violet
+  "#A855F7", // Purple
+  "#EC4899", // Fuchsia
+  "#3B82F6", // Blue
+  "#0EA5E9", // Light Blue
+  "#14B8A6", // Sky
+  "#06B6D4", // Cyan
+];
+
+function stringToColor(string: string) {
+  let hash = 0;
+  for (let i = 0; i < string.length; i += 1) {
+    hash = string.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return avatarColors[Math.abs(hash) % avatarColors.length];
+}
+
+function stringAvatar(name: string) {
+  const safeName = name || "?";
+  const parts = safeName.split(" ");
+  const initials =
+    parts.length > 1 ? `${parts[0][0]}${parts[1][0]}` : safeName[0];
+
+  return {
+    sx: {
+      bgcolor: stringToColor(safeName),
+      color: "#fff",
+      fontWeight: "bold",
+    },
+    children: initials.toUpperCase(),
+  };
+}
 
 interface QuarantineViewProps {
   quarantineMessages: QuarantineMessage[];
@@ -45,9 +91,21 @@ export function QuarantineView({
   isReviewingQuarantine,
   onQuarantineReview,
 }: QuarantineViewProps) {
+  const [copiedCodeId, setCopiedCodeId] = useState<string | null>(null);
+
   const selectedQuarantineMessage = quarantineMessages.find(
     (m) => m.id === selectedQuarantineId,
   );
+
+  const handleCopyCode = async (code: string, id: string) => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopiedCodeId(id);
+      setTimeout(() => setCopiedCodeId(null), 2000);
+    } catch (err) {
+      console.error("Failed to copy text: ", err);
+    }
+  };
 
   return (
     <Box
@@ -94,9 +152,11 @@ export function QuarantineView({
                     <ListItemButton
                       selected={isSelected}
                       onClick={() => onSelectMessage(message.id)}
-                      sx={{ py: 2 }}
+                      sx={{ py: 2, gap: 2 }}
                     >
+                      <Avatar {...stringAvatar(message.envelope_from)} />
                       <ListItemText
+                        disableTypography
                         primary={
                           <Box
                             sx={{
@@ -157,12 +217,15 @@ export function QuarantineView({
 
             {!quarantineMessages.length && !isLoadingQuarantine && (
               <Box sx={{ p: 4, textAlign: "center" }}>
+                <ShieldOutlined
+                  sx={{ fontSize: 48, color: "text.disabled", mb: 2 }}
+                />
                 <Typography
                   variant="subtitle1"
                   sx={{ fontWeight: "bold" }}
                   gutterBottom
                 >
-                  Quarantine is empty
+                  All clear
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
                   Messages that need manual classification will appear here for
@@ -208,6 +271,7 @@ export function QuarantineView({
                 </Typography>
               </Box>
               <Chip
+                icon={<WarningAmberOutlined />}
                 label="Needs review"
                 color="warning"
                 sx={{ fontWeight: "bold" }}
@@ -221,6 +285,7 @@ export function QuarantineView({
                 borderColor: "divider",
                 borderRadius: 2,
                 bgcolor: "background.default",
+                position: "relative",
               }}
             >
               <CardContent sx={{ p: 4, textAlign: "center" }}>
@@ -231,17 +296,63 @@ export function QuarantineView({
                 >
                   Detected code
                 </Typography>
-                <Typography
-                  variant="h3"
-                  sx={{ fontWeight: "bold", letterSpacing: 2 }}
+                <Box
+                  sx={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 2,
+                    justifyContent: "center",
+                  }}
                 >
-                  {selectedQuarantineMessage.extracted_code ??
-                    "No code detected"}
-                </Typography>
+                  <Typography
+                    variant="h3"
+                    sx={{ fontWeight: "bold", letterSpacing: 2 }}
+                  >
+                    {selectedQuarantineMessage.extracted_code ??
+                      "No code detected"}
+                  </Typography>
+                  {selectedQuarantineMessage.extracted_code && (
+                    <Tooltip
+                      title={
+                        copiedCodeId === selectedQuarantineMessage.id
+                          ? "Copied!"
+                          : "Copy code"
+                      }
+                      placement="top"
+                    >
+                      <IconButton
+                        onClick={() => {
+                          if (selectedQuarantineMessage.extracted_code) {
+                            handleCopyCode(
+                              selectedQuarantineMessage.extracted_code,
+                              selectedQuarantineMessage.id,
+                            );
+                          }
+                        }}
+                        color={
+                          copiedCodeId === selectedQuarantineMessage.id
+                            ? "success"
+                            : "default"
+                        }
+                        sx={{ ml: 1 }}
+                      >
+                        {copiedCodeId === selectedQuarantineMessage.id ? (
+                          <CheckCircleOutlined />
+                        ) : (
+                          <ContentCopyOutlined />
+                        )}
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                </Box>
               </CardContent>
             </Card>
 
-            <Alert severity="warning" sx={{ borderRadius: 2 }}>
+            <Alert
+              severity="warning"
+              icon={<WarningAmberOutlined fontSize="inherit" />}
+              sx={{ borderRadius: 2, alignItems: "center" }}
+            >
               <Typography
                 variant="subtitle2"
                 sx={{ fontWeight: "bold", mb: 0.5 }}
@@ -286,6 +397,7 @@ export function QuarantineView({
                 <Button
                   variant="contained"
                   color="primary"
+                  startIcon={<MoveToInboxOutlined />}
                   disabled={isReviewingQuarantine || !releaseProviderKey}
                   onClick={() => onQuarantineReview("release")}
                   sx={{ px: 4, py: 1.5 }}
@@ -294,6 +406,7 @@ export function QuarantineView({
                 </Button>
                 <Button
                   variant="outlined"
+                  startIcon={<DeleteOutlined />}
                   disabled={isReviewingQuarantine}
                   onClick={() => onQuarantineReview("dismiss")}
                   sx={{ px: 4, py: 1.5 }}
@@ -334,6 +447,9 @@ export function QuarantineView({
               borderStyle: "dashed",
             }}
           >
+            <WarningAmberOutlined
+              sx={{ fontSize: 48, color: "text.disabled", mb: 2 }}
+            />
             <Typography variant="h6" sx={{ fontWeight: "bold", mb: 1 }}>
               Select a quarantined message
             </Typography>

--- a/src/client/theme.ts
+++ b/src/client/theme.ts
@@ -8,24 +8,35 @@ export function getTheme(mode: "light" | "dark") {
     palette: {
       mode,
       primary: {
-        main: mode === "light" ? "#8D6E63" : "#D7CCC8",
-        light: "#BE9C91",
-        dark: "#5F4339",
+        main: "#6366F1",
+        light: "#818CF8",
+        dark: "#4F46E5",
       },
       secondary: {
-        main: mode === "light" ? "#F4A460" : "#FFCC80",
-        light: "#F8C699",
-        dark: "#C07C36",
+        main: "#A78BFA",
+        light: "#C4B5FD",
+        dark: "#7C3AED",
       },
       background: {
-        default: mode === "light" ? "#FAFAFA" : "#121212",
-        paper: mode === "light" ? "#FFFFFF" : "#1E1E1E",
+        default: mode === "light" ? "#F8FAFC" : "#0F172A",
+        paper: mode === "light" ? "#FFFFFF" : "#1E293B",
       },
+      text: {
+        primary: mode === "light" ? "#0F172A" : "#F1F5F9",
+        secondary: mode === "light" ? "#475569" : "#94A3B8",
+      },
+      divider: mode === "light" ? "#E2E8F0" : "#334155",
       warning: {
-        main: "#FF9800",
+        main: "#F59E0B",
       },
       success: {
-        main: "#4CAF50",
+        main: "#10B981",
+      },
+      error: {
+        main: "#EF4444",
+      },
+      info: {
+        main: "#38BDF8",
       },
     },
     typography: {
@@ -64,8 +75,8 @@ export function getTheme(mode: "light" | "dark") {
           root: {
             boxShadow:
               mode === "light"
-                ? "0px 4px 20px rgba(0, 0, 0, 0.05)"
-                : "0px 4px 20px rgba(0, 0, 0, 0.5)",
+                ? "0px 4px 20px rgba(99, 102, 241, 0.08)"
+                : "0px 4px 20px rgba(0, 0, 0, 0.4)",
           },
         },
       },


### PR DESCRIPTION
## Summary

Follow-up to the MUI redesign (#31, #32) with three additional polish commits that were left on the branch:

- **Indigo + violet color palette** — switches the theme from default MUI blue to a modern indigo/violet scheme (`theme.ts`)
- **MembersView redesign** — replaces the card grid with a proper MUI `Table` featuring avatar initials, role `Chip`s, responsive column hiding, and a sticky side-panel detail view with `Select` for role changes and `Switch` for provider toggles
- **InboxView & QuarantineView polish** — adds provider avatars with badge counts, verification code copy-to-clipboard with success feedback, icon-enhanced action buttons, and improved empty states with descriptive icons

### Changed files

| File | Change |
|---|---|
| `src/client/components/InboxView.tsx` | Icons, copy-to-clipboard, avatar badges, empty states |
| `src/client/components/MembersView.tsx` | Full table redesign with side panel |
| `src/client/components/QuarantineView.tsx` | Icons, copy-to-clipboard, empty states |
| `src/client/theme.ts` | Indigo + violet palette |
