### PR TITLE
fix: honor provider access toggle state

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -44,7 +44,7 @@ import type {
   SenderRuleFormState,
   SetupStatus,
 } from "./types";
-import { fetchJson } from "./utils";
+import { fetchJson, getProviderAccessToggleRequest } from "./utils";
 
 type ViewType = "inbox" | "quarantine" | "members" | "providers" | "settings";
 
@@ -1149,23 +1149,24 @@ export function App() {
   async function handleProviderAccessToggle(
     userId: string,
     providerKey: string,
-    hasAccess: boolean,
+    shouldHaveAccess: boolean,
   ) {
     setStatusMessage(null);
     setViewError(null);
 
     try {
+      const { method, statusMessage } =
+        getProviderAccessToggleRequest(shouldHaveAccess);
+
       await fetchJson<{ ok: boolean }>(
         `/api/admin/members/${userId}/provider-access`,
         {
-          method: hasAccess ? "DELETE" : "POST",
+          method,
           body: JSON.stringify({ providerKey }),
         },
       );
 
-      setStatusMessage(
-        hasAccess ? "Provider access revoked." : "Provider access granted.",
-      );
+      setStatusMessage(statusMessage);
       await refreshMembers();
       await refreshProviders();
     } catch (error) {

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -1,5 +1,20 @@
 import type { SessionData } from "./types";
 
+export function getProviderAccessToggleRequest(shouldHaveAccess: boolean): {
+  method: "POST" | "DELETE";
+  statusMessage: string;
+} {
+  return shouldHaveAccess
+    ? {
+        method: "POST",
+        statusMessage: "Provider access granted.",
+      }
+    : {
+        method: "DELETE",
+        statusMessage: "Provider access revoked.",
+      };
+}
+
 export async function fetchJson<T>(
   input: RequestInfo,
   init?: RequestInit,

--- a/test/client-utils.test.ts
+++ b/test/client-utils.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { getProviderAccessToggleRequest } from "../src/client/utils";
+
+describe("getProviderAccessToggleRequest", () => {
+  it("uses POST and a granted message when access should be enabled", () => {
+    expect(getProviderAccessToggleRequest(true)).toEqual({
+      method: "POST",
+      statusMessage: "Provider access granted.",
+    });
+  });
+
+  it("uses DELETE and a revoked message when access should be disabled", () => {
+    expect(getProviderAccessToggleRequest(false)).toEqual({
+      method: "DELETE",
+      statusMessage: "Provider access revoked.",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- fix the provider access toggle to use the switch's next checked state when choosing the admin mutation
- extract the POST/DELETE + status message mapping into a small client helper to make the behavior explicit
- add regression coverage for grant vs revoke semantics and verify related tests still pass