### PR TITLE
Add modal workflows for admin actions

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -348,7 +348,7 @@ export function App() {
     }
   }
 
-  async function handleDisable2FA() {
+  async function handleDisable2FA(): Promise<boolean> {
     setIsSavingSettings(true);
     setStatusMessage(null);
     setViewError(null);
@@ -363,10 +363,12 @@ export function App() {
       }
       setStatusMessage("Two-factor authentication disabled.");
       await refreshSettings();
+      return true;
     } catch (error) {
       setViewError(
         error instanceof Error ? error.message : "Unable to disable 2FA",
       );
+      return false;
     } finally {
       setIsSavingSettings(false);
     }
@@ -398,7 +400,7 @@ export function App() {
     }
   }
 
-  async function handleRevokeSession(sessionId: string) {
+  async function handleRevokeSession(sessionId: string): Promise<boolean> {
     setIsSavingSettings(true);
     setStatusMessage(null);
     setViewError(null);
@@ -409,16 +411,18 @@ export function App() {
       });
       setStatusMessage("Session revoked.");
       await refreshSettings();
+      return true;
     } catch (error) {
       setViewError(
         error instanceof Error ? error.message : "Unable to revoke session",
       );
+      return false;
     } finally {
       setIsSavingSettings(false);
     }
   }
 
-  async function handleRevokeOtherSessions() {
+  async function handleRevokeOtherSessions(): Promise<boolean> {
     setIsSavingSettings(true);
     setStatusMessage(null);
     setViewError(null);
@@ -427,10 +431,12 @@ export function App() {
       await fetchJson(`/api/settings/sessions/others`, { method: "DELETE" });
       setStatusMessage("Other sessions revoked.");
       await refreshSettings();
+      return true;
     } catch (error) {
       setViewError(
         error instanceof Error ? error.message : "Unable to revoke sessions",
       );
+      return false;
     } finally {
       setIsSavingSettings(false);
     }
@@ -952,8 +958,10 @@ export function App() {
     }
   }
 
-  async function handleQuarantineReview(action: "dismiss" | "release") {
-    if (!selectedQuarantineId) return;
+  async function handleQuarantineReview(
+    action: "dismiss" | "release",
+  ): Promise<boolean> {
+    if (!selectedQuarantineId) return false;
 
     setIsReviewingQuarantine(true);
     setStatusMessage(null);
@@ -976,16 +984,20 @@ export function App() {
       );
 
       await Promise.all([refreshQuarantine(), refreshProviders()]);
+      return true;
     } catch (error) {
       setViewError(
         error instanceof Error ? error.message : "Unable to review quarantine",
       );
+      return false;
     } finally {
       setIsReviewingQuarantine(false);
     }
   }
 
-  async function handleCreateMember(event: FormEvent<HTMLFormElement>) {
+  async function handleCreateMember(
+    event: FormEvent<HTMLFormElement>,
+  ): Promise<boolean> {
     event.preventDefault();
     setIsSavingMember(true);
     setStatusMessage(null);
@@ -1000,18 +1012,22 @@ export function App() {
       setMemberFormState(INITIAL_MEMBER_FORM_STATE);
       setStatusMessage("Household member created.");
       await refreshMembers();
+      return true;
     } catch (error) {
       setViewError(
         error instanceof Error
           ? error.message
           : "Unable to create household member",
       );
+      return false;
     } finally {
       setIsSavingMember(false);
     }
   }
 
-  async function handleCreateInvitation(event: FormEvent<HTMLFormElement>) {
+  async function handleCreateInvitation(
+    event: FormEvent<HTMLFormElement>,
+  ): Promise<boolean> {
     event.preventDefault();
     setIsSavingInvitation(true);
     setStatusMessage(null);
@@ -1029,10 +1045,12 @@ export function App() {
       setInvitationFormState(INITIAL_INVITATION_FORM_STATE);
       setStatusMessage("Invitation email sent.");
       await refreshInvitations();
+      return true;
     } catch (error) {
       setViewError(
         error instanceof Error ? error.message : "Unable to create invitation",
       );
+      return false;
     } finally {
       setIsSavingInvitation(false);
     }
@@ -1062,7 +1080,9 @@ export function App() {
     }
   }
 
-  async function handleCancelInvitation(invitationId: string) {
+  async function handleCancelInvitation(
+    invitationId: string,
+  ): Promise<boolean> {
     setIsSavingInvitation(true);
     setStatusMessage(null);
     setViewError(null);
@@ -1074,10 +1094,12 @@ export function App() {
 
       setStatusMessage("Invitation cancelled.");
       await refreshInvitations();
+      return true;
     } catch (error) {
       setViewError(
         error instanceof Error ? error.message : "Unable to cancel invitation",
       );
+      return false;
     } finally {
       setIsSavingInvitation(false);
     }
@@ -1141,7 +1163,9 @@ export function App() {
     }
   }
 
-  async function handleCreateProvider(event: FormEvent<HTMLFormElement>) {
+  async function handleCreateProvider(
+    event: FormEvent<HTMLFormElement>,
+  ): Promise<boolean> {
     event.preventDefault();
     setStatusMessage(null);
     setViewError(null);
@@ -1163,17 +1187,19 @@ export function App() {
         refreshProviders(),
         refreshMembers(),
       ]);
+      return true;
     } catch (error) {
       setViewError(
         error instanceof Error ? error.message : "Unable to create provider",
       );
+      return false;
     } finally {
       setIsSavingProviderConfiguration(false);
     }
   }
 
-  async function handleUpdateProvider() {
-    if (!selectedProviderId) return;
+  async function handleUpdateProvider(): Promise<boolean> {
+    if (!selectedProviderId) return false;
 
     setStatusMessage(null);
     setViewError(null);
@@ -1194,17 +1220,19 @@ export function App() {
         refreshProviders(),
         refreshMembers(),
       ]);
+      return true;
     } catch (error) {
       setViewError(
         error instanceof Error ? error.message : "Unable to update provider",
       );
+      return false;
     } finally {
       setIsSavingProviderConfiguration(false);
     }
   }
 
-  async function handleDeleteProvider() {
-    if (!selectedProviderId) return;
+  async function handleDeleteProvider(): Promise<boolean> {
+    if (!selectedProviderId) return false;
 
     setStatusMessage(null);
     setViewError(null);
@@ -1226,16 +1254,20 @@ export function App() {
         refreshProviders(),
         refreshMembers(),
       ]);
+      return true;
     } catch (error) {
       setViewError(
         error instanceof Error ? error.message : "Unable to delete provider",
       );
+      return false;
     } finally {
       setIsSavingProviderConfiguration(false);
     }
   }
 
-  async function handleCreateRule(event: FormEvent<HTMLFormElement>) {
+  async function handleCreateRule(
+    event: FormEvent<HTMLFormElement>,
+  ): Promise<boolean> {
     event.preventDefault();
     setStatusMessage(null);
     setViewError(null);
@@ -1257,17 +1289,19 @@ export function App() {
         refreshProviders(),
         refreshMembers(),
       ]);
+      return true;
     } catch (error) {
       setViewError(
         error instanceof Error ? error.message : "Unable to create sender rule",
       );
+      return false;
     } finally {
       setIsSavingProviderConfiguration(false);
     }
   }
 
