### PR TITLE
revert: remove frontend routing changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,7 @@
         "hono": "4.12.18",
         "postal-mime": "2.7.4",
         "react": "19.2.6",
-        "react-dom": "19.2.6",
-        "react-router-dom": "^7.15.0"
+        "react-dom": "19.2.6"
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
@@ -3373,6 +3372,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
       "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4470,50 +4470,6 @@
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
       "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
-      "license": "MIT"
-    },
-    "node_modules/react-router": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.0.tgz",
-      "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.0.tgz",
-      "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.15.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/react-router/node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
     "node_modules/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
     "hono": "4.12.18",
     "postal-mime": "2.7.4",
     "react": "19.2.6",
-    "react-dom": "19.2.6",
-    "react-router-dom": "^7.15.0"
+    "react-dom": "19.2.6"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.15",

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -7,14 +7,6 @@ import {
 } from "@mui/material";
 import { authClient } from "@server/auth/client";
 import { type FormEvent, useEffect, useState } from "react";
-import {
-  Navigate,
-  Route,
-  Routes,
-  useLocation,
-  useNavigate,
-  useParams,
-} from "react-router-dom";
 import { InboxView } from "./components/InboxView";
 import { InvitePage } from "./components/InvitePage";
 import { Layout } from "./components/Layout";