-  async function handleUpdateRule() {
-    if (!selectedRuleId) return;
+  async function handleUpdateRule(): Promise<boolean> {
+    if (!selectedRuleId) return false;
 
     setStatusMessage(null);
     setViewError(null);
@@ -1288,17 +1322,19 @@ export function App() {
         refreshProviders(),
         refreshMembers(),
       ]);
+      return true;
     } catch (error) {
       setViewError(
         error instanceof Error ? error.message : "Unable to update sender rule",
       );
+      return false;
     } finally {
       setIsSavingProviderConfiguration(false);
     }
   }
 
-  async function handleDeleteRule() {
-    if (!selectedRuleId) return;
+  async function handleDeleteRule(): Promise<boolean> {
+    if (!selectedRuleId) return false;
 
     setStatusMessage(null);
     setViewError(null);
@@ -1322,10 +1358,12 @@ export function App() {
         refreshProviders(),
         refreshMembers(),
       ]);
+      return true;
     } catch (error) {
       setViewError(
         error instanceof Error ? error.message : "Unable to delete sender rule",
       );
+      return false;
     } finally {
       setIsSavingProviderConfiguration(false);
     }

--- a/src/client/components/ConfirmDialog.tsx
+++ b/src/client/components/ConfirmDialog.tsx
@@ -1,0 +1,68 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from "@mui/material";
+import type { ReactNode } from "react";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description: ReactNode;
+  confirmLabel: string;
+  onClose: () => void;
+  onConfirm: () => void | Promise<void>;
+  confirmColor?: "primary" | "error" | "warning" | "info" | "success";
+  confirmVariant?: "contained" | "outlined" | "text";
+  isLoading?: boolean;
+  confirmDisabled?: boolean;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel,
+  onClose,
+  onConfirm,
+  confirmColor = "primary",
+  confirmVariant = "contained",
+  isLoading = false,
+  confirmDisabled = false,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onClose={isLoading ? undefined : onClose}
+      fullWidth
+      maxWidth="xs"
+    >
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        {typeof description === "string" ? (
+          <Typography variant="body2" color="text.secondary">
+            {description}
+          </Typography>
+        ) : (
+          description
+        )}
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 3 }}>
+        <Button onClick={onClose} disabled={isLoading}>
+          Cancel
+        </Button>
+        <Button
+          onClick={() => void onConfirm()}
+          color={confirmColor}
+          variant={confirmVariant}
+          disabled={isLoading || confirmDisabled}
+        >
+          {isLoading ? "Working…" : confirmLabel}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/client/components/MembersView.tsx
+++ b/src/client/components/MembersView.tsx
@@ -1,6 +1,8 @@
 import {
+  AddCircleOutlined,
   AdminPanelSettingsOutlined,
   ChevronRightOutlined,
+  CloseOutlined,
   EmailOutlined,
   GroupOutlined,
   KeyOutlined,
@@ -15,10 +17,13 @@ import {
   Box,
   Button,
   Card,
-  CardActions,
   CardContent,
   CardHeader,
   Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   Divider,
   FormControl,
   IconButton,
@@ -40,7 +45,7 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
-import React, { type FormEvent } from "react";
+import React, { type FormEvent, useState } from "react";
 import type {
   InvitationFormState,
   InvitationSummary,
@@ -48,6 +53,7 @@ import type {
   MemberSummary,
   ProviderOption,
 } from "../types";
+import { ConfirmDialog } from "./ConfirmDialog";
 
 interface MembersViewProps {
   members: MemberSummary[];
@@ -58,13 +64,13 @@ interface MembersViewProps {
   isLoadingMembers: boolean;
   memberFormState: MemberFormState;
   onMemberFormChange: (update: Partial<MemberFormState>) => void;
-  onCreateMember: (e: FormEvent<HTMLFormElement>) => void;
+  onCreateMember: (e: FormEvent<HTMLFormElement>) => Promise<boolean>;
   isSavingMember: boolean;
   invitationFormState: InvitationFormState;
   onInvitationFormChange: (update: Partial<InvitationFormState>) => void;
-  onCreateInvitation: (e: FormEvent<HTMLFormElement>) => void;
+  onCreateInvitation: (e: FormEvent<HTMLFormElement>) => Promise<boolean>;
   onResendInvitation: (invitationId: string) => void;
-  onCancelInvitation: (invitationId: string) => void;
+  onCancelInvitation: (invitationId: string) => Promise<boolean>;
   isSavingInvitation: boolean;
   onRoleChange: (userId: string, role: MemberSummary["role"]) => void;
   onProviderAccessToggle: (
@@ -130,135 +136,234 @@ export function MembersView({
   onProviderAccessToggle,
 }: MembersViewProps) {
   const selectedMember = members.find((m) => m.id === selectedMemberId);
+  const [isCreateMemberOpen, setIsCreateMemberOpen] = useState(false);
+  const [isInviteMemberOpen, setIsInviteMemberOpen] = useState(false);
+  const [invitationToCancel, setInvitationToCancel] =
+    useState<InvitationSummary | null>(null);
+
+  const handleOpenCreateMember = () => {
+    onMemberFormChange({
+      name: "",
+      email: "",
+      password: "",
+      role: "member",
+    });
+    setIsCreateMemberOpen(true);
+  };
+
+  const handleOpenInviteMember = () => {
+    onInvitationFormChange({
+      name: "",
+      email: "",
+      role: "member",
+      providerIds: [],
+    });
+    setIsInviteMemberOpen(true);
+  };
+
+  const handleCreateMemberSubmit = async (
+    event: FormEvent<HTMLFormElement>,
+  ) => {
+    const didCreate = await onCreateMember(event);
+
+    if (didCreate) {
+      setIsCreateMemberOpen(false);
+    }
+  };
+
+  const handleCreateInvitationSubmit = async (
+    event: FormEvent<HTMLFormElement>,
+  ) => {
+    const didInvite = await onCreateInvitation(event);
+
+    if (didInvite) {
+      setIsInviteMemberOpen(false);
+    }
+  };
+
+  const handleCancelInvitationConfirm = async () => {
+    if (!invitationToCancel) {
+      return;
+    }
+
+    const didCancel = await onCancelInvitation(invitationToCancel.id);
+
+    if (didCancel) {
+      setInvitationToCancel(null);
+    }
+  };
 
   return (
     <Box
       sx={{ display: "flex", flexDirection: "column", gap: 4, height: "100%" }}
     >
       <Card variant="outlined" sx={{ borderRadius: 2, borderColor: "divider" }}>
-        <Box component="form" onSubmit={onCreateMember}>
-          <CardHeader
-            avatar={
-              <Avatar
-                sx={{ bgcolor: "primary.light", color: "primary.contrastText" }}
-              >
-                <PersonAddOutlined />
-              </Avatar>
-            }
-            title="Create a household member"
-            subheader="Invite-only onboarding"
-            titleTypographyProps={{ variant: "h6", fontWeight: "bold" }}
-          />
-          <Divider />
-          <CardContent>
-            <Alert severity="info" sx={{ mb: 3 }} icon={<KeyOutlined />}>
-              Provision a member directly, then share the generated login
-              details privately with them.
+        <CardHeader
+          avatar={
+            <Avatar
+              sx={{ bgcolor: "primary.light", color: "primary.contrastText" }}
+            >
+              <AddCircleOutlined />
+            </Avatar>
+          }
+          title="Household member actions"
+          subheader="Open a focused flow when you need to add or invite someone"
+          titleTypographyProps={{ variant: "h6", fontWeight: "bold" }}
+        />
+        <Divider />
+        <CardContent>
+          <Stack spacing={2}>
+            <Alert severity="info" icon={<PersonAddOutlined />}>
+              Keep the roster visible while opening a dedicated dialog for
+              create and invite actions.
             </Alert>
-            <Box
-              sx={{
-                display: "flex",
-                flexDirection: { xs: "column", md: "row" },
-                gap: 2,
-                alignItems: "flex-start",
-              }}
-            >
-              <TextField
-                label="Name"
-                size="small"
-                value={memberFormState.name}
-                onChange={(e) => onMemberFormChange({ name: e.target.value })}
-                required
-                fullWidth
-              />
-              <TextField
-                label="Email"
-                type="email"
-                size="small"
-                value={memberFormState.email}
-                onChange={(e) => onMemberFormChange({ email: e.target.value })}
-                required
-                fullWidth
-              />
-              <TextField
-                label="Temporary password"
-                type="password"
-                size="small"
-                value={memberFormState.password}
-                onChange={(e) =>
-                  onMemberFormChange({ password: e.target.value })
-                }
-                slotProps={{ htmlInput: { minLength: 12 } }}
-                required
-                fullWidth
-              />
-              <FormControl size="small" fullWidth>
-                <InputLabel id="role-select-label">Role</InputLabel>
-                <Select
-                  labelId="role-select-label"
-                  value={memberFormState.role}
-                  label="Role"
-                  onChange={(e) =>
-                    onMemberFormChange({
-                      role: e.target.value as "member" | "admin",
-                    })
-                  }
-                >
-                  <MenuItem value="member">Member</MenuItem>
-                  <MenuItem value="admin">Owner</MenuItem>
-                </Select>
-              </FormControl>
-            </Box>
-          </CardContent>
-          <CardActions sx={{ justifyContent: "flex-end", px: 3, pb: 3, pt: 0 }}>
-            <Button
-              type="submit"
-              variant="contained"
-              disabled={isSavingMember}
-              sx={{ minWidth: 160 }}
-            >
-              {isSavingMember ? "Creating…" : "Create member"}
-            </Button>
-          </CardActions>
-        </Box>
+            <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+              <Button
+                variant="contained"
+                startIcon={<PersonAddOutlined />}
+                onClick={handleOpenCreateMember}
+                sx={{ minWidth: 180 }}
+              >
+                Create member
+              </Button>
+              <Button
+                variant="outlined"
+                startIcon={<EmailOutlined />}
+                onClick={handleOpenInviteMember}
+                sx={{ minWidth: 180 }}
+              >
+                Invite member
+              </Button>
+            </Stack>
+          </Stack>
+        </CardContent>
       </Card>
 
-      <Card variant="outlined" sx={{ borderRadius: 2, borderColor: "divider" }}>
-        <Box component="form" onSubmit={onCreateInvitation}>
-          <CardHeader
-            avatar={
-              <Avatar
-                sx={{
-                  bgcolor: "secondary.light",
-                  color: "secondary.contrastText",
-                }}
-              >
-                <EmailOutlined />
-              </Avatar>
-            }
-            title="Invite a household member"
-            subheader="Send a secure invite link by email"
-            titleTypographyProps={{ variant: "h6", fontWeight: "bold" }}
-          />
-          <Divider />
-          <CardContent>
-            <Alert severity="info" sx={{ mb: 3 }} icon={<PersonAddOutlined />}>
-              Invitations let members choose their own password and immediately
-              receive provider access once accepted.
-            </Alert>
-            <Box
-              sx={{
-                display: "flex",
-                flexDirection: "column",
-                gap: 2,
-              }}
-            >
+      <Dialog
+        open={isCreateMemberOpen}
+        onClose={
+          isSavingMember ? undefined : () => setIsCreateMemberOpen(false)
+        }
+        fullWidth
+        maxWidth="md"
+      >
+        <Box component="form" onSubmit={handleCreateMemberSubmit}>
+          <DialogTitle sx={{ pr: 7 }}>Create a household member</DialogTitle>
+          <IconButton
+            aria-label="Close create member dialog"
+            onClick={() => setIsCreateMemberOpen(false)}
+            disabled={isSavingMember}
+            sx={{ position: "absolute", top: 12, right: 12 }}
+          >
+            <CloseOutlined />
+          </IconButton>
+          <DialogContent dividers>
+            <Stack spacing={3}>
+              <Alert severity="info" icon={<KeyOutlined />}>
+                Provision a member directly, then share the generated login
+                details privately with them.
+              </Alert>
               <Box
                 sx={{
-                  display: "flex",
-                  flexDirection: { xs: "column", md: "row" },
+                  display: "grid",
+                  gridTemplateColumns: { xs: "1fr", md: "repeat(2, 1fr)" },
                   gap: 2,
-                  alignItems: "flex-start",
+                }}
+              >
+                <TextField
+                  label="Name"
+                  size="small"
+                  value={memberFormState.name}
+                  onChange={(e) => onMemberFormChange({ name: e.target.value })}
+                  required
+                  fullWidth
+                />
+                <TextField
+                  label="Email"
+                  type="email"
+                  size="small"
+                  value={memberFormState.email}
+                  onChange={(e) =>
+                    onMemberFormChange({ email: e.target.value })
+                  }
+                  required
+                  fullWidth
+                />
+                <TextField
+                  label="Temporary password"
+                  type="password"
+                  size="small"
+                  value={memberFormState.password}
+                  onChange={(e) =>
+                    onMemberFormChange({ password: e.target.value })
+                  }
+                  helperText="Must be at least 12 characters."
+                  slotProps={{ htmlInput: { minLength: 12 } }}
+                  required
+                  fullWidth
+                />
+                <FormControl size="small" fullWidth>
+                  <InputLabel id="role-select-label">Role</InputLabel>
+                  <Select
+                    labelId="role-select-label"
+                    value={memberFormState.role}
+                    label="Role"
+                    onChange={(e) =>
+                      onMemberFormChange({
+                        role: e.target.value as "member" | "admin",
+                      })
+                    }
+                  >
+                    <MenuItem value="member">Member</MenuItem>
+                    <MenuItem value="admin">Owner</MenuItem>
+                  </Select>
+                </FormControl>
+              </Box>
+            </Stack>
+          </DialogContent>
+          <DialogActions sx={{ px: 3, py: 2 }}>
+            <Button
+              onClick={() => setIsCreateMemberOpen(false)}
+              disabled={isSavingMember}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" variant="contained" disabled={isSavingMember}>
+              {isSavingMember ? "Creating…" : "Create member"}
+            </Button>
+          </DialogActions>
+        </Box>
+      </Dialog>
+
+      <Dialog
+        open={isInviteMemberOpen}
+        onClose={
+          isSavingInvitation ? undefined : () => setIsInviteMemberOpen(false)
+        }
+        fullWidth
+        maxWidth="md"
+      >
+        <Box component="form" onSubmit={handleCreateInvitationSubmit}>
+          <DialogTitle sx={{ pr: 7 }}>Invite a household member</DialogTitle>
+          <IconButton
+            aria-label="Close invite member dialog"
+            onClick={() => setIsInviteMemberOpen(false)}
+            disabled={isSavingInvitation}
+            sx={{ position: "absolute", top: 12, right: 12 }}
+          >
+            <CloseOutlined />
+          </IconButton>
+          <DialogContent dividers>
+            <Stack spacing={3}>
+              <Alert severity="info" icon={<PersonAddOutlined />}>
+                Invitations let members choose their own password and receive
+                provider access once accepted.
+              </Alert>
+              <Box
+                sx={{
+                  display: "grid",
+                  gridTemplateColumns: { xs: "1fr", md: "repeat(2, 1fr)" },
+                  gap: 2,
                 }}
               >
                 <TextField
@@ -298,45 +403,54 @@ export function MembersView({
                     <MenuItem value="admin">Owner</MenuItem>
                   </Select>
                 </FormControl>
-              </Box>
-
-              <FormControl size="small" fullWidth>
-                <InputLabel id="invite-providers-select-label">
-                  Provider Access
-                </InputLabel>
-                <Select
-                  labelId="invite-providers-select-label"
-                  multiple
-                  value={invitationFormState.providerIds}
-                  label="Provider Access"
-                  onChange={(e) =>
-                    onInvitationFormChange({
-                      providerIds: e.target.value as string[],
-                    })
-                  }
-                  renderValue={(selected) => {
-                    const providerIds = selected as string[];
-
-                    if (!providerIds.length) {
-                      return "No provider access yet";
-                    }
-
-                    return providerOptions
-                      .filter((provider) => providerIds.includes(provider.id))
-                      .map((provider) => provider.display_name)
-                      .join(", ");
-                  }}
+                <FormControl
+                  size="small"
+                  fullWidth
+                  sx={{ gridColumn: { md: "1 / -1" } }}
                 >
-                  {providerOptions.map((provider) => (
-                    <MenuItem key={provider.id} value={provider.id}>
-                      {provider.display_name}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-            </Box>
-          </CardContent>
-          <CardActions sx={{ justifyContent: "flex-end", px: 3, pb: 3, pt: 0 }}>
+                  <InputLabel id="invite-providers-select-label">
+                    Provider Access
+                  </InputLabel>
+                  <Select
+                    labelId="invite-providers-select-label"
+                    multiple
+                    value={invitationFormState.providerIds}
+                    label="Provider Access"
+                    onChange={(e) =>
+                      onInvitationFormChange({
+                        providerIds: e.target.value as string[],
+                      })
+                    }
+                    renderValue={(selected) => {
+                      const providerIds = selected as string[];
+
+                      if (!providerIds.length) {
+                        return "No provider access yet";
+                      }
+
+                      return providerOptions
+                        .filter((provider) => providerIds.includes(provider.id))
+                        .map((provider) => provider.display_name)
+                        .join(", ");
+                    }}
+                  >
+                    {providerOptions.map((provider) => (
+                      <MenuItem key={provider.id} value={provider.id}>
+                        {provider.display_name}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Box>
+            </Stack>
+          </DialogContent>
+          <DialogActions sx={{ px: 3, py: 2 }}>
+            <Button
+              onClick={() => setIsInviteMemberOpen(false)}
+              disabled={isSavingInvitation}
+            >
+              Cancel
+            </Button>
             <Button
               type="submit"
               variant="contained"
@@ -345,13 +459,12 @@ export function MembersView({
                 !invitationFormState.name.trim() ||
                 !invitationFormState.email.trim()
               }
-              sx={{ minWidth: 160 }}
             >
               {isSavingInvitation ? "Sending…" : "Send invitation"}
             </Button>
-          </CardActions>
+          </DialogActions>
         </Box>
-      </Card>
+      </Dialog>
 
       <Card variant="outlined" sx={{ borderRadius: 2, borderColor: "divider" }}>
         <CardHeader
@@ -455,7 +568,7 @@ export function MembersView({
                           color="error"
                           variant="text"
                           disabled={!isPending || isSavingInvitation}
-                          onClick={() => onCancelInvitation(invitation.id)}
+                          onClick={() => setInvitationToCancel(invitation)}
                         >
                           Cancel
                         </Button>
@@ -856,6 +969,31 @@ export function MembersView({
           </Card>
         )}
       </Box>
+
+      <ConfirmDialog
+        open={Boolean(invitationToCancel)}
+        title="Cancel invitation?"
+        description={
+          invitationToCancel ? (
+            <Stack spacing={1}>
+              <Typography variant="body2" color="text.secondary">
+                This will invalidate the pending invite link for
+                <strong>{` ${invitationToCancel.name}`}</strong>.
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                They will need a new invitation before they can join.
+              </Typography>
+            </Stack>
+          ) : (
+            ""
+          )
+        }
+        confirmLabel="Cancel invitation"
+        confirmColor="error"
+        isLoading={isSavingInvitation}
+        onClose={() => setInvitationToCancel(null)}
+        onConfirm={handleCancelInvitationConfirm}
+      />
     </Box>
   );
 }

--- a/src/client/components/ProvidersRulesView.tsx
+++ b/src/client/components/ProvidersRulesView.tsx
@@ -1,11 +1,11 @@
 import {
   AddCircleOutlined,
   AutoAwesomeOutlined,
+  CloseOutlined,
   DeleteOutlined,
   EditOutlined,
   LinkOutlined,
   RuleFolderOutlined,
-  SaveOutlined,
 } from "@mui/icons-material";
 import {
   Alert,
@@ -13,12 +13,16 @@ import {
   Box,
   Button,
   Card,
-  CardActions,
   CardContent,
   CardHeader,
   Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   Divider,
   FormControl,
+  IconButton,
   InputLabel,
   MenuItem,
   Paper,
@@ -34,7 +38,7 @@ import {
   type GridRowParams,
   type GridRowSelectionModel,
 } from "@mui/x-data-grid";
-import type { FormEvent } from "react";
+import { type FormEvent, useState } from "react";
 import type {
   ProviderConfiguration,
   ProviderFormState,
@@ -42,6 +46,7 @@ import type {
   SenderRuleFormState,
 } from "../types";
 import { formatTimestamp } from "../utils";
+import { ConfirmDialog } from "./ConfirmDialog";
 
 interface ProvidersRulesViewProps {
   providers: ProviderConfiguration[];
@@ -55,12 +60,12 @@ interface ProvidersRulesViewProps {
   onSelectRule: (ruleId: string) => void;
   onProviderFormChange: (update: Partial<ProviderFormState>) => void;
   onRuleFormChange: (update: Partial<SenderRuleFormState>) => void;
-  onCreateProvider: (event: FormEvent<HTMLFormElement>) => void;
-  onUpdateProvider: () => void;
-  onDeleteProvider: () => void;
-  onCreateRule: (event: FormEvent<HTMLFormElement>) => void;
-  onUpdateRule: () => void;
-  onDeleteRule: () => void;
+  onCreateProvider: (event: FormEvent<HTMLFormElement>) => Promise<boolean>;
+  onUpdateProvider: () => Promise<boolean>;
+  onDeleteProvider: () => Promise<boolean>;
+  onCreateRule: (event: FormEvent<HTMLFormElement>) => Promise<boolean>;
+  onUpdateRule: () => Promise<boolean>;
+  onDeleteRule: () => Promise<boolean>;
 }
 
 export function ProvidersRulesView({
@@ -88,6 +93,104 @@ export function ProvidersRulesView({
   const providerRules = rules.filter(
     (rule) => rule.provider_id === selectedProviderId,
   );
+  const [providerDialogMode, setProviderDialogMode] = useState<
+    "create" | "edit" | null
+  >(null);
+  const [ruleDialogMode, setRuleDialogMode] = useState<
+    "create" | "edit" | null
+  >(null);
+  const [isDeleteProviderOpen, setIsDeleteProviderOpen] = useState(false);
+  const [isDeleteRuleOpen, setIsDeleteRuleOpen] = useState(false);
+
+  const resetProviderDraft = () => {
+    onProviderFormChange({
+      displayName: "",
+      providerKey: "",
+    });
+  };
+
+  const resetRuleDraft = () => {
+    onRuleFormChange({
+      providerId: selectedProviderId ?? "",
+      matchType: "domain",
+      matchValue: "",
+    });
+  };
+
+  const handleOpenCreateProvider = () => {
+    resetProviderDraft();
+    setProviderDialogMode("create");
+  };
+
+  const handleOpenEditProvider = () => {
+    if (!selectedProvider) {
+      return;
+    }
+
+    onProviderFormChange({
+      displayName: selectedProvider.display_name,
+      providerKey: selectedProvider.provider_key,
+    });
+    setProviderDialogMode("edit");
+  };
+
+  const handleOpenCreateRule = () => {
+    resetRuleDraft();
+    setRuleDialogMode("create");
+  };
+
+  const handleOpenEditRule = () => {
+    if (!selectedRule) {
+      return;
+    }
+
+    onRuleFormChange({
+      providerId: selectedRule.provider_id,
+      matchType: selectedRule.match_type,
+      matchValue: selectedRule.match_value,
+    });
+    setRuleDialogMode("edit");
+  };
+
+  const handleProviderSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    const didSave =
+      providerDialogMode === "edit"
+        ? await onUpdateProvider()
+        : await onCreateProvider(event);
+
+    if (didSave) {
+      setProviderDialogMode(null);
+    }
+  };
+
+  const handleRuleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    const didSave =
+      ruleDialogMode === "edit"
+        ? await onUpdateRule()
+        : await onCreateRule(event);
+
+    if (didSave) {
+      setRuleDialogMode(null);
+    }
+  };
+
+  const handleDeleteProviderConfirm = async () => {
+    const didDelete = await onDeleteProvider();
+
+    if (didDelete) {
+      setIsDeleteProviderOpen(false);
+      setProviderDialogMode(null);
+    }
+  };
+
+  const handleDeleteRuleConfirm = async () => {
+    const didDelete = await onDeleteRule();
+
+    if (didDelete) {
+      setIsDeleteRuleOpen(false);
+      setRuleDialogMode(null);
+    }
+  };
 
   const providerColumns: GridColDef<ProviderConfiguration>[] = [
     {
@@ -182,17 +285,36 @@ export function ProvidersRulesView({
             exact addresses or domains to those providers so inbound
             verification emails classify automatically.
           </Alert>
-          <Stack direction={{ xs: "column", md: "row" }} spacing={2}>
-            <Chip
-              label={`${providers.length} providers`}
-              color="primary"
-              variant="outlined"
-            />
-            <Chip
-              label={`${rules.length} sender rules`}
-              color="secondary"
-              variant="outlined"
-            />
+          <Stack spacing={2}>
+            <Stack direction={{ xs: "column", md: "row" }} spacing={2}>
+              <Chip
+                label={`${providers.length} providers`}
+                color="primary"
+                variant="outlined"
+              />
+              <Chip
+                label={`${rules.length} sender rules`}
+                color="secondary"
+                variant="outlined"
+              />
+            </Stack>
+            <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+              <Button
+                variant="contained"
+                startIcon={<AddCircleOutlined />}
+                onClick={handleOpenCreateProvider}
+              >
+                Create provider
+              </Button>
+              <Button
+                variant="outlined"
+                startIcon={<RuleFolderOutlined />}
+                onClick={handleOpenCreateRule}
+                disabled={!providers.length}
+              >
+                Add rule
+              </Button>
+            </Stack>
           </Stack>
         </CardContent>
       </Card>
@@ -290,203 +412,336 @@ export function ProvidersRulesView({
 
         <Stack spacing={3}>
           <Card variant="outlined" sx={{ borderRadius: 2 }}>
-            <Box component="form" onSubmit={onCreateProvider}>
-              <CardHeader
-                avatar={
-                  <Avatar
-                    sx={{
-                      bgcolor: "secondary.light",
-                      color: "secondary.contrastText",
-                    }}
-                  >
-                    <AddCircleOutlined />
-                  </Avatar>
-                }
-                title="New provider"
-                subheader="Create or maintain a service bucket"
-                titleTypographyProps={{ variant: "h6", fontWeight: "bold" }}
-              />
-              <Divider />
-              <CardContent>
-                <Stack spacing={2}>
-                  <TextField
-                    label="Display name"
-                    size="small"
-                    value={providerFormState.displayName}
-                    onChange={(event) =>
-                      onProviderFormChange({ displayName: event.target.value })
-                    }
-                    required
-                    fullWidth
-                  />
-                  <TextField
-                    label="Provider key"
-                    size="small"
-                    helperText="Lowercase identifier used in routing and access control"
-                    value={providerFormState.providerKey}
-                    onChange={(event) =>
-                      onProviderFormChange({ providerKey: event.target.value })
-                    }
-                    required
-                    fullWidth
-                  />
-                </Stack>
-              </CardContent>
-              <CardActions
-                sx={{ justifyContent: "space-between", px: 3, pb: 3, pt: 0 }}
-              >
-                <Button
-                  startIcon={<EditOutlined />}
-                  onClick={onUpdateProvider}
-                  disabled={isSaving || !selectedProviderId}
+            <CardHeader
+              avatar={
+                <Avatar
+                  sx={{
+                    bgcolor: "secondary.light",
+                    color: "secondary.contrastText",
+                  }}
                 >
-                  Update selected
-                </Button>
-                <Box sx={{ display: "flex", gap: 1 }}>
+                  <AddCircleOutlined />
+                </Avatar>
+              }
+              title="Provider actions"
+              subheader="Open a dialog to create, update, or delete a selected provider"
+              titleTypographyProps={{ variant: "h6", fontWeight: "bold" }}
+            />
+            <Divider />
+            <CardContent>
+              <Stack spacing={2}>
+                <Typography variant="body2" color="text.secondary">
+                  Select a provider from the inventory, then open the focused
+                  edit flow when you need to make changes.
+                </Typography>
+                <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+                  <Button
+                    variant="contained"
+                    startIcon={<AddCircleOutlined />}
+                    onClick={handleOpenCreateProvider}
+                  >
+                    Create provider
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    startIcon={<EditOutlined />}
+                    onClick={handleOpenEditProvider}
+                    disabled={!selectedProviderId}
+                  >
+                    Edit selected
+                  </Button>
                   <Button
                     color="error"
+                    variant="text"
                     startIcon={<DeleteOutlined />}
-                    onClick={onDeleteProvider}
-                    disabled={isSaving || !selectedProviderId}
+                    onClick={() => setIsDeleteProviderOpen(true)}
+                    disabled={!selectedProviderId || isSaving}
                   >
                     Delete
                   </Button>
-                  <Button
-                    type="submit"
-                    variant="contained"
-                    startIcon={<SaveOutlined />}
-                    disabled={isSaving}
-                  >
-                    {isSaving ? "Saving…" : "Create provider"}
-                  </Button>
-                </Box>
-              </CardActions>
-            </Box>
+                </Stack>
+              </Stack>
+            </CardContent>
           </Card>
 
           <Card variant="outlined" sx={{ borderRadius: 2 }}>
-            <Box component="form" onSubmit={onCreateRule}>
-              <CardHeader
-                avatar={
-                  <Avatar
-                    sx={{
-                      bgcolor: "warning.main",
-                      color: "warning.contrastText",
-                    }}
-                  >
-                    <RuleFolderOutlined />
-                  </Avatar>
-                }
-                title="Rule details"
-                subheader="Map incoming sender identities to the selected provider"
-                titleTypographyProps={{ variant: "h6", fontWeight: "bold" }}
-              />
-              <Divider />
-              <CardContent>
-                <Stack spacing={2}>
-                  <FormControl size="small" fullWidth>
-                    <InputLabel id="provider-rule-provider-label">
-                      Provider
-                    </InputLabel>
-                    <Select
-                      labelId="provider-rule-provider-label"
-                      label="Provider"
-                      value={ruleFormState.providerId}
-                      onChange={(event) =>
-                        onRuleFormChange({
-                          providerId: String(event.target.value),
-                        })
-                      }
-                    >
-                      {providers.map((provider) => (
-                        <MenuItem key={provider.id} value={provider.id}>
-                          {provider.display_name}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  </FormControl>
-
-                  <FormControl size="small" fullWidth>
-                    <InputLabel id="provider-rule-type-label">
-                      Match type
-                    </InputLabel>
-                    <Select
-                      labelId="provider-rule-type-label"
-                      label="Match type"
-                      value={ruleFormState.matchType}
-                      onChange={(event) =>
-                        onRuleFormChange({
-                          matchType: event.target
-                            .value as SenderRuleFormState["matchType"],
-                        })
-                      }
-                    >
-                      <MenuItem value="domain">Domain</MenuItem>
-                      <MenuItem value="exact">Exact sender</MenuItem>
-                    </Select>
-                  </FormControl>
-
-                  <TextField
-                    label={
-                      ruleFormState.matchType === "domain"
-                        ? "Domain"
-                        : "Exact sender address"
-                    }
-                    size="small"
-                    helperText={
-                      ruleFormState.matchType === "domain"
-                        ? "Example: netflix.com"
-                        : "Example: login@netflix.com"
-                    }
-                    value={ruleFormState.matchValue}
-                    onChange={(event) =>
-                      onRuleFormChange({ matchValue: event.target.value })
-                    }
-                    required
-                    fullWidth
-                  />
-
-                  {selectedRule && (
-                    <Alert severity="success" icon={<LinkOutlined />}>
-                      Editing existing rule{" "}
-                      <strong>{selectedRule.match_value}</strong>.
-                    </Alert>
-                  )}
-                </Stack>
-              </CardContent>
-              <CardActions
-                sx={{ justifyContent: "space-between", px: 3, pb: 3, pt: 0 }}
-              >
-                <Button
-                  startIcon={<EditOutlined />}
-                  onClick={onUpdateRule}
-                  disabled={isSaving || !selectedRuleId}
+            <CardHeader
+              avatar={
+                <Avatar
+                  sx={{
+                    bgcolor: "warning.main",
+                    color: "warning.contrastText",
+                  }}
                 >
-                  Update selected
-                </Button>
-                <Box sx={{ display: "flex", gap: 1 }}>
+                  <RuleFolderOutlined />
+                </Avatar>
+              }
+              title="Rule actions"
+              subheader="Create or refine sender mapping rules without losing grid context"
+              titleTypographyProps={{ variant: "h6", fontWeight: "bold" }}
+            />
+            <Divider />
+            <CardContent>
+              <Stack spacing={2}>
+                <Typography variant="body2" color="text.secondary">
+                  Rules stay tied to the selected provider, but the editor opens
+                  separately so the inventory remains easy to scan.
+                </Typography>
+                <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+                  <Button
+                    variant="contained"
+                    startIcon={<RuleFolderOutlined />}
+                    onClick={handleOpenCreateRule}
+                    disabled={!providers.length}
+                  >
+                    Add rule
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    startIcon={<EditOutlined />}
+                    onClick={handleOpenEditRule}
+                    disabled={!selectedRuleId}
+                  >
+                    Edit selected
+                  </Button>
                   <Button
                     color="error"
+                    variant="text"
                     startIcon={<DeleteOutlined />}
-                    onClick={onDeleteRule}
-                    disabled={isSaving || !selectedRuleId}
+                    onClick={() => setIsDeleteRuleOpen(true)}
+                    disabled={!selectedRuleId || isSaving}
                   >
                     Delete
                   </Button>
-                  <Button
-                    type="submit"
-                    variant="contained"
-                    startIcon={<SaveOutlined />}
-                    disabled={isSaving || !ruleFormState.providerId}
-                  >
-                    {isSaving ? "Saving…" : "Add rule"}
-                  </Button>
-                </Box>
-              </CardActions>
-            </Box>
+                </Stack>
+                {selectedRule && (
+                  <Alert severity="success" icon={<LinkOutlined />}>
+                    Selected rule <strong>{selectedRule.match_value}</strong> is
+                    ready to edit.
+                  </Alert>
+                )}
+              </Stack>
+            </CardContent>
           </Card>
         </Stack>
       </Box>
+
+      <Dialog
+        open={providerDialogMode !== null}
+        onClose={isSaving ? undefined : () => setProviderDialogMode(null)}
+        fullWidth
+        maxWidth="sm"
+      >
+        <Box component="form" onSubmit={handleProviderSubmit}>
+          <DialogTitle sx={{ pr: 7 }}>
+            {providerDialogMode === "edit"
+              ? "Edit provider"
+              : "Create provider"}
+          </DialogTitle>
+          <IconButton
+            aria-label="Close provider dialog"
+            onClick={() => setProviderDialogMode(null)}
+            disabled={isSaving}
+            sx={{ position: "absolute", top: 12, right: 12 }}
+          >
+            <CloseOutlined />
+          </IconButton>
+          <DialogContent dividers>
+            <Stack spacing={3}>
+              <Alert severity="info" icon={<LinkOutlined />}>
+                Providers define the household service buckets used by inbox and
+                access controls.
+              </Alert>
+              <Stack spacing={2}>
+                <TextField
+                  label="Display name"
+                  size="small"
+                  value={providerFormState.displayName}
+                  onChange={(event) =>
+                    onProviderFormChange({ displayName: event.target.value })
+                  }
+                  required
+                  fullWidth
+                />
+                <TextField
+                  label="Provider key"
+                  size="small"
+                  helperText="Lowercase identifier used in routing and access control"
+                  value={providerFormState.providerKey}
+                  onChange={(event) =>
+                    onProviderFormChange({ providerKey: event.target.value })
+                  }
+                  required
+                  fullWidth
+                />
+              </Stack>
+            </Stack>
+          </DialogContent>
+          <DialogActions sx={{ px: 3, py: 2 }}>
+            <Button
+              onClick={() => setProviderDialogMode(null)}
+              disabled={isSaving}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" variant="contained" disabled={isSaving}>
+              {isSaving
+                ? "Saving…"
+                : providerDialogMode === "edit"
+                  ? "Save provider"
+                  : "Create provider"}
+            </Button>
+          </DialogActions>
+        </Box>
+      </Dialog>
+
+      <Dialog
+        open={ruleDialogMode !== null}
+        onClose={isSaving ? undefined : () => setRuleDialogMode(null)}
+        fullWidth
+        maxWidth="sm"
+      >
+        <Box component="form" onSubmit={handleRuleSubmit}>
+          <DialogTitle sx={{ pr: 7 }}>
+            {ruleDialogMode === "edit" ? "Edit sender rule" : "Add sender rule"}
+          </DialogTitle>
+          <IconButton
+            aria-label="Close rule dialog"
+            onClick={() => setRuleDialogMode(null)}
+            disabled={isSaving}
+            sx={{ position: "absolute", top: 12, right: 12 }}
+          >
+            <CloseOutlined />
+          </IconButton>
+          <DialogContent dividers>
+            <Stack spacing={3}>
+              <Alert severity="info" icon={<RuleFolderOutlined />}>
+                Match exact senders or domains to the provider that should own
+                incoming verification messages.
+              </Alert>
+              <Stack spacing={2}>
+                <FormControl size="small" fullWidth>
+                  <InputLabel id="provider-rule-provider-label">
+                    Provider
+                  </InputLabel>
+                  <Select
+                    labelId="provider-rule-provider-label"
+                    label="Provider"
+                    value={ruleFormState.providerId}
+                    onChange={(event) =>
+                      onRuleFormChange({
+                        providerId: String(event.target.value),
+                      })
+                    }
+                  >
+                    {providers.map((provider) => (
+                      <MenuItem key={provider.id} value={provider.id}>
+                        {provider.display_name}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+
+                <FormControl size="small" fullWidth>
+                  <InputLabel id="provider-rule-type-label">
+                    Match type
+                  </InputLabel>
+                  <Select
+                    labelId="provider-rule-type-label"
+                    label="Match type"
+                    value={ruleFormState.matchType}
+                    onChange={(event) =>
+                      onRuleFormChange({
+                        matchType: event.target
+                          .value as SenderRuleFormState["matchType"],
+                      })
+                    }
+                  >
+                    <MenuItem value="domain">Domain</MenuItem>
+                    <MenuItem value="exact">Exact sender</MenuItem>
+                  </Select>
+                </FormControl>
+
+                <TextField
+                  label={
+                    ruleFormState.matchType === "domain"
+                      ? "Domain"
+                      : "Exact sender address"
+                  }
+                  size="small"
+                  helperText={
+                    ruleFormState.matchType === "domain"
+                      ? "Example: netflix.com"
+                      : "Example: login@netflix.com"
+                  }
+                  value={ruleFormState.matchValue}
+                  onChange={(event) =>
+                    onRuleFormChange({ matchValue: event.target.value })
+                  }
+                  required
+                  fullWidth
+                />
+              </Stack>
+            </Stack>
+          </DialogContent>
+          <DialogActions sx={{ px: 3, py: 2 }}>
+            <Button onClick={() => setRuleDialogMode(null)} disabled={isSaving}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="contained"
+              disabled={isSaving || !ruleFormState.providerId}
+            >
+              {isSaving
+                ? "Saving…"
+                : ruleDialogMode === "edit"
+                  ? "Save rule"
+                  : "Add rule"}
+            </Button>
+          </DialogActions>
+        </Box>
+      </Dialog>
+
+      <ConfirmDialog
+        open={isDeleteProviderOpen}
+        title="Delete provider?"
+        description={
+          selectedProvider ? (
+            <Typography variant="body2" color="text.secondary">
+              <strong>{selectedProvider.display_name}</strong> and its sender
+              rules will be removed from routing and member access management.
+            </Typography>
+          ) : (
+            ""
+          )
+        }
+        confirmLabel="Delete provider"
+        confirmColor="error"
+        isLoading={isSaving}
+        onClose={() => setIsDeleteProviderOpen(false)}
+        onConfirm={handleDeleteProviderConfirm}
+      />
+
+      <ConfirmDialog
+        open={isDeleteRuleOpen}
+        title="Delete sender rule?"
+        description={
+          selectedRule ? (
+            <Typography variant="body2" color="text.secondary">
+              Rule <strong>{selectedRule.match_value}</strong> will stop routing
+              senders to this provider.
+            </Typography>
+          ) : (
+            ""
+          )
+        }
+        confirmLabel="Delete rule"
+        confirmColor="error"
+        isLoading={isSaving}
+        onClose={() => setIsDeleteRuleOpen(false)}
+        onConfirm={handleDeleteRuleConfirm}
+      />
     </Box>
   );
 }

--- a/src/client/components/QuarantineView.tsx
+++ b/src/client/components/QuarantineView.tsx
@@ -32,6 +32,7 @@ import {
 import React, { useState } from "react";
 import type { ProviderSummary, QuarantineMessage } from "../types";
 import { formatTimestamp } from "../utils";
+import { ConfirmDialog } from "./ConfirmDialog";
 
 const avatarColors = [
   "#6366F1", // Indigo
@@ -77,7 +78,7 @@ interface QuarantineViewProps {
   releaseProviderKey: string;
   onReleaseProviderKeyChange: (key: string) => void;
   isReviewingQuarantine: boolean;
-  onQuarantineReview: (action: "dismiss" | "release") => void;
+  onQuarantineReview: (action: "dismiss" | "release") => Promise<boolean>;
 }
 
 export function QuarantineView({
@@ -92,6 +93,9 @@ export function QuarantineView({
   onQuarantineReview,
 }: QuarantineViewProps) {
   const [copiedCodeId, setCopiedCodeId] = useState<string | null>(null);
+  const [reviewAction, setReviewAction] = useState<
+    "dismiss" | "release" | null
+  >(null);
 
   const selectedQuarantineMessage = quarantineMessages.find(
     (m) => m.id === selectedQuarantineId,
@@ -104,6 +108,18 @@ export function QuarantineView({
       setTimeout(() => setCopiedCodeId(null), 2000);
     } catch (err) {
       console.error("Failed to copy text: ", err);
+    }
+  };
+
+  const handleReviewConfirm = async () => {
+    if (!reviewAction) {
+      return;
+    }
+
+    const didReview = await onQuarantineReview(reviewAction);
+
+    if (didReview) {
+      setReviewAction(null);
     }
   };
 
@@ -399,7 +415,7 @@ export function QuarantineView({
                   color="primary"
                   startIcon={<MoveToInboxOutlined />}
                   disabled={isReviewingQuarantine || !releaseProviderKey}
-                  onClick={() => onQuarantineReview("release")}
+                  onClick={() => setReviewAction("release")}
                   sx={{ px: 4, py: 1.5 }}
                 >
                   Release to inbox
@@ -408,7 +424,7 @@ export function QuarantineView({
                   variant="outlined"
                   startIcon={<DeleteOutlined />}
                   disabled={isReviewingQuarantine}
-                  onClick={() => onQuarantineReview("dismiss")}
+                  onClick={() => setReviewAction("dismiss")}
                   sx={{ px: 4, py: 1.5 }}
                 >
                   Dismiss
@@ -460,6 +476,42 @@ export function QuarantineView({
           </Paper>
         )}
       </Box>
+
+      <ConfirmDialog
+        open={reviewAction !== null}
+        title={
+          reviewAction === "release"
+            ? "Release message to inbox?"
+            : "Dismiss quarantined message?"
+        }
+        description={
+          selectedQuarantineMessage ? (
+            <Stack spacing={1}>
+              <Typography variant="body2" color="text.secondary">
+                <strong>
+                  {selectedQuarantineMessage.subject ?? "Untitled message"}
+                </strong>{" "}
+                from {selectedQuarantineMessage.envelope_from}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {reviewAction === "release"
+                  ? `This will move the message into ${providers.find((provider) => provider.provider_key === releaseProviderKey)?.display_name || "the selected provider"}.`
+                  : "This will remove the message from quarantine review."}
+              </Typography>
+            </Stack>
+          ) : (
+            ""
+          )
+        }
+        confirmLabel={
+          reviewAction === "release" ? "Release to inbox" : "Dismiss message"
+        }
+        confirmColor={reviewAction === "release" ? "primary" : "error"}
+        isLoading={isReviewingQuarantine}
+        confirmDisabled={reviewAction === "release" && !releaseProviderKey}
+        onClose={() => setReviewAction(null)}
+        onConfirm={handleReviewConfirm}
+      />
     </Box>
   );
 }

--- a/src/client/components/SettingsView.tsx
+++ b/src/client/components/SettingsView.tsx
@@ -15,12 +15,13 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import { type FormEvent, Fragment } from "react";
+import { type FormEvent, Fragment, useState } from "react";
 import type {
   AccountProfile,
   AccountSession,
   AccountSettingsFormState,
 } from "../types";
+import { ConfirmDialog } from "./ConfirmDialog";
 
 interface SettingsViewProps {
   profile: AccountProfile | null;
@@ -33,10 +34,10 @@ interface SettingsViewProps {
   onChangePassword: (e: FormEvent<HTMLFormElement>) => void;
   onRequestPasswordReset: (e: FormEvent<HTMLFormElement>) => void;
   onEnable2FA: (e: FormEvent<HTMLFormElement>) => void;
-  onDisable2FA: () => void;
+  onDisable2FA: () => Promise<boolean>;
   onAddPasskey: (e: FormEvent<HTMLFormElement>) => void;
-  onRevokeSession: (sessionId: string) => void;
-  onRevokeOtherSessions: () => void;
+  onRevokeSession: (sessionId: string) => Promise<boolean>;
+  onRevokeOtherSessions: () => Promise<boolean>;
   isSaving: boolean;
 }
 
@@ -57,6 +58,12 @@ export function SettingsView({
   onRevokeOtherSessions,
   isSaving,
 }: SettingsViewProps) {
+  const [sessionToRevoke, setSessionToRevoke] = useState<AccountSession | null>(
+    null,
+  );
+  const [isRevokeOthersOpen, setIsRevokeOthersOpen] = useState(false);
+  const [isDisable2FAOpen, setIsDisable2FAOpen] = useState(false);
+
   if (isLoading && !profile) {
     return (
       <Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
@@ -68,6 +75,34 @@ export function SettingsView({
   if (!profile) {
     return <Alert severity="error">{error || "Unable to load profile"}</Alert>;
   }
+
+  const handleDisable2FAConfirm = async () => {
+    const didDisable = await onDisable2FA();
+
+    if (didDisable) {
+      setIsDisable2FAOpen(false);
+    }
+  };
+
+  const handleRevokeSessionConfirm = async () => {
+    if (!sessionToRevoke) {
+      return;
+    }
+
+    const didRevoke = await onRevokeSession(sessionToRevoke.id);
+
+    if (didRevoke) {
+      setSessionToRevoke(null);
+    }
+  };
+
+  const handleRevokeOthersConfirm = async () => {
+    const didRevoke = await onRevokeOtherSessions();
+
+    if (didRevoke) {
+      setIsRevokeOthersOpen(false);
+    }
+  };
 
   return (
     <Container maxWidth="md" disableGutters>
@@ -250,10 +285,11 @@ export function SettingsView({
                 </Box>
                 <Box>
                   <Button
-                    type="submit"
+                    type="button"
                     variant="outlined"
                     color="error"
                     disabled={isSaving || !formState.twoFactorPassword}
+                    onClick={() => setIsDisable2FAOpen(true)}
                   >
                     Disable 2FA
                   </Button>
@@ -338,7 +374,7 @@ export function SettingsView({
             <Button
               color="error"
               disabled={isSaving || sessions.length <= 1}
-              onClick={onRevokeOtherSessions}
+              onClick={() => setIsRevokeOthersOpen(true)}
             >
               Revoke Others
             </Button>
@@ -354,7 +390,7 @@ export function SettingsView({
                   <Button
                     color="error"
                     size="small"
-                    onClick={() => onRevokeSession(session.id)}
+                    onClick={() => setSessionToRevoke(session)}
                     disabled={isSaving}
                   >
                     Revoke
@@ -383,6 +419,66 @@ export function SettingsView({
           )}
         </List>
       </Card>
+
+      <ConfirmDialog
+        open={isDisable2FAOpen}
+        title="Disable two-factor authentication?"
+        description={
+          <Stack spacing={1}>
+            <Typography variant="body2" color="text.secondary">
+              This will remove the extra verification step from your account.
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Your current password is still required to confirm the change.
+            </Typography>
+          </Stack>
+        }
+        confirmLabel="Disable 2FA"
+        confirmColor="error"
+        isLoading={isSaving}
+        confirmDisabled={!formState.twoFactorPassword}
+        onClose={() => setIsDisable2FAOpen(false)}
+        onConfirm={handleDisable2FAConfirm}
+      />
+
+      <ConfirmDialog
+        open={Boolean(sessionToRevoke)}
+        title="Revoke session?"
+        description={
+          sessionToRevoke ? (
+            <Stack spacing={1}>
+              <Typography variant="body2" color="text.secondary">
+                This will sign out
+                <strong>{` ${sessionToRevoke.userAgent || "this device"}`}</strong>
+                .
+              </Typography>
+              {sessionToRevoke.ipAddress && (
+                <Typography variant="body2" color="text.secondary">
+                  IP address: {sessionToRevoke.ipAddress}
+                </Typography>
+              )}
+            </Stack>
+          ) : (
+            ""
+          )
+        }
+        confirmLabel="Revoke session"
+        confirmColor="error"
+        isLoading={isSaving}
+        onClose={() => setSessionToRevoke(null)}
+        onConfirm={handleRevokeSessionConfirm}
+      />
+
+      <ConfirmDialog
+        open={isRevokeOthersOpen}
+        title="Revoke all other sessions?"
+        description="All other signed-in devices will be logged out immediately. Your current session will stay active."
+        confirmLabel="Revoke others"
+        confirmColor="error"
+        isLoading={isSaving}
+        onClose={() => setIsRevokeOthersOpen(false)}
+        onConfirm={handleRevokeOthersConfirm}
+      />
     </Container>
   );
 }

--- a/test/members-view.test.tsx
+++ b/test/members-view.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { MembersView } from "../src/client/components/MembersView";
 
 describe("MembersView", () => {
-  it("renders direct member creation and invitation management controls", () => {
+  it("renders member action triggers and invitation management controls", () => {
     const html = renderToStaticMarkup(
       <MembersView
         members={[
@@ -81,9 +81,9 @@ describe("MembersView", () => {
       />,
     );
 
-    expect(html).toContain("Create a household member");
-    expect(html).toContain("Invite a household member");
-    expect(html).toContain("Send invitation");
+    expect(html).toContain("Household member actions");
+    expect(html).toContain("Create member");
+    expect(html).toContain("Invite member");
     expect(html).toContain("Pending and recent invitations");
     expect(html).toContain("Resend");
     expect(html).toContain("Cancel");

--- a/test/providers-rules-view.test.tsx
+++ b/test/providers-rules-view.test.tsx
@@ -67,10 +67,11 @@ describe("ProvidersRulesView", () => {
     expect(html).toContain("Provider and rule setup");
     expect(html).toContain("Connected providers");
     expect(html).toContain("Sender rules");
-    expect(html).toContain("New provider");
-    expect(html).toContain("Rule details");
+    expect(html).toContain("Provider actions");
+    expect(html).toContain("Rule actions");
     expect(html).toContain("Create provider");
     expect(html).toContain("Add rule");
+    expect(html).toContain("Edit selected");
     expect(html).toContain("Match value");
   });
 });


### PR DESCRIPTION
## Summary
- replace always-visible member, provider, and rule admin forms with action-triggered dialogs so browsing and editing are clearly separated
- add a reusable confirmation dialog and use it for invitation cancellation, provider/rule deletion, session revocation, 2FA disable, and quarantine review actions
- update app handlers and UI tests to support modal-close-on-success flows while keeping existing validation and server interactions intact

## Validation
- npm run check
- npm run typecheck
- npm run test
- npm run build