@@ -97,24 +89,23 @@ export function App() {
   const [isCheckingSetup, setIsCheckingSetup] = useState(
     typeof window !== "undefined",
   );
-  const navigate = useNavigate();
-  const location = useLocation();
-  const isSetupPath = location.pathname === "/setup";
+  const [isSetupPath, setIsSetupPath] = useState(
+    typeof window !== "undefined" && window.location.pathname === "/setup",
+  );
 
-  const activeView: ViewType = 
-    location.pathname.startsWith("/settings") ? "settings" :
-    location.pathname.startsWith("/quarantine") ? "quarantine" :
-    location.pathname.startsWith("/members") ? "members" :
-    location.pathname.startsWith("/providers") ? "providers" :
-    "inbox";
+  const [activeView, setActiveView] = useState<ViewType>("inbox");
   const [providers, setProviders] = useState<ProviderSummary[]>([]);
   const [selectedProviderKey, setSelectedProviderKey] = useState<string | null>(
     null,
   );
   const [messages, setMessages] = useState<InboxMessage[]>([]);
 
-  const isInvitePath = location.pathname.startsWith("/invite/");
-  const inviteToken = isInvitePath ? location.pathname.split("/invite/")[1] : null;
+  const [inviteToken, setInviteToken] = useState<string | null>(
+    typeof window !== "undefined" &&
+      window.location.pathname.startsWith("/invite/")
+      ? window.location.pathname.split("/invite/")[1]
+      : null,
+  );
 
   const [profile, setProfile] = useState<AccountProfile | null>(null);
   const [settingsSessions, setSettingsSessions] = useState<AccountSession[]>(
@@ -181,24 +172,6 @@ export function App() {
     setStatusMessage(null);
     setViewError(null);
   };
-
-  function InviteRoute() {
-    const { token } = useParams<{ token: string }>();
-
-    if (!token) {
-      return <Navigate to="/login" replace />;
-    }
-
-    return (
-      <InvitePage
-        token={token}
-        onAcceptSuccess={() => {
-          navigate("/inbox", { replace: true });
-          void refetch();
-        }}
-      />
-    );
-  }
 
   useEffect(() => {
     if (!isAuthenticated || activeView !== "settings") {
@@ -471,15 +444,19 @@ export function App() {
     const status = await fetchJson<SetupStatus>("/api/setup/status");
     setSetupStatus(status);
 
-    if (status.needsSetup && location.pathname !== "/setup") {
-      navigate("/setup", { replace: true });
+    if (status.needsSetup && window.location.pathname !== "/setup") {
+      window.history.replaceState({}, "", "/setup");
+      setIsSetupPath(true);
       return;
     }
 
-    if (!status.needsSetup && location.pathname === "/setup") {
-      navigate("/inbox", { replace: true });
+    if (!status.needsSetup && window.location.pathname === "/setup") {
+      window.history.replaceState({}, "", "/");
+      setIsSetupPath(false);
       return;
     }
+
+    setIsSetupPath(window.location.pathname === "/setup");
   }
 
   useEffect(() => {
@@ -497,10 +474,17 @@ export function App() {
 
         setSetupStatus(status);
 
-        if (status.needsSetup && location.pathname !== "/setup") {
-          navigate("/setup", { replace: true });
-        } else if (!status.needsSetup && location.pathname === "/setup") {
-          navigate("/inbox", { replace: true });
+        if (status.needsSetup && window.location.pathname !== "/setup") {
+          window.history.replaceState({}, "", "/setup");
+          setIsSetupPath(true);
+        } else if (
+          !status.needsSetup &&
+          window.location.pathname === "/setup"
+        ) {
+          window.history.replaceState({}, "", "/");
+          setIsSetupPath(false);
+        } else {
+          setIsSetupPath(window.location.pathname === "/setup");
         }
       } catch (error) {
         if (!cancelled) {
@@ -545,6 +529,7 @@ export function App() {
       setSenderRules([]);
       setProviderFormState(INITIAL_PROVIDER_FORM_STATE);
       setRuleFormState(INITIAL_RULE_FORM_STATE);
+      setActiveView("inbox");
       return;
     }
 
@@ -1368,47 +1353,39 @@ export function App() {
     );
   }
 
+  if (inviteToken) {
+    return (
+      <InvitePage
+        token={inviteToken}
+        onAcceptSuccess={() => {
+          window.history.replaceState({}, "", "/");
+          setInviteToken(null);
+          void refetch();
+        }}
+      />
+    );
+  }
+
+  if (!isAuthenticated && setupStatus?.needsSetup && isSetupPath) {
+    return (
+      <SetupPage
+        setupError={setupError}
+        onSetupError={setSetupError}
+        onSetupComplete={async () => {
+          setStatusMessage("Owner account created. You are now signed in.");
+          await Promise.all([refetch(), refreshSetupStatus()]);
+        }}
+      />
+    );
+  }
+
   if (!isAuthenticated) {
     return (
-      <Routes>
-        <Route path="/invite/:token" element={<InviteRoute />} />
-        <Route
-          path="/setup"
-          element={
-            setupStatus?.needsSetup ? (
-              <SetupPage
-                setupError={setupError}
-                onSetupError={setSetupError}
-                onSetupComplete={async () => {
-                  setStatusMessage("Owner account created. You are now signed in.");
-                  await Promise.all([refetch(), refreshSetupStatus()]);
-                }}
-              />
-            ) : (
-              <Navigate to="/login" replace />
-            )
-          }
-        />
-        <Route
-          path="/login"
-          element={
-            <LoginPage
-              setupStatus={setupStatus}
-              setupError={setupError}
-              onLoginSuccess={() => refetch()}
-            />
-          }
-        />
-        <Route
-          path="*"
-          element={
-            <Navigate
-              to={setupStatus?.needsSetup ? "/setup" : "/login"}
-              replace
-            />
-          }
-        />
-      </Routes>
+      <LoginPage
+        setupStatus={setupStatus}
+        setupError={setupError}
+        onLoginSuccess={() => refetch()}
+      />
     );
   }
 
@@ -1417,180 +1394,155 @@ export function App() {
       session={session}
       isOwner={isOwner}
       onLogout={handleLogout}
+      activeView={activeView}
+      onNavigate={setActiveView}
     >
-      <Routes>
-        <Route path="/" element={<Navigate to="/inbox" replace />} />
-        <Route
-          path="/inbox"
-          element={
-            <InboxView
-              providers={providers}
-              selectedProviderKey={selectedProviderKey}
-              onSelectProvider={setSelectedProviderKey}
-              messages={messages}
-              selectedMessageId={selectedMessageId}
-              onSelectMessage={setSelectedMessageId}
-              isLoadingInbox={isLoadingInbox}
-              isSavingMessage={isSavingMessage}
-              onStatusChange={handleStatusChange}
-            />
-          }
+      {activeView === "inbox" && (
+        <InboxView
+          providers={providers}
+          selectedProviderKey={selectedProviderKey}
+          onSelectProvider={setSelectedProviderKey}
+          messages={messages}
+          selectedMessageId={selectedMessageId}
+          onSelectMessage={setSelectedMessageId}
+          isLoadingInbox={isLoadingInbox}
+          isSavingMessage={isSavingMessage}
+          onStatusChange={handleStatusChange}
         />
-        <Route
-          path="/settings"
-          element={
-            <SettingsView
-              profile={profile}
-              sessions={settingsSessions}
-              isLoading={isLoadingSettings}
-              error={viewError}
-              formState={settingsFormState}
-              onFormChange={(update) =>
-                setSettingsFormState((current) => ({ ...current, ...update }))
-              }
-              onUpdateProfile={handleUpdateProfile}
-              onChangePassword={handleChangePassword}
-              onRequestPasswordReset={handleRequestPasswordReset}
-              onEnable2FA={handleEnable2FA}
-              onDisable2FA={handleDisable2FA}
-              onAddPasskey={handleAddPasskey}
-              onRevokeSession={handleRevokeSession}
-              onRevokeOtherSessions={handleRevokeOtherSessions}
-              isSaving={isSavingSettings}
-            />
-          }
-        />
-        <Route
-          path="/quarantine"
-          element={
-            isOwner ? (
-              <QuarantineView
-                quarantineMessages={quarantineMessages}
-                selectedQuarantineId={selectedQuarantineId}
-                onSelectMessage={setSelectedQuarantineId}
-                isLoadingQuarantine={isLoadingQuarantine}
-                providers={providers}
-                releaseProviderKey={releaseProviderKey}
-                onReleaseProviderKeyChange={setReleaseProviderKey}
-                isReviewingQuarantine={isReviewingQuarantine}
-                onQuarantineReview={handleQuarantineReview}
-              />
-            ) : (
-              <Navigate to="/inbox" replace />
-            )
-          }
-        />
-        <Route
-          path="/members"
-          element={
-            isOwner ? (
-              <MembersView
-                members={members}
-                invitations={invitations}
-                providerOptions={providerOptions}
-                selectedMemberId={selectedMemberId}
-                onSelectMember={setSelectedMemberId}
-                isLoadingMembers={isLoadingMembers}
-                memberFormState={memberFormState}
-                onMemberFormChange={(update) =>
-                  setMemberFormState((current) => ({ ...current, ...update }))
-                }
-                onCreateMember={handleCreateMember}
-                isSavingMember={isSavingMember}
-                invitationFormState={invitationFormState}
-                onInvitationFormChange={(update) =>
-                  setInvitationFormState((current) => ({ ...current, ...update }))
-                }
-                onCreateInvitation={handleCreateInvitation}
-                onResendInvitation={handleResendInvitation}
-                onCancelInvitation={handleCancelInvitation}
-                isSavingInvitation={isSavingInvitation}
-                onRoleChange={handleMemberRoleChange}
-                onProviderAccessToggle={handleProviderAccessToggle}
-              />
-            ) : (
-              <Navigate to="/inbox" replace />
-            )
-          }
-        />
-        <Route
-          path="/providers"
-          element={
-            isOwner ? (
-              <ProvidersRulesView
-                providers={providerConfigurations}
-                rules={senderRules}
-                selectedProviderId={selectedProviderId}
-                selectedRuleId={selectedRuleId}
-                providerFormState={providerFormState}
-                ruleFormState={ruleFormState}
-                isSaving={isSavingProviderConfiguration}
-                onSelectProvider={(providerId) => {
-                  setSelectedProviderId(providerId);
-                  const provider = providerConfigurations.find(
-                    (item) => item.id === providerId,
-                  );
+      )}
 
-                  setProviderFormState(
-                    provider
-                      ? {
-                          providerKey: provider.provider_key,
-                          displayName: provider.display_name,
-                        }
-                      : INITIAL_PROVIDER_FORM_STATE,
-                  );
+      {activeView === "settings" && (
+        <SettingsView
+          profile={profile}
+          sessions={settingsSessions}
+          isLoading={isLoadingSettings}
+          error={viewError}
+          formState={settingsFormState}
+          onFormChange={(update) =>
+            setSettingsFormState((current) => ({ ...current, ...update }))
+          }
+          onUpdateProfile={handleUpdateProfile}
+          onChangePassword={handleChangePassword}
+          onRequestPasswordReset={handleRequestPasswordReset}
+          onEnable2FA={handleEnable2FA}
+          onDisable2FA={handleDisable2FA}
+          onAddPasskey={handleAddPasskey}
+          onRevokeSession={handleRevokeSession}
+          onRevokeOtherSessions={handleRevokeOtherSessions}
+          isSaving={isSavingSettings}
+        />
+      )}
 
-                  const firstRule =
-                    senderRules.find((rule) => rule.provider_id === providerId) ??
-                    null;
-                  setSelectedRuleId(firstRule?.id ?? null);
-                  setRuleFormState(
-                    firstRule
-                      ? {
-                          providerId: firstRule.provider_id,
-                          matchType: firstRule.match_type,
-                          matchValue: firstRule.match_value,
-                        }
-                      : {
-                          ...INITIAL_RULE_FORM_STATE,
-                          providerId,
-                        },
-                  );
-                }}
-                onSelectRule={(ruleId) => {
-                  setSelectedRuleId(ruleId);
-                  const rule = senderRules.find((item) => item.id === ruleId);
+      {activeView === "quarantine" && isOwner && (
+        <QuarantineView
+          quarantineMessages={quarantineMessages}
+          selectedQuarantineId={selectedQuarantineId}
+          onSelectMessage={setSelectedQuarantineId}
+          isLoadingQuarantine={isLoadingQuarantine}
+          providers={providers}
+          releaseProviderKey={releaseProviderKey}
+          onReleaseProviderKeyChange={setReleaseProviderKey}
+          isReviewingQuarantine={isReviewingQuarantine}
+          onQuarantineReview={handleQuarantineReview}
+        />
+      )}
 
-                  if (!rule) {
-                    return;
+      {activeView === "members" && isOwner && (
+        <MembersView
+          members={members}
+          invitations={invitations}
+          providerOptions={providerOptions}
+          selectedMemberId={selectedMemberId}
+          onSelectMember={setSelectedMemberId}
+          isLoadingMembers={isLoadingMembers}
+          memberFormState={memberFormState}
+          onMemberFormChange={(update) =>
+            setMemberFormState((current) => ({ ...current, ...update }))
+          }
+          onCreateMember={handleCreateMember}
+          isSavingMember={isSavingMember}
+          invitationFormState={invitationFormState}
+          onInvitationFormChange={(update) =>
+            setInvitationFormState((current) => ({ ...current, ...update }))
+          }
+          onCreateInvitation={handleCreateInvitation}
+          onResendInvitation={handleResendInvitation}
+          onCancelInvitation={handleCancelInvitation}
+          isSavingInvitation={isSavingInvitation}
+          onRoleChange={handleMemberRoleChange}
+          onProviderAccessToggle={handleProviderAccessToggle}
+        />
+      )}
+
+      {activeView === "providers" && isOwner && (
+        <ProvidersRulesView
+          providers={providerConfigurations}
+          rules={senderRules}
+          selectedProviderId={selectedProviderId}
+          selectedRuleId={selectedRuleId}
+          providerFormState={providerFormState}
+          ruleFormState={ruleFormState}
+          isSaving={isSavingProviderConfiguration}
+          onSelectProvider={(providerId) => {
+            setSelectedProviderId(providerId);
+            const provider = providerConfigurations.find(
+              (item) => item.id === providerId,
+            );
+
+            setProviderFormState(
+              provider
+                ? {
+                    providerKey: provider.provider_key,
+                    displayName: provider.display_name,
                   }
+                : INITIAL_PROVIDER_FORM_STATE,
+            );
 
-                  setRuleFormState({
-                    providerId: rule.provider_id,
-                    matchType: rule.match_type,
-                    matchValue: rule.match_value,
-                  });
-                }}
-                onProviderFormChange={(update) =>
-                  setProviderFormState((current) => ({ ...current, ...update }))
-                }
-                onRuleFormChange={(update) =>
-                  setRuleFormState((current) => ({ ...current, ...update }))
-                }
-                onCreateProvider={handleCreateProvider}
-                onUpdateProvider={handleUpdateProvider}
-                onDeleteProvider={handleDeleteProvider}
-                onCreateRule={handleCreateRule}
-                onUpdateRule={handleUpdateRule}
-                onDeleteRule={handleDeleteRule}
-              />
-            ) : (
-              <Navigate to="/inbox" replace />
-            )
+            const firstRule =
+              senderRules.find((rule) => rule.provider_id === providerId) ??
+              null;
+            setSelectedRuleId(firstRule?.id ?? null);
+            setRuleFormState(
+              firstRule
+                ? {
+                    providerId: firstRule.provider_id,
+                    matchType: firstRule.match_type,
+                    matchValue: firstRule.match_value,
+                  }
+                : {
+                    ...INITIAL_RULE_FORM_STATE,
+                    providerId,
+                  },
+            );
+          }}
+          onSelectRule={(ruleId) => {
+            setSelectedRuleId(ruleId);
+            const rule = senderRules.find((item) => item.id === ruleId);
+
+            if (!rule) {
+              return;
+            }
+
+            setRuleFormState({
+              providerId: rule.provider_id,
+              matchType: rule.match_type,
+              matchValue: rule.match_value,
+            });
+          }}
+          onProviderFormChange={(update) =>
+            setProviderFormState((current) => ({ ...current, ...update }))
           }
+          onRuleFormChange={(update) =>
+            setRuleFormState((current) => ({ ...current, ...update }))
+          }
+          onCreateProvider={handleCreateProvider}
+          onUpdateProvider={handleUpdateProvider}
+          onDeleteProvider={handleDeleteProvider}
+          onCreateRule={handleCreateRule}
+          onUpdateRule={handleUpdateRule}
+          onDeleteRule={handleDeleteRule}
         />
-        <Route path="*" element={<Navigate to="/inbox" replace />} />
-      </Routes>
+      )}
 
       <Snackbar
         open={Boolean(statusMessage || viewError)}

--- a/src/client/components/InvitePage.tsx
+++ b/src/client/components/InvitePage.tsx
@@ -10,7 +10,6 @@ import {
   Typography,
 } from "@mui/material";
 import { type FormEvent, useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import type { InvitationAcceptanceState, InvitationSummary } from "../types";
 import { fetchJson } from "../utils";
 
@@ -20,7 +19,6 @@ interface InvitePageProps {
 }
 
 export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
-  const navigate = useNavigate();
   const [invitation, setInvitation] = useState<InvitationSummary | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -133,7 +131,8 @@ export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
                 variant="outlined"
                 fullWidth
                 onClick={() => {
-                  navigate("/login", { replace: true });
+                  window.history.replaceState({}, "", "/");
+                  window.location.reload();
                 }}
               >
                 Return to Login

--- a/src/client/components/Layout.tsx
+++ b/src/client/components/Layout.tsx
@@ -26,7 +26,6 @@ import {
   useTheme,
 } from "@mui/material";
 import type React from "react";
-import { Link, useLocation } from "react-router-dom";
 import { useContext, useState } from "react";
 import { ColorModeContext } from "../theme";
 import type { SessionData } from "../types";
@@ -41,6 +40,8 @@ interface LayoutProps {
   session: SessionData | null | undefined;
   isOwner: boolean;
   onLogout: () => void;
+  activeView: ViewType;
+  onNavigate: (view: ViewType) => void;
 }
 
 export function Layout({
@@ -48,13 +49,9 @@ export function Layout({
   session,
   isOwner,
   onLogout,
+  activeView,
+  onNavigate,
 }: LayoutProps) {
-  const location = useLocation();
-  const activeView = location.pathname.startsWith("/settings") ? "settings" :
-    location.pathname.startsWith("/quarantine") ? "quarantine" :
-    location.pathname.startsWith("/members") ? "members" :
-    location.pathname.startsWith("/providers") ? "providers" :
-    "inbox";
   const theme = useTheme();
   const colorMode = useContext(ColorModeContext);
   const isDesktop = useMediaQuery(theme.breakpoints.up("lg"));
@@ -64,7 +61,8 @@ export function Layout({
     setMobileOpen(!mobileOpen);
   };
 
-  const handleNavClick = () => {
+  const handleNavClick = (view: ViewType) => {
+    onNavigate(view);
     if (!isDesktop) {
       setMobileOpen(false);
     }
@@ -96,7 +94,7 @@ export function Layout({
         <ListItem disablePadding sx={{ mb: 1 }}>
           <ListItemButton
             selected={activeView === "inbox"}
-            component={Link} to="/inbox" onClick={handleNavClick}
+            onClick={() => handleNavClick("inbox")}
             sx={{ borderRadius: 2 }}
           >
             <ListItemIcon>
@@ -121,7 +119,7 @@ export function Layout({
         <ListItem disablePadding sx={{ mb: 1 }}>
           <ListItemButton
             selected={activeView === "settings"}
-            component={Link} to="/settings" onClick={handleNavClick}
+            onClick={() => handleNavClick("settings")}
             sx={{ borderRadius: 2 }}
           >
             <ListItemIcon>
@@ -148,7 +146,7 @@ export function Layout({
             <ListItem disablePadding sx={{ mb: 1 }}>
               <ListItemButton
                 selected={activeView === "quarantine"}
-                component={Link} to="/quarantine" onClick={handleNavClick}
+                onClick={() => handleNavClick("quarantine")}
                 sx={{ borderRadius: 2 }}
               >
                 <ListItemIcon>
@@ -174,7 +172,7 @@ export function Layout({
             <ListItem disablePadding>
               <ListItemButton
                 selected={activeView === "members"}
-                component={Link} to="/members" onClick={handleNavClick}
+                onClick={() => handleNavClick("members")}
                 sx={{ borderRadius: 2 }}
               >
                 <ListItemIcon>
@@ -200,7 +198,7 @@ export function Layout({
             <ListItem disablePadding sx={{ mt: 1 }}>
               <ListItemButton
                 selected={activeView === "providers"}
-                component={Link} to="/providers" onClick={handleNavClick}
+                onClick={() => handleNavClick("providers")}
                 sx={{ borderRadius: 2 }}
               >
                 <ListItemIcon>

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -2,8 +2,6 @@ import { CssBaseline, ThemeProvider, useMediaQuery } from "@mui/material";
 import { StrictMode, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
 
-import { BrowserRouter } from "react-router-dom";
-
 import { App } from "./App";
 import { ColorModeContext, getTheme } from "./theme";
 
@@ -25,14 +23,12 @@ function AppWrapper() {
   const theme = useMemo(() => getTheme(mode), [mode]);
 
   return (
-    <BrowserRouter>
-      <ColorModeContext.Provider value={colorMode}>
-        <ThemeProvider theme={theme}>
-          <CssBaseline />
-          <App />
-        </ThemeProvider>
-      </ColorModeContext.Provider>
-    </BrowserRouter>
+    <ColorModeContext.Provider value={colorMode}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <App />
+      </ThemeProvider>
+    </ColorModeContext.Provider>
   );
 }
 


### PR DESCRIPTION
## Summary
- revert the route-based navigation app-shell changes
- remove the react-router dependency added for that migration
- restore the previous frontend navigation behavior without rewriting main history

## Validation
- npm run typecheck
- npm run build