### PR TITLE
feat: add multi-household tenancy isolation

### DIFF
--- a/migrations/0005_multi_household_isolation.sql
+++ b/migrations/0005_multi_household_isolation.sql
@@ -10,6 +10,14 @@ ALTER TABLE quarantine_messages RENAME TO quarantine_messages__legacy;
 ALTER TABLE household_invitations RENAME TO household_invitations__legacy;
 ALTER TABLE household_invitation_provider_access RENAME TO household_invitation_provider_access__legacy;
 
+DROP INDEX IF EXISTS idx_sender_rules_lookup;
+DROP INDEX IF EXISTS idx_messages_provider_received;
+DROP INDEX IF EXISTS idx_messages_delete_after;
+DROP INDEX IF EXISTS idx_quarantine_delete_after;
+DROP INDEX IF EXISTS idx_household_invitations_email;
+DROP INDEX IF EXISTS idx_household_invitations_status;
+DROP INDEX IF EXISTS idx_household_invitations_expires_at;
+
 CREATE TABLE households (
   id TEXT PRIMARY KEY NOT NULL,
   slug TEXT NOT NULL UNIQUE,

--- a/migrations/0005_multi_household_isolation.sql
+++ b/migrations/0005_multi_household_isolation.sql
@@ -1,0 +1,313 @@
+-- Migrate the original single-household app schema to the household-scoped model.
+
+PRAGMA foreign_keys = OFF;
+
+ALTER TABLE providers RENAME TO providers__legacy;
+ALTER TABLE sender_rules RENAME TO sender_rules__legacy;
+ALTER TABLE user_provider_access RENAME TO user_provider_access__legacy;
+ALTER TABLE messages RENAME TO messages__legacy;
+ALTER TABLE quarantine_messages RENAME TO quarantine_messages__legacy;
+ALTER TABLE household_invitations RENAME TO household_invitations__legacy;
+ALTER TABLE household_invitation_provider_access RENAME TO household_invitation_provider_access__legacy;
+
+CREATE TABLE households (
+  id TEXT PRIMARY KEY NOT NULL,
+  slug TEXT NOT NULL UNIQUE,
+  display_name TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX households_slug_idx ON households(slug);
+
+CREATE TABLE household_memberships (
+  id TEXT PRIMARY KEY NOT NULL,
+  household_id TEXT NOT NULL REFERENCES households(id) ON DELETE CASCADE,
+  user_id TEXT NOT NULL REFERENCES user(id) ON DELETE CASCADE,
+  role TEXT NOT NULL CHECK (role IN ('owner', 'member')),
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (household_id, user_id)
+);
+
+CREATE INDEX household_memberships_household_id_idx ON household_memberships(household_id);
+CREATE INDEX household_memberships_user_id_idx ON household_memberships(user_id);
+
+INSERT INTO households (id, slug, display_name)
+VALUES ('00000000-0000-0000-0000-000000000001', 'home', 'Primary household');
+
+INSERT INTO household_memberships (id, household_id, user_id, role)
+SELECT
+  'membership-' || user.id,
+  '00000000-0000-0000-0000-000000000001',
+  user.id,
+  CASE
+    WHEN app_installation.owner_user_id IS NOT NULL AND user.id = app_installation.owner_user_id THEN 'owner'
+    ELSE 'member'
+  END
+FROM user
+LEFT JOIN app_installation ON app_installation.id = 1;
+
+CREATE TABLE providers (
+  id TEXT PRIMARY KEY NOT NULL,
+  household_id TEXT NOT NULL REFERENCES households(id) ON DELETE CASCADE,
+  provider_key TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX providers_household_id_provider_key_unique
+ON providers(household_id, provider_key);
+
+CREATE INDEX providers_household_id_idx ON providers(household_id);
+
+INSERT INTO providers (id, household_id, provider_key, display_name, created_at)
+SELECT
+  id,
+  '00000000-0000-0000-0000-000000000001',
+  provider_key,
+  display_name,
+  created_at
+FROM providers__legacy;
+
+CREATE TABLE household_member_provider_access (
+  id TEXT PRIMARY KEY NOT NULL,
+  household_membership_id TEXT NOT NULL REFERENCES household_memberships(id) ON DELETE CASCADE,
+  provider_id TEXT NOT NULL REFERENCES providers(id) ON DELETE CASCADE,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (household_membership_id, provider_id)
+);
+
+CREATE INDEX household_member_provider_access_membership_idx
+ON household_member_provider_access(household_membership_id);
+
+CREATE INDEX household_member_provider_access_provider_idx
+ON household_member_provider_access(provider_id);
+
+INSERT INTO household_member_provider_access (id, household_membership_id, provider_id, created_at)
+SELECT
+  user_provider_access__legacy.id,
+  household_memberships.id,
+  user_provider_access__legacy.provider_id,
+  user_provider_access__legacy.created_at
+FROM user_provider_access__legacy
+INNER JOIN household_memberships
+  ON household_memberships.household_id = '00000000-0000-0000-0000-000000000001'
+ AND household_memberships.user_id = user_provider_access__legacy.user_id;
+
+CREATE TABLE sender_rules (
+  id TEXT PRIMARY KEY NOT NULL,
+  household_id TEXT NOT NULL REFERENCES households(id) ON DELETE CASCADE,
+  provider_id TEXT NOT NULL REFERENCES providers(id) ON DELETE CASCADE,
+  match_type TEXT NOT NULL CHECK (match_type IN ('exact', 'domain')),
+  match_value TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (household_id, match_type, match_value)
+);
+
+CREATE INDEX idx_sender_rules_lookup ON sender_rules(household_id, match_type, match_value);
+
+INSERT INTO sender_rules (id, household_id, provider_id, match_type, match_value, created_at)
+SELECT
+  id,
+  '00000000-0000-0000-0000-000000000001',
+  provider_id,
+  match_type,
+  match_value,
+  created_at
+FROM sender_rules__legacy;
+
+CREATE TABLE messages (
+  id TEXT PRIMARY KEY NOT NULL,
+  message_id TEXT NOT NULL,
+  household_id TEXT NOT NULL REFERENCES households(id) ON DELETE CASCADE,
+  provider_id TEXT NOT NULL REFERENCES providers(id) ON DELETE CASCADE,
+  envelope_from TEXT NOT NULL,
+  envelope_to TEXT NOT NULL,
+  from_header TEXT,
+  subject TEXT,
+  text_body TEXT NOT NULL,
+  extracted_code TEXT,
+  status TEXT NOT NULL DEFAULT 'new' CHECK (status IN ('new', 'used', 'expired')),
+  classification_reason TEXT NOT NULL,
+  raw_size INTEGER NOT NULL,
+  received_at TEXT NOT NULL,
+  delete_after TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (household_id, message_id)
+);
+
+CREATE INDEX idx_messages_provider_received ON messages(household_id, provider_id, received_at DESC);
+CREATE INDEX idx_messages_household_received ON messages(household_id, received_at DESC);
+CREATE INDEX idx_messages_delete_after ON messages(delete_after);
+
+INSERT INTO messages (
+  id,
+  message_id,
+  household_id,
+  provider_id,
+  envelope_from,
+  envelope_to,
+  from_header,
+  subject,
+  text_body,
+  extracted_code,
+  status,
+  classification_reason,
+  raw_size,
+  received_at,
+  delete_after,
+  created_at
+)
+SELECT
+  id,
+  message_id,
+  '00000000-0000-0000-0000-000000000001',
+  provider_id,
+  envelope_from,
+  envelope_to,
+  from_header,
+  subject,
+  text_body,
+  extracted_code,
+  status,
+  classification_reason,
+  raw_size,
+  received_at,
+  delete_after,
+  created_at
+FROM messages__legacy;
+
+CREATE TABLE quarantine_messages (
+  id TEXT PRIMARY KEY NOT NULL,
+  message_id TEXT NOT NULL,
+  household_id TEXT NOT NULL REFERENCES households(id) ON DELETE CASCADE,
+  envelope_from TEXT NOT NULL,
+  envelope_to TEXT NOT NULL,
+  from_header TEXT,
+  subject TEXT,
+  text_body TEXT NOT NULL,
+  extracted_code TEXT,
+  quarantine_reason TEXT NOT NULL,
+  raw_size INTEGER NOT NULL,
+  received_at TEXT NOT NULL,
+  delete_after TEXT NOT NULL,
+  reviewed_at TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (household_id, message_id)
+);
+
+CREATE INDEX idx_quarantine_household_received ON quarantine_messages(household_id, received_at DESC);
+CREATE INDEX idx_quarantine_delete_after ON quarantine_messages(delete_after);
+
+INSERT INTO quarantine_messages (
+  id,
+  message_id,
+  household_id,
+  envelope_from,
+  envelope_to,
+  from_header,
+  subject,
+  text_body,
+  extracted_code,
+  quarantine_reason,
+  raw_size,
+  received_at,
+  delete_after,
+  reviewed_at,
+  created_at
+)
+SELECT
+  id,
+  message_id,
+  '00000000-0000-0000-0000-000000000001',
+  envelope_from,
+  envelope_to,
+  from_header,
+  subject,
+  text_body,
+  extracted_code,
+  quarantine_reason,
+  raw_size,
+  received_at,
+  delete_after,
+  reviewed_at,
+  created_at
+FROM quarantine_messages__legacy;
+
+CREATE TABLE household_invitations (
+  id TEXT PRIMARY KEY NOT NULL,
+  household_id TEXT NOT NULL REFERENCES households(id) ON DELETE CASCADE,
+  email TEXT NOT NULL,
+  name TEXT NOT NULL,
+  role TEXT NOT NULL CHECK (role IN ('member', 'owner')),
+  token_hash TEXT NOT NULL UNIQUE,
+  status TEXT NOT NULL CHECK (status IN ('pending', 'accepted', 'cancelled', 'expired')),
+  invited_by_user_id TEXT NOT NULL REFERENCES user(id) ON DELETE CASCADE,
+  accepted_by_user_id TEXT REFERENCES user(id) ON DELETE SET NULL,
+  expires_at TEXT NOT NULL,
+  accepted_at TEXT,
+  cancelled_at TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_household_invitations_household_id ON household_invitations(household_id);
+CREATE INDEX idx_household_invitations_email ON household_invitations(email);
+CREATE INDEX idx_household_invitations_status ON household_invitations(status);
+CREATE INDEX idx_household_invitations_expires_at ON household_invitations(expires_at);
+
+INSERT INTO household_invitations (
+  id,
+  household_id,
+  email,
+  name,
+  role,
+  token_hash,
+  status,
+  invited_by_user_id,
+  accepted_by_user_id,
+  expires_at,
+  accepted_at,
+  cancelled_at,
+  created_at,
+  updated_at
+)
+SELECT
+  id,
+  '00000000-0000-0000-0000-000000000001',
+  email,
+  name,
+  CASE WHEN role = 'admin' THEN 'owner' ELSE 'member' END,
+  token_hash,
+  status,
+  invited_by_user_id,
+  accepted_by_user_id,
+  expires_at,
+  accepted_at,
+  cancelled_at,
+  created_at,
+  updated_at
+FROM household_invitations__legacy;
+
+CREATE TABLE household_invitation_provider_access (
+  id TEXT PRIMARY KEY NOT NULL,
+  invitation_id TEXT NOT NULL REFERENCES household_invitations(id) ON DELETE CASCADE,
+  provider_id TEXT NOT NULL REFERENCES providers(id) ON DELETE CASCADE,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (invitation_id, provider_id)
+);
+
+INSERT INTO household_invitation_provider_access (id, invitation_id, provider_id, created_at)
+SELECT id, invitation_id, provider_id, created_at
+FROM household_invitation_provider_access__legacy;
+
+DROP TABLE household_invitation_provider_access__legacy;
+DROP TABLE household_invitations__legacy;
+DROP TABLE quarantine_messages__legacy;
+DROP TABLE messages__legacy;
+DROP TABLE user_provider_access__legacy;
+DROP TABLE sender_rules__legacy;
+DROP TABLE providers__legacy;
+
+PRAGMA foreign_keys = ON;

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -16,6 +16,7 @@ import {
   useParams,
 } from "react-router-dom";
 import { InboxView } from "./components/InboxView";
+import { CreateHouseholdPage } from "./components/CreateHouseholdPage";
 import { InvitePage } from "./components/InvitePage";
 import { Layout } from "./components/Layout";
 import { LoginPage } from "./components/LoginPage";
@@ -28,6 +29,8 @@ import type {
   AccountProfile,
   AccountSession,
   AccountSettingsFormState,
+  AccountSettingsResponse,
+  HouseholdSummary,
   InboxMessage,
   InvitationFormState,
   InvitationSummary,
@@ -44,7 +47,12 @@ import type {
   SenderRuleFormState,
   SetupStatus,
 } from "./types";
-import { fetchJson, getProviderAccessToggleRequest } from "./utils";
+import {
+  buildHouseholdApiPath,
+  buildHouseholdPath,
+  fetchJson,
+  getProviderAccessToggleRequest,
+} from "./utils";
 
 type ViewType = "inbox" | "quarantine" | "members" | "providers" | "settings";
 
@@ -63,7 +71,6 @@ const INITIAL_SETTINGS_FORM_STATE: AccountSettingsFormState = {
 const INITIAL_MEMBER_FORM_STATE: MemberFormState = {
   email: "",
   name: "",
-  password: "",
   role: "member",
 };
 
@@ -99,16 +106,24 @@ export function App() {
   );
   const navigate = useNavigate();
   const location = useLocation();
+  const routeSegments = location.pathname.split("/").filter(Boolean);
+  const routeSlug =
+    routeSegments[0] &&
+    !["login", "setup", "invite"].includes(routeSegments[0])
+      ? routeSegments[0]
+      : null;
 
-  const activeView: ViewType = location.pathname.startsWith("/settings")
+  const activeView: ViewType = location.pathname.includes("/settings")
     ? "settings"
-    : location.pathname.startsWith("/quarantine")
+    : location.pathname.includes("/quarantine")
       ? "quarantine"
-      : location.pathname.startsWith("/members")
+      : location.pathname.includes("/members")
         ? "members"
-        : location.pathname.startsWith("/providers")
+        : location.pathname.includes("/providers")
           ? "providers"
           : "inbox";
+  const [households, setHouseholds] = useState<HouseholdSummary[]>([]);
+  const [isLoadingHouseholds, setIsLoadingHouseholds] = useState(false);
   const [providers, setProviders] = useState<ProviderSummary[]>([]);
   const [selectedProviderKey, setSelectedProviderKey] = useState<string | null>(
     null,
@@ -174,7 +189,18 @@ export function App() {
   const [viewError, setViewError] = useState<string | null>(null);
 
   const isAuthenticated = Boolean(session?.user?.email);
-  const isOwner = session?.user?.role === "admin";
+  const currentHousehold = routeSlug
+    ? households.find((household) => household.slug === routeSlug) ?? null
+    : null;
+  const defaultHousehold = households[0] ?? null;
+  const isOwner = currentHousehold?.role === "owner";
+  const householdApiPath = (path: string) => {
+    if (!currentHousehold) {
+      throw new Error("No household selected");
+    }
+
+    return buildHouseholdApiPath(currentHousehold.slug, path);
+  };
 
   const handleSnackbarClose = () => {
     setStatusMessage(null);
@@ -191,13 +217,72 @@ export function App() {
     return (
       <InvitePage
         token={token}
-        onAcceptSuccess={() => {
-          navigate("/inbox", { replace: true });
+        onAcceptSuccess={(householdSlug) => {
+          navigate(buildHouseholdPath(householdSlug, "/inbox"), { replace: true });
           void refetch();
         }}
       />
     );
   }
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setHouseholds([]);
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadHouseholds = async () => {
+      setIsLoadingHouseholds(true);
+
+      try {
+        const response = await fetchJson<{ households: HouseholdSummary[] }>(
+          "/api/settings/households",
+        );
+
+        if (cancelled) return;
+
+        setHouseholds(response.households);
+      } catch (error) {
+        if (!cancelled) {
+          setViewError(
+            error instanceof Error ? error.message : "Unable to load households",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingHouseholds(false);
+        }
+      }
+    };
+
+    void loadHouseholds();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated]);
+
+  useEffect(() => {
+    if (!isAuthenticated || isLoadingHouseholds || households.length === 0) {
+      return;
+    }
+
+    if (!routeSlug || !currentHousehold) {
+      navigate(buildHouseholdPath(defaultHousehold?.slug ?? households[0].slug, "/inbox"), {
+        replace: true,
+      });
+    }
+  }, [
+    currentHousehold,
+    defaultHousehold,
+    households,
+    isAuthenticated,
+    isLoadingHouseholds,
+    navigate,
+    routeSlug,
+  ]);
 
   useEffect(() => {
     if (!isAuthenticated || activeView !== "settings") {
@@ -210,15 +295,13 @@ export function App() {
       setIsLoadingSettings(true);
 
       try {
-        const response = await fetchJson<{
-          profile: AccountProfile;
-          sessions: AccountSession[];
-        }>("/api/settings");
+        const response = await fetchJson<AccountSettingsResponse>("/api/settings");
 
         if (cancelled) return;
 
         setProfile(response.profile);
         setSettingsSessions(response.sessions);
+        setHouseholds(response.profile.households);
         setSettingsFormState((current) => ({
           ...current,
           name: response.profile.name,
@@ -246,12 +329,10 @@ export function App() {
 
   async function refreshSettings() {
     if (!isAuthenticated) return;
-    const response = await fetchJson<{
-      profile: AccountProfile;
-      sessions: AccountSession[];
-    }>("/api/settings");
+    const response = await fetchJson<AccountSettingsResponse>("/api/settings");
     setProfile(response.profile);
     setSettingsSessions(response.sessions);
+    setHouseholds(response.profile.households);
   }
 
   async function handleUpdateProfile(event: FormEvent<HTMLFormElement>) {
@@ -482,7 +563,7 @@ export function App() {
     }
 
     if (!status.needsSetup && location.pathname === "/setup") {
-      navigate("/inbox", { replace: true });
+      navigate("/", { replace: true });
       return;
     }
   }
@@ -505,7 +586,7 @@ export function App() {
         if (status.needsSetup && location.pathname !== "/setup") {
           navigate("/setup", { replace: true });
         } else if (!status.needsSetup && location.pathname === "/setup") {
-          navigate("/inbox", { replace: true });
+          navigate("/", { replace: true });
         }
       } catch (error) {
         if (!cancelled) {
@@ -530,7 +611,7 @@ export function App() {
   }, [location.pathname, navigate]);
 
   useEffect(() => {
-    if (!isAuthenticated) {
+    if (!isAuthenticated || !currentHousehold) {
       setProviders([]);
       setMessages([]);
       setQuarantineMessages([]);
@@ -561,7 +642,7 @@ export function App() {
 
       try {
         const response = await fetchJson<{ providers: ProviderSummary[] }>(
-          "/api/inbox/providers",
+          householdApiPath("/inbox/providers"),
         );
 
         if (cancelled) return;
@@ -603,10 +684,10 @@ export function App() {
     return () => {
       cancelled = true;
     };
-  }, [isAuthenticated]);
+  }, [currentHousehold, isAuthenticated]);
 
   useEffect(() => {
-    if (!isAuthenticated || !selectedProviderKey) {
+    if (!isAuthenticated || !currentHousehold || !selectedProviderKey) {
       setMessages([]);
       setSelectedMessageId(null);
       return;
@@ -620,7 +701,7 @@ export function App() {
 
       try {
         const response = await fetchJson<ProviderMessagesResponse>(
-          `/api/inbox/providers/${selectedProviderKey}`,
+          householdApiPath(`/inbox/providers/${selectedProviderKey}`),
         );
 
         if (cancelled) return;
@@ -650,10 +731,10 @@ export function App() {
     return () => {
       cancelled = true;
     };
-  }, [isAuthenticated, selectedProviderKey]);
+  }, [currentHousehold, isAuthenticated, selectedProviderKey]);
 
   useEffect(() => {
-    if (!isAuthenticated || !isOwner || activeView !== "quarantine") {
+    if (!isAuthenticated || !isOwner || !currentHousehold || activeView !== "quarantine") {
       return;
     }
 
@@ -664,7 +745,7 @@ export function App() {
 
       try {
         const response = await fetchJson<{ messages: QuarantineMessage[] }>(
-          "/api/inbox/quarantine",
+          householdApiPath("/inbox/quarantine"),
         );
 
         if (cancelled) return;
@@ -696,10 +777,10 @@ export function App() {
     return () => {
       cancelled = true;
     };
-  }, [isAuthenticated, isOwner, activeView]);
+  }, [activeView, currentHousehold, isAuthenticated, isOwner]);
 
   useEffect(() => {
-    if (!isAuthenticated || !isOwner || activeView !== "providers") {
+    if (!isAuthenticated || !isOwner || !currentHousehold || activeView !== "providers") {
       return;
     }
 
@@ -710,7 +791,7 @@ export function App() {
 
       try {
         const response = await fetchJson<ProviderConfigurationResponse>(
-          "/api/admin/providers",
+          householdApiPath("/admin/providers"),
         );
 
         if (cancelled) return;
@@ -786,13 +867,14 @@ export function App() {
   }, [
     isAuthenticated,
     isOwner,
+    currentHousehold,
     activeView,
     selectedProviderId,
     selectedRuleId,
   ]);
 
   useEffect(() => {
-    if (!isAuthenticated || !isOwner || activeView !== "members") {
+    if (!isAuthenticated || !isOwner || !currentHousehold || activeView !== "members") {
       return;
     }
 
@@ -806,9 +888,9 @@ export function App() {
           fetchJson<{
             members: MemberSummary[];
             providers: ProviderOption[];
-          }>("/api/admin/members"),
+          }>(householdApiPath("/admin/members")),
           fetchJson<{ invitations: InvitationSummary[] }>(
-            "/api/admin/invitations",
+            householdApiPath("/admin/invitations"),
           ),
         ]);
 
@@ -844,12 +926,12 @@ export function App() {
     return () => {
       cancelled = true;
     };
-  }, [isAuthenticated, isOwner, activeView]);
+  }, [activeView, currentHousehold, isAuthenticated, isOwner]);
 
   async function refreshProviders() {
-    if (!isAuthenticated) return;
+    if (!isAuthenticated || !currentHousehold) return;
     const response = await fetchJson<{ providers: ProviderSummary[] }>(
-      "/api/inbox/providers",
+      householdApiPath("/inbox/providers"),
     );
     setProviders(response.providers);
     setReleaseProviderKey((current) => {
@@ -864,9 +946,9 @@ export function App() {
   }
 
   async function refreshQuarantine() {
-    if (!isAuthenticated || !isOwner) return;
+    if (!isAuthenticated || !isOwner || !currentHousehold) return;
     const response = await fetchJson<{ messages: QuarantineMessage[] }>(
-      "/api/inbox/quarantine",
+      householdApiPath("/inbox/quarantine"),
     );
     setQuarantineMessages(response.messages);
     setSelectedQuarantineId((current) => {
@@ -878,11 +960,11 @@ export function App() {
   }
 
   async function refreshMembers() {
-    if (!isAuthenticated || !isOwner) return;
+    if (!isAuthenticated || !isOwner || !currentHousehold) return;
     const response = await fetchJson<{
       members: MemberSummary[];
       providers: ProviderOption[];
-    }>("/api/admin/members");
+    }>(householdApiPath("/admin/members"));
     setMembers(response.members);
     setProviderOptions(response.providers);
     setSelectedMemberId((current) => {
@@ -894,18 +976,18 @@ export function App() {
   }
 
   async function refreshInvitations() {
-    if (!isAuthenticated || !isOwner) return;
+    if (!isAuthenticated || !isOwner || !currentHousehold) return;
     const response = await fetchJson<{ invitations: InvitationSummary[] }>(
-      "/api/admin/invitations",
+      householdApiPath("/admin/invitations"),
     );
     setInvitations(response.invitations);
   }
 
   async function refreshProviderConfigurations() {
-    if (!isAuthenticated || !isOwner) return;
+    if (!isAuthenticated || !isOwner || !currentHousehold) return;
 
     const response = await fetchJson<ProviderConfigurationResponse>(
-      "/api/admin/providers",
+      householdApiPath("/admin/providers"),
     );
 
     setProviderConfigurations(response.providers);
@@ -946,8 +1028,8 @@ export function App() {
     setViewError(null);
 
     try {
-      const response = await fetchJson<{ message: InboxMessage }>(
-        `/api/inbox/messages/${selectedMessageId}/status`,
+        const response = await fetchJson<{ message: InboxMessage }>(
+        householdApiPath(`/inbox/messages/${selectedMessageId}/status`),
         {
           method: "PATCH",
           body: JSON.stringify({ status: nextStatus }),
@@ -982,7 +1064,7 @@ export function App() {
     setViewError(null);
 
     try {
-      await fetchJson(`/api/inbox/quarantine/${selectedQuarantineId}/review`, {
+      await fetchJson(householdApiPath(`/inbox/quarantine/${selectedQuarantineId}/review`), {
         method: "POST",
         body: JSON.stringify(
           action === "release"
@@ -1018,20 +1100,20 @@ export function App() {
     setViewError(null);
 
     try {
-      await fetchJson<{ member: unknown }>("/api/admin/members", {
+      await fetchJson<{ invitation: InvitationSummary }>(householdApiPath("/admin/members"), {
         method: "POST",
         body: JSON.stringify(memberFormState),
       });
 
       setMemberFormState(INITIAL_MEMBER_FORM_STATE);
-      setStatusMessage("Household member created.");
-      await refreshMembers();
+      setStatusMessage("Invitation email sent.");
+      await refreshInvitations();
       return true;
     } catch (error) {
       setViewError(
         error instanceof Error
           ? error.message
-          : "Unable to create household member",
+          : "Unable to create household invitation",
       );
       return false;
     } finally {
@@ -1049,7 +1131,7 @@ export function App() {
 
     try {
       await fetchJson<{ invitation: InvitationSummary }>(
-        "/api/admin/invitations",
+        householdApiPath("/admin/invitations"),
         {
           method: "POST",
           body: JSON.stringify(invitationFormState),
@@ -1077,7 +1159,7 @@ export function App() {
 
     try {
       await fetchJson<{ invitation: InvitationSummary }>(
-        `/api/admin/invitations/${invitationId}/resend`,
+        householdApiPath(`/admin/invitations/${invitationId}/resend`),
         {
           method: "POST",
         },
@@ -1102,7 +1184,7 @@ export function App() {
     setViewError(null);
 
     try {
-      await fetchJson(`/api/admin/invitations/${invitationId}`, {
+      await fetchJson(householdApiPath(`/admin/invitations/${invitationId}`), {
         method: "DELETE",
       });
 
@@ -1127,7 +1209,7 @@ export function App() {
     setViewError(null);
 
     try {
-      await fetchJson<{ ok: boolean }>(`/api/admin/members/${userId}/role`, {
+      await fetchJson<{ ok: boolean }>(householdApiPath(`/admin/members/${userId}/role`), {
         method: "PATCH",
         body: JSON.stringify({ role }),
       });
@@ -1159,7 +1241,7 @@ export function App() {
         getProviderAccessToggleRequest(shouldHaveAccess);
 
       await fetchJson<{ ok: boolean }>(
-        `/api/admin/members/${userId}/provider-access`,
+        householdApiPath(`/admin/members/${userId}/provider-access`),
         {
           method,
           body: JSON.stringify({ providerKey }),
@@ -1188,7 +1270,7 @@ export function App() {
 
     try {
       await fetchJson<{ provider: ProviderConfiguration }>(
-        "/api/admin/providers",
+        householdApiPath("/admin/providers"),
         {
           method: "POST",
           body: JSON.stringify(providerFormState),
@@ -1222,7 +1304,7 @@ export function App() {
 
     try {
       await fetchJson<{ provider: ProviderConfiguration }>(
-        `/api/admin/providers/${selectedProviderId}`,
+        householdApiPath(`/admin/providers/${selectedProviderId}`),
         {
           method: "PATCH",
           body: JSON.stringify(providerFormState),
@@ -1255,7 +1337,7 @@ export function App() {
 
     try {
       await fetchJson<{ ok: boolean }>(
-        `/api/admin/providers/${selectedProviderId}`,
+        householdApiPath(`/admin/providers/${selectedProviderId}`),
         {
           method: "DELETE",
         },
@@ -1289,7 +1371,7 @@ export function App() {
     setIsSavingProviderConfiguration(true);
 
     try {
-      await fetchJson<{ rule: SenderRule }>("/api/admin/provider-rules", {
+      await fetchJson<{ rule: SenderRule }>(householdApiPath("/admin/provider-rules"), {
         method: "POST",
         body: JSON.stringify(ruleFormState),
       });
@@ -1324,7 +1406,7 @@ export function App() {
 
     try {
       await fetchJson<{ rule: SenderRule }>(
-        `/api/admin/provider-rules/${selectedRuleId}`,
+        householdApiPath(`/admin/provider-rules/${selectedRuleId}`),
         {
           method: "PATCH",
           body: JSON.stringify(ruleFormState),
@@ -1357,7 +1439,7 @@ export function App() {
 
     try {
       await fetchJson<{ ok: boolean }>(
-        `/api/admin/provider-rules/${selectedRuleId}`,
+        householdApiPath(`/admin/provider-rules/${selectedRuleId}`),
         {
           method: "DELETE",
         },
@@ -1384,7 +1466,7 @@ export function App() {
     }
   }
 
-  if (isSessionPending || isCheckingSetup) {
+  if (isSessionPending || isCheckingSetup || (isAuthenticated && isLoadingHouseholds)) {
     return (
       <Box
         sx={{
@@ -1452,12 +1534,41 @@ export function App() {
     );
   }
 
+  if (households.length === 0) {
+    return (
+      <CreateHouseholdPage
+        onCreated={(household) => {
+          setHouseholds([household]);
+          navigate(buildHouseholdPath(household.slug, "/inbox"), { replace: true });
+        }}
+      />
+    );
+  }
+
+  if (!currentHousehold) {
+    return null;
+  }
+
   return (
-    <Layout session={session} isOwner={isOwner} onLogout={handleLogout}>
+    <Layout
+      session={session}
+      isOwner={isOwner}
+      householdSlug={currentHousehold.slug}
+      householdName={currentHousehold.displayName}
+      onLogout={handleLogout}
+    >
       <Routes>
-        <Route path="/" element={<Navigate to="/inbox" replace />} />
         <Route
-          path="/inbox"
+          path="/"
+          element={
+            <Navigate
+              to={buildHouseholdPath(currentHousehold.slug, "/inbox")}
+              replace
+            />
+          }
+        />
+        <Route
+          path="/:slug/inbox"
           element={
             <InboxView
               providers={providers}
@@ -1473,7 +1584,7 @@ export function App() {
           }
         />
         <Route
-          path="/settings"
+          path="/:slug/settings"
           element={
             <SettingsView
               profile={profile}
@@ -1497,7 +1608,7 @@ export function App() {
           }
         />
         <Route
-          path="/quarantine"
+          path="/:slug/quarantine"
           element={
             isOwner ? (
               <QuarantineView
@@ -1512,12 +1623,15 @@ export function App() {
                 onQuarantineReview={handleQuarantineReview}
               />
             ) : (
-              <Navigate to="/inbox" replace />
+              <Navigate
+                to={buildHouseholdPath(currentHousehold.slug, "/inbox")}
+                replace
+              />
             )
           }
         />
         <Route
-          path="/members"
+          path="/:slug/members"
           element={
             isOwner ? (
               <MembersView
@@ -1548,12 +1662,15 @@ export function App() {
                 onProviderAccessToggle={handleProviderAccessToggle}
               />
             ) : (
-              <Navigate to="/inbox" replace />
+              <Navigate
+                to={buildHouseholdPath(currentHousehold.slug, "/inbox")}
+                replace
+              />
             )
           }
         />
         <Route
-          path="/providers"
+          path="/:slug/providers"
           element={
             isOwner ? (
               <ProvidersRulesView
@@ -1625,11 +1742,22 @@ export function App() {
                 onDeleteRule={handleDeleteRule}
               />
             ) : (
-              <Navigate to="/inbox" replace />
+              <Navigate
+                to={buildHouseholdPath(currentHousehold.slug, "/inbox")}
+                replace
+              />
             )
           }
         />
-        <Route path="*" element={<Navigate to="/inbox" replace />} />
+        <Route
+          path="*"
+          element={
+            <Navigate
+              to={buildHouseholdPath(currentHousehold.slug, "/inbox")}
+              replace
+            />
+          }
+        />
       </Routes>
 
       <Snackbar

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -6,7 +6,7 @@ import {
   Typography,
 } from "@mui/material";
 import { authClient } from "@server/auth/client";
-import { type FormEvent, useEffect, useState } from "react";
+import { type FormEvent, useCallback, useEffect, useState } from "react";
 import {
   Navigate,
   Route,
@@ -15,8 +15,8 @@ import {
   useNavigate,
   useParams,
 } from "react-router-dom";
-import { InboxView } from "./components/InboxView";
 import { CreateHouseholdPage } from "./components/CreateHouseholdPage";
+import { InboxView } from "./components/InboxView";
 import { InvitePage } from "./components/InvitePage";
 import { Layout } from "./components/Layout";
 import { LoginPage } from "./components/LoginPage";
@@ -108,8 +108,7 @@ export function App() {
   const location = useLocation();
   const routeSegments = location.pathname.split("/").filter(Boolean);
   const routeSlug =
-    routeSegments[0] &&
-    !["login", "setup", "invite"].includes(routeSegments[0])
+    routeSegments[0] && !["login", "setup", "invite"].includes(routeSegments[0])
       ? routeSegments[0]
       : null;
 
@@ -190,17 +189,20 @@ export function App() {
 
   const isAuthenticated = Boolean(session?.user?.email);
   const currentHousehold = routeSlug
-    ? households.find((household) => household.slug === routeSlug) ?? null
+    ? (households.find((household) => household.slug === routeSlug) ?? null)
     : null;
   const defaultHousehold = households[0] ?? null;
   const isOwner = currentHousehold?.role === "owner";
-  const householdApiPath = (path: string) => {
-    if (!currentHousehold) {
-      throw new Error("No household selected");
-    }
+  const householdApiPath = useCallback(
+    (path: string) => {
+      if (!currentHousehold) {
+        throw new Error("No household selected");
+      }
 
-    return buildHouseholdApiPath(currentHousehold.slug, path);
-  };
+      return buildHouseholdApiPath(currentHousehold.slug, path);
+    },
+    [currentHousehold],
+  );
 
   const handleSnackbarClose = () => {
     setStatusMessage(null);
@@ -218,7 +220,9 @@ export function App() {
       <InvitePage
         token={token}
         onAcceptSuccess={(householdSlug) => {
-          navigate(buildHouseholdPath(householdSlug, "/inbox"), { replace: true });
+          navigate(buildHouseholdPath(householdSlug, "/inbox"), {
+            replace: true,
+          });
           void refetch();
         }}
       />
@@ -247,7 +251,9 @@ export function App() {
       } catch (error) {
         if (!cancelled) {
           setViewError(
-            error instanceof Error ? error.message : "Unable to load households",
+            error instanceof Error
+              ? error.message
+              : "Unable to load households",
           );
         }
       } finally {
@@ -270,9 +276,15 @@ export function App() {
     }
 
     if (!routeSlug || !currentHousehold) {
-      navigate(buildHouseholdPath(defaultHousehold?.slug ?? households[0].slug, "/inbox"), {
-        replace: true,
-      });
+      navigate(
+        buildHouseholdPath(
+          defaultHousehold?.slug ?? households[0].slug,
+          "/inbox",
+        ),
+        {
+          replace: true,
+        },
+      );
     }
   }, [
     currentHousehold,
@@ -295,7 +307,8 @@ export function App() {
       setIsLoadingSettings(true);
 
       try {
-        const response = await fetchJson<AccountSettingsResponse>("/api/settings");
+        const response =
+          await fetchJson<AccountSettingsResponse>("/api/settings");
 
         if (cancelled) return;
 
@@ -684,7 +697,7 @@ export function App() {
     return () => {
       cancelled = true;
     };
-  }, [currentHousehold, isAuthenticated]);
+  }, [currentHousehold, householdApiPath, isAuthenticated]);
 
   useEffect(() => {
     if (!isAuthenticated || !currentHousehold || !selectedProviderKey) {
@@ -731,10 +744,20 @@ export function App() {
     return () => {
       cancelled = true;
     };
-  }, [currentHousehold, isAuthenticated, selectedProviderKey]);
+  }, [
+    currentHousehold,
+    householdApiPath,
+    isAuthenticated,
+    selectedProviderKey,
+  ]);
 
   useEffect(() => {
-    if (!isAuthenticated || !isOwner || !currentHousehold || activeView !== "quarantine") {
+    if (
+      !isAuthenticated ||
+      !isOwner ||
+      !currentHousehold ||
+      activeView !== "quarantine"
+    ) {
       return;
     }
 
@@ -777,10 +800,21 @@ export function App() {
     return () => {
       cancelled = true;
     };
-  }, [activeView, currentHousehold, isAuthenticated, isOwner]);
+  }, [
+    activeView,
+    currentHousehold,
+    householdApiPath,
+    isAuthenticated,
+    isOwner,
+  ]);
 
   useEffect(() => {
-    if (!isAuthenticated || !isOwner || !currentHousehold || activeView !== "providers") {
+    if (
+      !isAuthenticated ||
+      !isOwner ||
+      !currentHousehold ||
+      activeView !== "providers"
+    ) {
       return;
     }
 
@@ -871,10 +905,16 @@ export function App() {
     activeView,
     selectedProviderId,
     selectedRuleId,
+    householdApiPath,
   ]);
 
   useEffect(() => {
-    if (!isAuthenticated || !isOwner || !currentHousehold || activeView !== "members") {
+    if (
+      !isAuthenticated ||
+      !isOwner ||
+      !currentHousehold ||
+      activeView !== "members"
+    ) {
       return;
     }
 
@@ -926,7 +966,13 @@ export function App() {
     return () => {
       cancelled = true;
     };
-  }, [activeView, currentHousehold, isAuthenticated, isOwner]);
+  }, [
+    activeView,
+    currentHousehold,
+    householdApiPath,
+    isAuthenticated,
+    isOwner,
+  ]);
 
   async function refreshProviders() {
     if (!isAuthenticated || !currentHousehold) return;
@@ -1028,7 +1074,7 @@ export function App() {
     setViewError(null);
 
     try {
-        const response = await fetchJson<{ message: InboxMessage }>(
+      const response = await fetchJson<{ message: InboxMessage }>(
         householdApiPath(`/inbox/messages/${selectedMessageId}/status`),
         {
           method: "PATCH",
@@ -1064,14 +1110,17 @@ export function App() {
     setViewError(null);
 
     try {
-      await fetchJson(householdApiPath(`/inbox/quarantine/${selectedQuarantineId}/review`), {
-        method: "POST",
-        body: JSON.stringify(
-          action === "release"
-            ? { action, providerKey: releaseProviderKey }
-            : { action },
-        ),
-      });
+      await fetchJson(
+        householdApiPath(`/inbox/quarantine/${selectedQuarantineId}/review`),
+        {
+          method: "POST",
+          body: JSON.stringify(
+            action === "release"
+              ? { action, providerKey: releaseProviderKey }
+              : { action },
+          ),
+        },
+      );
 
       setStatusMessage(
         action === "release"
@@ -1100,10 +1149,13 @@ export function App() {
     setViewError(null);
 
     try {
-      await fetchJson<{ invitation: InvitationSummary }>(householdApiPath("/admin/members"), {
-        method: "POST",
-        body: JSON.stringify(memberFormState),
-      });
+      await fetchJson<{ invitation: InvitationSummary }>(
+        householdApiPath("/admin/members"),
+        {
+          method: "POST",
+          body: JSON.stringify(memberFormState),
+        },
+      );
 
       setMemberFormState(INITIAL_MEMBER_FORM_STATE);
       setStatusMessage("Invitation email sent.");
@@ -1209,10 +1261,13 @@ export function App() {
     setViewError(null);
 
     try {
-      await fetchJson<{ ok: boolean }>(householdApiPath(`/admin/members/${userId}/role`), {
-        method: "PATCH",
-        body: JSON.stringify({ role }),
-      });
+      await fetchJson<{ ok: boolean }>(
+        householdApiPath(`/admin/members/${userId}/role`),
+        {
+          method: "PATCH",
+          body: JSON.stringify({ role }),
+        },
+      );
 
       setStatusMessage(`Updated member role to ${role}.`);
       await refreshMembers();
@@ -1371,10 +1426,13 @@ export function App() {
     setIsSavingProviderConfiguration(true);
 
     try {
-      await fetchJson<{ rule: SenderRule }>(householdApiPath("/admin/provider-rules"), {
-        method: "POST",
-        body: JSON.stringify(ruleFormState),
-      });
+      await fetchJson<{ rule: SenderRule }>(
+        householdApiPath("/admin/provider-rules"),
+        {
+          method: "POST",
+          body: JSON.stringify(ruleFormState),
+        },
+      );
 
       setRuleFormState((current) => ({
         ...INITIAL_RULE_FORM_STATE,
@@ -1466,7 +1524,11 @@ export function App() {
     }
   }
 
-  if (isSessionPending || isCheckingSetup || (isAuthenticated && isLoadingHouseholds)) {
+  if (
+    isSessionPending ||
+    isCheckingSetup ||
+    (isAuthenticated && isLoadingHouseholds)
+  ) {
     return (
       <Box
         sx={{
@@ -1539,7 +1601,9 @@ export function App() {
       <CreateHouseholdPage
         onCreated={(household) => {
           setHouseholds([household]);
-          navigate(buildHouseholdPath(household.slug, "/inbox"), { replace: true });
+          navigate(buildHouseholdPath(household.slug, "/inbox"), {
+            replace: true,
+          });
         }}
       />
     );

--- a/src/client/components/CreateHouseholdPage.tsx
+++ b/src/client/components/CreateHouseholdPage.tsx
@@ -79,8 +79,8 @@ export function CreateHouseholdPage({ onCreated }: CreateHouseholdPageProps) {
               You need a household to continue.
             </Typography>
             <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
-              Pick the household name your members will see and the immutable slug
-              used in URLs and inbound email addresses.
+              Pick the household name your members will see and the immutable
+              slug used in URLs and inbound email addresses.
             </Typography>
 
             <Box component="form" onSubmit={handleSubmit} noValidate>
@@ -125,7 +125,9 @@ export function CreateHouseholdPage({ onCreated }: CreateHouseholdPageProps) {
                 variant="contained"
                 size="large"
                 disabled={
-                  isCreating || !formState.displayName.trim() || !formState.slug.trim()
+                  isCreating ||
+                  !formState.displayName.trim() ||
+                  !formState.slug.trim()
                 }
                 sx={{ py: 1.5 }}
               >

--- a/src/client/components/CreateHouseholdPage.tsx
+++ b/src/client/components/CreateHouseholdPage.tsx
@@ -1,0 +1,140 @@
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Container,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { type FormEvent, useState } from "react";
+import type { CreateHouseholdFormState, HouseholdSummary } from "../types";
+import { fetchJson } from "../utils";
+
+interface CreateHouseholdPageProps {
+  onCreated: (household: HouseholdSummary) => void;
+}
+
+export function CreateHouseholdPage({ onCreated }: CreateHouseholdPageProps) {
+  const [formState, setFormState] = useState<CreateHouseholdFormState>({
+    displayName: "",
+    slug: "",
+  });
+  const [error, setError] = useState<string | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setIsCreating(true);
+
+    try {
+      const response = await fetchJson<{ household: HouseholdSummary }>(
+        "/api/households",
+        {
+          method: "POST",
+          body: JSON.stringify(formState),
+        },
+      );
+
+      onCreated(response.household);
+    } catch (submitError) {
+      setError(
+        submitError instanceof Error
+          ? submitError.message
+          : "Unable to create household",
+      );
+    } finally {
+      setIsCreating(false);
+    }
+  }
+
+  return (
+    <Container component="main" maxWidth="sm">
+      <Box
+        sx={{
+          minHeight: "100vh",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          py: 4,
+        }}
+      >
+        <Card elevation={3} sx={{ borderRadius: 3 }}>
+          <CardContent sx={{ p: 4 }}>
+            <Typography
+              variant="overline"
+              color="text.secondary"
+              sx={{ fontWeight: "bold", letterSpacing: 1 }}
+            >
+              Create your household
+            </Typography>
+            <Typography
+              variant="h4"
+              component="h1"
+              gutterBottom
+              sx={{ mt: 1, fontWeight: "bold" }}
+            >
+              You need a household to continue.
+            </Typography>
+            <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
+              Pick the household name your members will see and the immutable slug
+              used in URLs and inbound email addresses.
+            </Typography>
+
+            <Box component="form" onSubmit={handleSubmit} noValidate>
+              <TextField
+                margin="normal"
+                required
+                fullWidth
+                label="Household name"
+                value={formState.displayName}
+                onChange={(e) =>
+                  setFormState((current) => ({
+                    ...current,
+                    displayName: e.target.value,
+                  }))
+                }
+              />
+              <TextField
+                margin="normal"
+                required
+                fullWidth
+                label="Household slug"
+                helperText="Lowercase letters, numbers, and hyphens only. This cannot be changed later."
+                value={formState.slug}
+                onChange={(e) =>
+                  setFormState((current) => ({
+                    ...current,
+                    slug: e.target.value.toLowerCase(),
+                  }))
+                }
+                sx={{ mb: 3 }}
+              />
+
+              {error && (
+                <Alert severity="error" sx={{ mb: 3 }}>
+                  {error}
+                </Alert>
+              )}
+
+              <Button
+                type="submit"
+                fullWidth
+                variant="contained"
+                size="large"
+                disabled={
+                  isCreating || !formState.displayName.trim() || !formState.slug.trim()
+                }
+                sx={{ py: 1.5 }}
+              >
+                {isCreating ? "Creating household…" : "Create household"}
+              </Button>
+            </Box>
+          </CardContent>
+        </Card>
+      </Box>
+    </Container>
+  );
+}

--- a/src/client/components/InvitePage.tsx
+++ b/src/client/components/InvitePage.tsx
@@ -16,7 +16,7 @@ import { fetchJson } from "../utils";
 
 interface InvitePageProps {
   token: string;
-  onAcceptSuccess: () => void;
+  onAcceptSuccess: (householdSlug: string) => void;
 }
 
 export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
@@ -76,15 +76,22 @@ export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
     setIsAccepting(true);
 
     try {
-      await fetchJson(`/api/invitations/${token}/accept`, {
-        method: "POST",
-        body: JSON.stringify({
-          name: formState.name,
-          password: formState.password,
-        }),
-      });
+      const response = await fetchJson<{ household?: { slug: string } | null }>(
+        `/api/invitations/${token}/accept`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            name: formState.name,
+            password: formState.password,
+          }),
+        },
+      );
 
-      onAcceptSuccess();
+      if (!response.household?.slug) {
+        throw new Error("Invitation accepted but no household was returned");
+      }
+
+      onAcceptSuccess(response.household.slug);
     } catch (err) {
       setError(
         err instanceof Error ? err.message : "Unable to accept invitation",

--- a/src/client/components/Layout.tsx
+++ b/src/client/components/Layout.tsx
@@ -30,7 +30,7 @@ import { useContext, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { ColorModeContext } from "../theme";
 import type { SessionData } from "../types";
-import { getDisplayName } from "../utils";
+import { buildHouseholdPath, getDisplayName } from "../utils";
 
 const DRAWER_WIDTH = 280;
 
@@ -38,18 +38,27 @@ interface LayoutProps {
   children: React.ReactNode;
   session: SessionData | null | undefined;
   isOwner: boolean;
+  householdSlug: string;
+  householdName: string;
   onLogout: () => void;
 }
 
-export function Layout({ children, session, isOwner, onLogout }: LayoutProps) {
+export function Layout({
+  children,
+  session,
+  isOwner,
+  householdSlug,
+  householdName,
+  onLogout,
+}: LayoutProps) {
   const location = useLocation();
-  const activeView = location.pathname.startsWith("/settings")
+  const activeView = location.pathname.includes("/settings")
     ? "settings"
-    : location.pathname.startsWith("/quarantine")
+    : location.pathname.includes("/quarantine")
       ? "quarantine"
-      : location.pathname.startsWith("/members")
+      : location.pathname.includes("/members")
         ? "members"
-        : location.pathname.startsWith("/providers")
+        : location.pathname.includes("/providers")
           ? "providers"
           : "inbox";
   const theme = useTheme();
@@ -82,7 +91,7 @@ export function Layout({ children, session, isOwner, onLogout }: LayoutProps) {
       <Divider />
       <Box sx={{ p: 2 }}>
         <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-          Access: {isOwner ? "Owner" : "Family member"}
+          {householdName} · {isOwner ? "Owner" : "Family member"}
         </Typography>
         <Typography variant="body2" noWrap title={session?.user?.email ?? ""}>
           {session?.user?.email}
@@ -94,7 +103,7 @@ export function Layout({ children, session, isOwner, onLogout }: LayoutProps) {
           <ListItemButton
             selected={activeView === "inbox"}
             component={Link}
-            to="/inbox"
+            to={buildHouseholdPath(householdSlug, "/inbox")}
             onClick={handleNavClick}
             sx={{ borderRadius: 2 }}
           >
@@ -121,7 +130,7 @@ export function Layout({ children, session, isOwner, onLogout }: LayoutProps) {
           <ListItemButton
             selected={activeView === "settings"}
             component={Link}
-            to="/settings"
+            to={buildHouseholdPath(householdSlug, "/settings")}
             onClick={handleNavClick}
             sx={{ borderRadius: 2 }}
           >
@@ -150,7 +159,7 @@ export function Layout({ children, session, isOwner, onLogout }: LayoutProps) {
               <ListItemButton
                 selected={activeView === "quarantine"}
                 component={Link}
-                to="/quarantine"
+                to={buildHouseholdPath(householdSlug, "/quarantine")}
                 onClick={handleNavClick}
                 sx={{ borderRadius: 2 }}
               >
@@ -178,7 +187,7 @@ export function Layout({ children, session, isOwner, onLogout }: LayoutProps) {
               <ListItemButton
                 selected={activeView === "members"}
                 component={Link}
-                to="/members"
+                to={buildHouseholdPath(householdSlug, "/members")}
                 onClick={handleNavClick}
                 sx={{ borderRadius: 2 }}
               >
@@ -206,7 +215,7 @@ export function Layout({ children, session, isOwner, onLogout }: LayoutProps) {
               <ListItemButton
                 selected={activeView === "providers"}
                 component={Link}
-                to="/providers"
+                to={buildHouseholdPath(householdSlug, "/providers")}
                 onClick={handleNavClick}
                 sx={{ borderRadius: 2 }}
               >

--- a/src/client/components/MembersView.tsx
+++ b/src/client/components/MembersView.tsx
@@ -145,7 +145,6 @@ export function MembersView({
     onMemberFormChange({
       name: "",
       email: "",
-      password: "",
       role: "member",
     });
     setIsCreateMemberOpen(true);
@@ -260,8 +259,8 @@ export function MembersView({
           <DialogContent dividers>
             <Stack spacing={3}>
               <Alert severity="info" icon={<KeyOutlined />}>
-                Provision a member directly, then share the generated login
-                details privately with them.
+                Send a direct invitation so the member can choose their own
+                password securely.
               </Alert>
               <Box
                 sx={{
@@ -286,19 +285,6 @@ export function MembersView({
                   onChange={(e) =>
                     onMemberFormChange({ email: e.target.value })
                   }
-                  required
-                  fullWidth
-                />
-                <TextField
-                  label="Temporary password"
-                  type="password"
-                  size="small"
-                  value={memberFormState.password}
-                  onChange={(e) =>
-                    onMemberFormChange({ password: e.target.value })
-                  }
-                  helperText="Must be at least 12 characters."
-                  slotProps={{ htmlInput: { minLength: 12 } }}
                   required
                   fullWidth
                 />
@@ -329,7 +315,7 @@ export function MembersView({
               Cancel
             </Button>
             <Button type="submit" variant="contained" disabled={isSavingMember}>
-              {isSavingMember ? "Creating…" : "Create member"}
+              {isSavingMember ? "Sending…" : "Send invite"}
             </Button>
           </DialogActions>
         </Box>

--- a/src/client/components/SetupPage.tsx
+++ b/src/client/components/SetupPage.tsx
@@ -27,6 +27,8 @@ export function SetupPage({
     email: "",
     name: "",
     password: "",
+    householdName: "",
+    householdSlug: "",
     setupSecret: "",
   });
   const [isCompletingSetup, setIsCompletingSetup] = useState(false);
@@ -45,6 +47,8 @@ export function SetupPage({
         email: "",
         name: "",
         password: "",
+        householdName: "",
+        householdSlug: "",
         setupSecret: "",
       });
 
@@ -119,6 +123,37 @@ export function SetupPage({
             </Alert>
 
             <Box component="form" onSubmit={handleSetupComplete} noValidate>
+              <TextField
+                margin="normal"
+                required
+                fullWidth
+                id="setup-household-name"
+                label="Household name"
+                name="setup-household-name"
+                value={setupFormState.householdName}
+                onChange={(e) =>
+                  setSetupFormState((current) => ({
+                    ...current,
+                    householdName: e.target.value,
+                  }))
+                }
+              />
+              <TextField
+                margin="normal"
+                required
+                fullWidth
+                id="setup-household-slug"
+                label="Household slug"
+                name="setup-household-slug"
+                helperText="Lowercase letters, numbers, and hyphens only."
+                value={setupFormState.householdSlug}
+                onChange={(e) =>
+                  setSetupFormState((current) => ({
+                    ...current,
+                    householdSlug: e.target.value.toLowerCase(),
+                  }))
+                }
+              />
               <TextField
                 margin="normal"
                 required

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -11,6 +11,13 @@ export type SessionData = {
   };
 };
 
+export type HouseholdSummary = {
+  id: string;
+  slug: string;
+  displayName: string;
+  role: "owner" | "member";
+};
+
 export type ProviderSummary = {
   provider_key: string;
   display_name: string;
@@ -99,7 +106,6 @@ export type SenderRuleFormState = {
 export type MemberFormState = {
   email: string;
   name: string;
-  password: string;
   role: "member" | "admin";
 };
 
@@ -144,6 +150,7 @@ export type AccountProfile = {
   image: string | null;
   role: string | null;
   twoFactorEnabled: boolean;
+  households: HouseholdSummary[];
 };
 
 export type AccountSettingsResponse = {
@@ -192,5 +199,12 @@ export type SetupFormState = {
   email: string;
   name: string;
   password: string;
+  householdName: string;
+  householdSlug: string;
   setupSecret: string;
+};
+
+export type CreateHouseholdFormState = {
+  displayName: string;
+  slug: string;
 };

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -1,5 +1,15 @@
 import type { SessionData } from "./types";
 
+export function buildHouseholdPath(slug: string, path: string = "") {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `/${slug}${normalizedPath}`;
+}
+
+export function buildHouseholdApiPath(slug: string, path: string) {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `/api${buildHouseholdPath(slug, normalizedPath)}`;
+}
+
 export function getProviderAccessToggleRequest(shouldHaveAccess: boolean): {
   method: "POST" | "DELETE";
   statusMessage: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { handleIncomingEmail } from "./server/email/handler";
 import { purgeExpiredMessages } from "./server/jobs/retention";
 import { adminRoutes } from "./server/routes/admin";
 import { healthRoutes } from "./server/routes/health";
+import { householdRoutes } from "./server/routes/households";
 import { inboxRoutes } from "./server/routes/inbox";
 import { invitationRoutes } from "./server/routes/invitations";
 import { settingsRoutes } from "./server/routes/settings";
@@ -27,12 +28,14 @@ app.use(
 
 app.use("/api/inbox/*", loadAuthSession);
 app.use("/api/admin/*", loadAuthSession);
+app.use("/api/households/*", loadAuthSession);
 app.use("/api/settings/*", loadAuthSession);
 
 app.on(["GET", "POST"], "/api/auth/*", (c) =>
   authForEnv(c.env).handler(c.req.raw),
 );
 app.route("/api/health", healthRoutes);
+app.route("/api/households", householdRoutes);
 app.route("/api/inbox", inboxRoutes);
 app.route("/api/admin", adminRoutes);
 app.route("/api/invitations", invitationRoutes);

--- a/src/server/auth/auth-context.ts
+++ b/src/server/auth/auth-context.ts
@@ -3,9 +3,20 @@ export type AuthContext = {
     id: string;
     email: string;
     role: string;
+    households: Array<{
+      id: string;
+      slug: string;
+      displayName: string;
+      role: "owner" | "member";
+    }>;
   } | null;
   session: {
     id: string;
     userId: string;
+  } | null;
+  household: {
+    id: string;
+    slug: string;
+    role: "owner" | "member";
   } | null;
 };

--- a/src/server/auth/auth.ts
+++ b/src/server/auth/auth.ts
@@ -1,7 +1,7 @@
 import { drizzleAdapter } from "@better-auth/drizzle-adapter";
 import { passkey } from "@better-auth/passkey";
 import { betterAuth } from "better-auth";
-import { admin, twoFactor } from "better-auth/plugins";
+import { twoFactor } from "better-auth/plugins";
 
 import { dbForEnv } from "../db/client";
 import * as schema from "../db/schema";
@@ -16,6 +16,14 @@ function getRpId(url: string) {
 }
 
 export function authForEnv(env: Env) {
+  return createAuth(env, { disableSignUp: true });
+}
+
+export function provisioningAuthForEnv(env: Env) {
+  return createAuth(env, { disableSignUp: false });
+}
+
+function createAuth(env: Env, options: { disableSignUp: boolean }) {
   return betterAuth({
     appName: "Mi Casa Su Casa",
     baseURL: env.APP_URL,
@@ -26,7 +34,7 @@ export function authForEnv(env: Env) {
     }),
     emailAndPassword: {
       enabled: true,
-      disableSignUp: true,
+      disableSignUp: options.disableSignUp,
       minPasswordLength: 12,
       maxPasswordLength: 128,
       sendResetPassword: async ({ user, url }) => {
@@ -53,10 +61,6 @@ export function authForEnv(env: Env) {
       },
     },
     plugins: [
-      admin({
-        adminRoles: ["admin"],
-        defaultRole: "user",
-      }),
       twoFactor(),
       passkey({
         rpID: getRpId(env.APP_URL),

--- a/src/server/auth/middleware.ts
+++ b/src/server/auth/middleware.ts
@@ -1,6 +1,10 @@
 import type { MiddlewareHandler } from "hono";
 import { authForEnv } from "./auth";
 import type { AuthContext } from "./auth-context";
+import {
+  listHouseholdsForUser,
+  userBelongsToHousehold,
+} from "../db/repositories/households";
 
 export type AppVariables = AuthContext;
 
@@ -13,32 +17,19 @@ export const loadAuthSession: MiddlewareHandler<{
     headers: c.req.raw.headers,
   });
 
-  const storedRole =
-    typeof result?.user?.role === "string" ? result.user.role : "user";
-  let role = storedRole === "admin" ? "admin" : "member";
-
-  if (
-    result?.user &&
-    c.env.OWNER_EMAIL &&
-    result.user.email.toLowerCase() === c.env.OWNER_EMAIL.toLowerCase() &&
-    storedRole !== "admin"
-  ) {
-    // Direct D1 update bypasses Better Auth admin plugin permission check.
-    // The admin plugin's setRole API requires the *caller* to already be admin,
-    // creating a chicken-and-egg problem for owner auto-promotion.
-    await c.env.DB.prepare("UPDATE user SET role = 'admin' WHERE id = ?")
-      .bind(result.user.id)
-      .run();
-    role = "admin";
-  }
+  const role = typeof result?.user?.role === "string" ? result.user.role : "user";
+  const households = result?.user
+    ? await listHouseholdsForUser(c.env.DB, result.user.id)
+    : [];
 
   c.set(
     "user",
     result?.user
-      ? {
+        ? {
           id: result.user.id,
           email: result.user.email,
           role,
+          households,
         }
       : null,
   );
@@ -51,6 +42,7 @@ export const loadAuthSession: MiddlewareHandler<{
         }
       : null,
   );
+  c.set("household", null);
 
   await next();
 };
@@ -70,11 +62,42 @@ export const requireOwner: MiddlewareHandler<{
   Bindings: Env;
   Variables: AppVariables;
 }> = async (c, next) => {
-  const user = c.get("user");
+  const household = c.get("household");
 
-  if (!user || user.role !== "admin") {
+  if (!household || household.role !== "owner") {
     return c.json({ error: "Forbidden" }, 403);
   }
+
+  await next();
+};
+
+export const requireHouseholdContext: MiddlewareHandler<{
+  Bindings: Env;
+  Variables: AppVariables;
+}> = async (c, next) => {
+  const user = c.get("user");
+
+  if (!user) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const slug = c.req.param("slug");
+
+  if (!slug) {
+    return c.json({ error: "Household slug is required" }, 400);
+  }
+
+  const membership = await userBelongsToHousehold(c.env.DB, user.id, slug);
+
+  if (!membership) {
+    return c.json({ error: "Forbidden" }, 403);
+  }
+
+  c.set("household", {
+    id: membership.householdId,
+    slug: membership.slug,
+    role: membership.role,
+  });
 
   await next();
 };

--- a/src/server/auth/middleware.ts
+++ b/src/server/auth/middleware.ts
@@ -1,10 +1,10 @@
 import type { MiddlewareHandler } from "hono";
-import { authForEnv } from "./auth";
-import type { AuthContext } from "./auth-context";
 import {
   listHouseholdsForUser,
   userBelongsToHousehold,
 } from "../db/repositories/households";
+import { authForEnv } from "./auth";
+import type { AuthContext } from "./auth-context";
 
 export type AppVariables = AuthContext;
 
@@ -17,7 +17,8 @@ export const loadAuthSession: MiddlewareHandler<{
     headers: c.req.raw.headers,
   });
 
-  const role = typeof result?.user?.role === "string" ? result.user.role : "user";
+  const role =
+    typeof result?.user?.role === "string" ? result.user.role : "user";
   const households = result?.user
     ? await listHouseholdsForUser(c.env.DB, result.user.id)
     : [];
@@ -25,7 +26,7 @@ export const loadAuthSession: MiddlewareHandler<{
   c.set(
     "user",
     result?.user
-        ? {
+      ? {
           id: result.user.id,
           email: result.user.email,
           role,

--- a/src/server/db/repositories/households.ts
+++ b/src/server/db/repositories/households.ts
@@ -1,0 +1,226 @@
+import { and, eq, inArray, sql } from "drizzle-orm";
+
+import { dbForDatabase } from "../client";
+import { householdMemberships, households, providers, senderRules } from "../schema";
+
+export type HouseholdMembershipRole = "owner" | "member";
+
+export type HouseholdSummary = {
+  id: string;
+  slug: string;
+  displayName: string;
+  role: HouseholdMembershipRole;
+};
+
+export async function listHouseholdsForUser(
+  db: D1Database,
+  userId: string,
+): Promise<HouseholdSummary[]> {
+  return dbForDatabase(db)
+    .select({
+      id: households.id,
+      slug: households.slug,
+      displayName: households.displayName,
+      role: householdMemberships.role,
+    })
+    .from(householdMemberships)
+    .innerJoin(households, eq(households.id, householdMemberships.householdId))
+    .where(eq(householdMemberships.userId, userId))
+    .orderBy(sql`lower(${households.displayName}) asc`);
+}
+
+export async function getHouseholdMembership(
+  db: D1Database,
+  userId: string,
+  householdId: string,
+) {
+  const rows = await dbForDatabase(db)
+    .select({
+      householdId: householdMemberships.householdId,
+      userId: householdMemberships.userId,
+      role: householdMemberships.role,
+      slug: households.slug,
+      displayName: households.displayName,
+    })
+    .from(householdMemberships)
+    .innerJoin(households, eq(households.id, householdMemberships.householdId))
+    .where(
+      and(
+        eq(householdMemberships.userId, userId),
+        eq(householdMemberships.householdId, householdId),
+      ),
+    )
+    .limit(1);
+
+  return rows[0] ?? null;
+}
+
+export async function getHouseholdBySlug(db: D1Database, slug: string) {
+  const rows = await dbForDatabase(db)
+    .select({
+      id: households.id,
+      slug: households.slug,
+      displayName: households.displayName,
+      createdAt: households.createdAt,
+      updatedAt: households.updatedAt,
+    })
+    .from(households)
+    .where(eq(households.slug, slug))
+    .limit(1);
+
+  return rows[0] ?? null;
+}
+
+export async function getHouseholdById(db: D1Database, id: string) {
+  const rows = await dbForDatabase(db)
+    .select({
+      id: households.id,
+      slug: households.slug,
+      displayName: households.displayName,
+      createdAt: households.createdAt,
+      updatedAt: households.updatedAt,
+    })
+    .from(households)
+    .where(eq(households.id, id))
+    .limit(1);
+
+  return rows[0] ?? null;
+}
+
+export async function createHousehold(
+  db: D1Database,
+  input: {
+    slug: string;
+    displayName: string;
+    ownerUserId: string;
+  },
+) {
+  const householdId = crypto.randomUUID();
+
+  await dbForDatabase(db).transaction(async (tx) => {
+    await tx.insert(households).values({
+      id: householdId,
+      slug: input.slug,
+      displayName: input.displayName,
+      createdAt: sql`CURRENT_TIMESTAMP`,
+      updatedAt: sql`CURRENT_TIMESTAMP`,
+    });
+
+    await tx.insert(householdMemberships).values({
+      id: crypto.randomUUID(),
+      householdId,
+      userId: input.ownerUserId,
+      role: "owner",
+      createdAt: sql`CURRENT_TIMESTAMP`,
+      updatedAt: sql`CURRENT_TIMESTAMP`,
+    });
+  });
+
+  return getHouseholdBySlug(db, input.slug);
+}
+
+export async function addUserToHousehold(
+  db: D1Database,
+  input: {
+    householdId: string;
+    userId: string;
+    role: HouseholdMembershipRole;
+  },
+) {
+  await dbForDatabase(db)
+    .insert(householdMemberships)
+    .values({
+      id: crypto.randomUUID(),
+      householdId: input.householdId,
+      userId: input.userId,
+      role: input.role,
+      createdAt: sql`CURRENT_TIMESTAMP`,
+      updatedAt: sql`CURRENT_TIMESTAMP`,
+    })
+    .onConflictDoUpdate({
+      target: [householdMemberships.householdId, householdMemberships.userId],
+      set: {
+        role: input.role,
+        updatedAt: sql`CURRENT_TIMESTAMP`,
+      },
+    });
+}
+
+export async function updateHouseholdMembershipRole(
+  db: D1Database,
+  input: {
+    householdId: string;
+    userId: string;
+    role: HouseholdMembershipRole;
+  },
+) {
+  await dbForDatabase(db)
+    .update(householdMemberships)
+    .set({
+      role: input.role,
+      updatedAt: sql`CURRENT_TIMESTAMP`,
+    })
+    .where(
+      and(
+        eq(householdMemberships.householdId, input.householdId),
+        eq(householdMemberships.userId, input.userId),
+      ),
+    );
+}
+
+export async function userBelongsToHousehold(
+  db: D1Database,
+  userId: string,
+  householdSlug: string,
+) {
+  const rows = await dbForDatabase(db)
+    .select({
+      householdId: householdMemberships.householdId,
+      role: householdMemberships.role,
+      slug: households.slug,
+    })
+    .from(householdMemberships)
+    .innerJoin(households, eq(households.id, householdMemberships.householdId))
+    .where(
+      and(
+        eq(householdMemberships.userId, userId),
+        eq(households.slug, householdSlug),
+      ),
+    )
+    .limit(1);
+
+  return rows[0] ?? null;
+}
+
+export async function assertProvidersBelongToHousehold(
+  db: D1Database,
+  householdId: string,
+  providerIds: string[],
+) {
+  if (providerIds.length === 0) {
+    return true;
+  }
+
+  const rows = await dbForDatabase(db)
+    .select({ id: providers.id })
+    .from(providers)
+    .where(
+      and(eq(providers.householdId, householdId), inArray(providers.id, providerIds)),
+    );
+
+  return rows.length === providerIds.length;
+}
+
+export async function assertSenderRuleBelongsToHousehold(
+  db: D1Database,
+  householdId: string,
+  ruleId: string,
+) {
+  const rows = await dbForDatabase(db)
+    .select({ id: senderRules.id })
+    .from(senderRules)
+    .where(and(eq(senderRules.id, ruleId), eq(senderRules.householdId, householdId)))
+    .limit(1);
+
+  return Boolean(rows[0]);
+}

--- a/src/server/db/repositories/households.ts
+++ b/src/server/db/repositories/households.ts
@@ -1,7 +1,12 @@
 import { and, eq, inArray, sql } from "drizzle-orm";
 
 import { dbForDatabase } from "../client";
-import { householdMemberships, households, providers, senderRules } from "../schema";
+import {
+  householdMemberships,
+  households,
+  providers,
+  senderRules,
+} from "../schema";
 
 export type HouseholdMembershipRole = "owner" | "member";
 
@@ -205,7 +210,10 @@ export async function assertProvidersBelongToHousehold(
     .select({ id: providers.id })
     .from(providers)
     .where(
-      and(eq(providers.householdId, householdId), inArray(providers.id, providerIds)),
+      and(
+        eq(providers.householdId, householdId),
+        inArray(providers.id, providerIds),
+      ),
     );
 
   return rows.length === providerIds.length;
@@ -219,7 +227,9 @@ export async function assertSenderRuleBelongsToHousehold(
   const rows = await dbForDatabase(db)
     .select({ id: senderRules.id })
     .from(senderRules)
-    .where(and(eq(senderRules.id, ruleId), eq(senderRules.householdId, householdId)))
+    .where(
+      and(eq(senderRules.id, ruleId), eq(senderRules.householdId, householdId)),
+    )
     .limit(1);
 
   return Boolean(rows[0]);

--- a/src/server/db/repositories/invitations.ts
+++ b/src/server/db/repositories/invitations.ts
@@ -4,15 +4,16 @@ import { dbForDatabase } from "../client";
 import {
   householdInvitationProviderAccess,
   householdInvitations,
+  householdMemberships,
   providers,
-  userProviderAccess,
 } from "../schema";
 
-export type InvitationRole = "member" | "admin";
+export type InvitationRole = "member" | "owner";
 export type InvitationStatus = "pending" | "accepted" | "cancelled" | "expired";
 
 export type InvitationRecord = {
   id: string;
+  householdId: string;
   email: string;
   name: string;
   role: InvitationRole;
@@ -35,6 +36,7 @@ type InvitationWithProviderRow = InvitationRecord & {
 export async function createHouseholdInvitation(
   db: D1Database,
   input: {
+    householdId: string;
     email: string;
     name: string;
     role: InvitationRole;
@@ -47,9 +49,10 @@ export async function createHouseholdInvitation(
   const invitationId = crypto.randomUUID();
 
   await dbForDatabase(db).transaction(async (tx) => {
-    await tx.insert(householdInvitations).values({
-      id: invitationId,
-      email: input.email,
+      await tx.insert(householdInvitations).values({
+        id: invitationId,
+        householdId: input.householdId,
+        email: input.email,
       name: input.name,
       role: input.role,
       tokenHash: input.tokenHash,
@@ -78,10 +81,14 @@ export async function createHouseholdInvitation(
   return invitationId;
 }
 
-export async function listHouseholdInvitations(db: D1Database) {
+export async function listHouseholdInvitations(
+  db: D1Database,
+  householdId?: string,
+) {
   const rows = await dbForDatabase(db)
     .select({
       id: householdInvitations.id,
+      householdId: householdInvitations.householdId,
       email: householdInvitations.email,
       name: householdInvitations.name,
       role: householdInvitations.role,
@@ -109,6 +116,9 @@ export async function listHouseholdInvitations(db: D1Database) {
       providers,
       eq(providers.id, householdInvitationProviderAccess.providerId),
     )
+    .where(
+      householdId ? eq(householdInvitations.householdId, householdId) : undefined,
+    )
     .orderBy(sql`${householdInvitations.createdAt} DESC`);
 
   return groupInvitationRows(rows);
@@ -121,6 +131,7 @@ export async function getInvitationByTokenHash(
   const rows = await dbForDatabase(db)
     .select({
       id: householdInvitations.id,
+      householdId: householdInvitations.householdId,
       email: householdInvitations.email,
       name: householdInvitations.name,
       role: householdInvitations.role,
@@ -157,6 +168,7 @@ export async function getInvitationById(db: D1Database, invitationId: string) {
   const rows = await dbForDatabase(db)
     .select({
       id: householdInvitations.id,
+      householdId: householdInvitations.householdId,
       email: householdInvitations.email,
       name: householdInvitations.name,
       role: householdInvitations.role,
@@ -204,21 +216,26 @@ export async function acceptInvitation(
   db: D1Database,
   input: {
     invitationId: string;
+    householdId: string;
     acceptedByUserId: string;
-    providerIds: string[];
+    role: InvitationRole;
   },
 ) {
   await dbForDatabase(db).transaction(async (tx) => {
-    if (input.providerIds.length > 0) {
-      await tx.insert(userProviderAccess).values(
-        input.providerIds.map((providerId) => ({
-          id: crypto.randomUUID(),
-          userId: input.acceptedByUserId,
-          providerId,
-          createdAt: sql`CURRENT_TIMESTAMP`,
-        })),
-      );
-    }
+    await tx.insert(householdMemberships).values({
+      id: crypto.randomUUID(),
+      householdId: input.householdId,
+      userId: input.acceptedByUserId,
+      role: input.role,
+      createdAt: sql`CURRENT_TIMESTAMP`,
+      updatedAt: sql`CURRENT_TIMESTAMP`,
+    }).onConflictDoUpdate({
+      target: [householdMemberships.householdId, householdMemberships.userId],
+      set: {
+        role: input.role,
+        updatedAt: sql`CURRENT_TIMESTAMP`,
+      },
+    });
 
     await tx
       .update(householdInvitations)
@@ -251,6 +268,7 @@ function groupInvitationRows(rows: InvitationWithProviderRow[]) {
   const grouped = new Map<
     string,
     InvitationRecord & {
+      householdId: string;
       providers: Array<{
         id: string;
         provider_key: string;
@@ -275,6 +293,7 @@ function groupInvitationRows(rows: InvitationWithProviderRow[]) {
 
     grouped.set(row.id, {
       id: row.id,
+      householdId: row.householdId,
       email: row.email,
       name: row.name,
       role: row.role,

--- a/src/server/db/repositories/invitations.ts
+++ b/src/server/db/repositories/invitations.ts
@@ -49,10 +49,10 @@ export async function createHouseholdInvitation(
   const invitationId = crypto.randomUUID();
 
   await dbForDatabase(db).transaction(async (tx) => {
-      await tx.insert(householdInvitations).values({
-        id: invitationId,
-        householdId: input.householdId,
-        email: input.email,
+    await tx.insert(householdInvitations).values({
+      id: invitationId,
+      householdId: input.householdId,
+      email: input.email,
       name: input.name,
       role: input.role,
       tokenHash: input.tokenHash,
@@ -117,7 +117,9 @@ export async function listHouseholdInvitations(
       eq(providers.id, householdInvitationProviderAccess.providerId),
     )
     .where(
-      householdId ? eq(householdInvitations.householdId, householdId) : undefined,
+      householdId
+        ? eq(householdInvitations.householdId, householdId)
+        : undefined,
     )
     .orderBy(sql`${householdInvitations.createdAt} DESC`);
 
@@ -222,20 +224,23 @@ export async function acceptInvitation(
   },
 ) {
   await dbForDatabase(db).transaction(async (tx) => {
-    await tx.insert(householdMemberships).values({
-      id: crypto.randomUUID(),
-      householdId: input.householdId,
-      userId: input.acceptedByUserId,
-      role: input.role,
-      createdAt: sql`CURRENT_TIMESTAMP`,
-      updatedAt: sql`CURRENT_TIMESTAMP`,
-    }).onConflictDoUpdate({
-      target: [householdMemberships.householdId, householdMemberships.userId],
-      set: {
+    await tx
+      .insert(householdMemberships)
+      .values({
+        id: crypto.randomUUID(),
+        householdId: input.householdId,
+        userId: input.acceptedByUserId,
         role: input.role,
+        createdAt: sql`CURRENT_TIMESTAMP`,
         updatedAt: sql`CURRENT_TIMESTAMP`,
-      },
-    });
+      })
+      .onConflictDoUpdate({
+        target: [householdMemberships.householdId, householdMemberships.userId],
+        set: {
+          role: input.role,
+          updatedAt: sql`CURRENT_TIMESTAMP`,
+        },
+      });
 
     await tx
       .update(householdInvitations)

--- a/src/server/db/repositories/member-access.ts
+++ b/src/server/db/repositories/member-access.ts
@@ -11,18 +11,30 @@ function normalizeTimestamp(value: number | string | null | undefined) {
   return value ?? new Date(0).toISOString();
 }
 
-export async function listMembers(db: D1Database): Promise<MemberRecord[]> {
+export async function listMembers(
+  db: D1Database,
+  householdId: string,
+): Promise<MemberRecord[]> {
   const result = await dbForDatabase(db).all<{
     id: string;
+    householdRole: "owner" | "member";
     email: string;
     name: string;
     role: string | null;
     createdAt: number | string;
     updatedAt: number | string;
   }>(sql`
-    SELECT id, email, name, role, createdAt, updatedAt
-    FROM user
-    ORDER BY createdAt ASC
+    SELECT user.id,
+           household_memberships.role AS householdRole,
+           user.email,
+           user.name,
+           user.role,
+           user.createdAt,
+           user.updatedAt
+    FROM household_memberships
+    INNER JOIN user ON user.id = household_memberships.user_id
+    WHERE household_memberships.household_id = ${householdId}
+    ORDER BY user.createdAt ASC
   `);
 
   return result.map((member) => ({
@@ -34,27 +46,36 @@ export async function listMembers(db: D1Database): Promise<MemberRecord[]> {
 
 export async function listMemberProviderAccess(
   db: D1Database,
+  householdId: string,
 ): Promise<MemberAccessRow[]> {
   const result = await dbForDatabase(db).all<MemberAccessRow>(sql`
     SELECT user.id,
+            household_memberships.role AS household_role,
             user.email,
             user.name,
             user.role,
             providers.provider_key,
             providers.display_name AS provider_display_name
-    FROM user
-    LEFT JOIN user_provider_access ON user_provider_access.user_id = user.id
-    LEFT JOIN providers ON providers.id = user_provider_access.provider_id
+    FROM household_memberships
+    INNER JOIN user ON user.id = household_memberships.user_id
+    LEFT JOIN household_member_provider_access
+      ON household_member_provider_access.household_membership_id = household_memberships.id
+    LEFT JOIN providers ON providers.id = household_member_provider_access.provider_id
+    WHERE household_memberships.household_id = ${householdId}
     ORDER BY user.createdAt ASC, providers.display_name ASC
   `);
 
   return result;
 }
 
-export async function listProviders(db: D1Database): Promise<ProviderRow[]> {
+export async function listProviders(
+  db: D1Database,
+  householdId: string,
+): Promise<ProviderRow[]> {
   const result = await dbForDatabase(db).all<ProviderRow>(sql`
-    SELECT id, provider_key, display_name
+    SELECT id, household_id, provider_key, display_name
     FROM providers
+    WHERE household_id = ${householdId}
     ORDER BY display_name ASC
   `);
 
@@ -63,22 +84,32 @@ export async function listProviders(db: D1Database): Promise<ProviderRow[]> {
 
 export async function grantProviderAccess(
   db: D1Database,
+  householdId: string,
   userId: string,
   providerId: string,
 ) {
   await dbForDatabase(db).run(sql`
-    INSERT OR IGNORE INTO user_provider_access (id, user_id, provider_id)
-    VALUES (${crypto.randomUUID()}, ${userId}, ${providerId})
+    INSERT OR IGNORE INTO household_member_provider_access (id, household_membership_id, provider_id)
+    SELECT ${crypto.randomUUID()}, household_memberships.id, ${providerId}
+    FROM household_memberships
+    WHERE household_memberships.household_id = ${householdId}
+      AND household_memberships.user_id = ${userId}
   `);
 }
 
 export async function revokeProviderAccess(
   db: D1Database,
+  householdId: string,
   userId: string,
   providerId: string,
 ) {
   await dbForDatabase(db).run(sql`
-    DELETE FROM user_provider_access
-    WHERE user_id = ${userId} AND provider_id = ${providerId}
+    DELETE FROM household_member_provider_access
+    WHERE provider_id = ${providerId}
+      AND household_membership_id IN (
+        SELECT id
+        FROM household_memberships
+        WHERE household_id = ${householdId} AND user_id = ${userId}
+      )
   `);
 }

--- a/src/server/db/repositories/messages.ts
+++ b/src/server/db/repositories/messages.ts
@@ -41,7 +41,7 @@ function isDuplicateMessageError(
   return (
     databaseError instanceof Error &&
     databaseError.message.includes(
-      `UNIQUE constraint failed: ${tableName}.message_id`,
+      `UNIQUE constraint failed: ${tableName}.household_id, ${tableName}.message_id`,
     )
   );
 }
@@ -63,6 +63,7 @@ function unwrapDatabaseError(error: unknown): unknown {
 export async function insertMessage(
   db: D1Database,
   parsed: ParsedIncomingEmail,
+  householdId: string,
   providerId: string,
   result: Extract<ClassificationResult, { kind: "matched" }>,
 ) {
@@ -74,10 +75,10 @@ export async function insertMessage(
   try {
     await database.run(sql`
       INSERT INTO messages (
-        id, message_id, provider_id, envelope_from, envelope_to, from_header, subject,
+        id, household_id, message_id, provider_id, envelope_from, envelope_to, from_header, subject,
         text_body, extracted_code, classification_reason, raw_size, received_at, delete_after
       ) VALUES (
-        ${id}, ${parsed.messageId ?? id}, ${providerId}, ${parsed.envelopeFrom}, ${parsed.envelopeTo},
+        ${id}, ${householdId}, ${parsed.messageId ?? id}, ${providerId}, ${parsed.envelopeFrom}, ${parsed.envelopeTo},
         ${parsed.fromHeader}, ${parsed.subject}, ${parsed.textBody}, ${result.code}, ${result.reason},
         ${parsed.rawSize}, ${receivedAt}, ${deleteAfter}
       )
@@ -94,6 +95,7 @@ export async function insertMessage(
 export async function insertQuarantineMessage(
   db: D1Database,
   parsed: ParsedIncomingEmail,
+  householdId: string,
   result: Extract<ClassificationResult, { kind: "quarantine" }>,
 ) {
   const database = dbForDatabase(db);
@@ -104,10 +106,10 @@ export async function insertQuarantineMessage(
   try {
     await database.run(sql`
       INSERT INTO quarantine_messages (
-        id, message_id, envelope_from, envelope_to, from_header, subject,
+        id, household_id, message_id, envelope_from, envelope_to, from_header, subject,
         text_body, extracted_code, quarantine_reason, raw_size, received_at, delete_after
       ) VALUES (
-        ${id}, ${parsed.messageId ?? id}, ${parsed.envelopeFrom}, ${parsed.envelopeTo},
+        ${id}, ${householdId}, ${parsed.messageId ?? id}, ${parsed.envelopeFrom}, ${parsed.envelopeTo},
         ${parsed.fromHeader}, ${parsed.subject}, ${parsed.textBody}, ${result.code}, ${result.reason},
         ${parsed.rawSize}, ${receivedAt}, ${deleteAfter}
       )
@@ -123,15 +125,17 @@ export async function insertQuarantineMessage(
 
 export async function listMessagesForProvider(
   db: D1Database,
+  householdId: string,
   providerKey: string,
 ): Promise<InboxMessageRow[]> {
   const result = await dbForDatabase(db).all<InboxMessageRow>(sql`
-    SELECT messages.id, providers.provider_key, providers.display_name AS provider_display_name,
+    SELECT messages.id, households.slug AS household_slug, providers.provider_key, providers.display_name AS provider_display_name,
             messages.subject, messages.from_header, messages.text_body,
             messages.extracted_code, messages.status, messages.received_at
     FROM messages
     INNER JOIN providers ON providers.id = messages.provider_id
-    WHERE providers.provider_key = ${providerKey}
+    INNER JOIN households ON households.id = messages.household_id
+    WHERE messages.household_id = ${householdId} AND providers.provider_key = ${providerKey}
     ORDER BY messages.received_at DESC
   `);
 
@@ -140,21 +144,30 @@ export async function listMessagesForProvider(
 
 export async function listProviderSummariesForUser(
   db: D1Database,
+  householdId: string,
   userId: string,
-  role: string,
 ): Promise<ProviderSummaryRow[]> {
   const result = await dbForDatabase(db).all<ProviderSummaryRow>(sql`
-    SELECT providers.provider_key,
+    SELECT households.slug AS household_slug,
+            providers.provider_key,
             providers.display_name,
             CAST(COUNT(messages.id) AS INTEGER) AS message_count,
             CAST(COALESCE(SUM(CASE WHEN messages.status = 'new' THEN 1 ELSE 0 END), 0) AS INTEGER) AS new_count,
             MAX(messages.received_at) AS latest_received_at
     FROM providers
-    LEFT JOIN user_provider_access
-      ON user_provider_access.provider_id = providers.id AND user_provider_access.user_id = ${userId}
-    LEFT JOIN messages ON messages.provider_id = providers.id
-    WHERE ${role} = 'admin' OR user_provider_access.user_id IS NOT NULL
-    GROUP BY providers.id, providers.provider_key, providers.display_name, providers.created_at
+    INNER JOIN households ON households.id = providers.household_id
+    INNER JOIN household_memberships
+      ON household_memberships.household_id = providers.household_id
+      AND household_memberships.user_id = ${userId}
+    LEFT JOIN household_member_provider_access
+      ON household_member_provider_access.household_membership_id = household_memberships.id
+      AND household_member_provider_access.provider_id = providers.id
+    LEFT JOIN messages
+      ON messages.provider_id = providers.id
+      AND messages.household_id = providers.household_id
+    WHERE providers.household_id = ${householdId}
+      AND (household_memberships.role = 'owner' OR household_member_provider_access.id IS NOT NULL)
+    GROUP BY households.slug, providers.id, providers.provider_key, providers.display_name, providers.created_at
     ORDER BY COALESCE(MAX(messages.received_at), providers.created_at) DESC, providers.display_name ASC
   `);
 
@@ -163,9 +176,11 @@ export async function listProviderSummariesForUser(
 
 export async function listQuarantineMessages(
   db: D1Database,
+  householdId: string,
 ): Promise<QuarantineMessageRow[]> {
   const result = await dbForDatabase(db).all<QuarantineMessageRow>(sql`
-    SELECT id,
+    SELECT quarantine_messages.id,
+            households.slug AS household_slug,
             'quarantine' AS provider_key,
             'Quarantine' AS provider_display_name,
             subject,
@@ -177,7 +192,8 @@ export async function listQuarantineMessages(
             quarantine_reason,
             received_at
     FROM quarantine_messages
-    WHERE reviewed_at IS NULL
+    INNER JOIN households ON households.id = quarantine_messages.household_id
+    WHERE quarantine_messages.household_id = ${householdId} AND reviewed_at IS NULL
     ORDER BY received_at DESC
   `);
 
@@ -186,33 +202,37 @@ export async function listQuarantineMessages(
 
 export async function updateMessageStatus(
   db: D1Database,
+  householdId: string,
   messageId: string,
   status: MessageStatus,
 ): Promise<InboxMessageRow | null> {
   await dbForDatabase(db).run(sql`
-    UPDATE messages SET status = ${status} WHERE id = ${messageId}
+    UPDATE messages SET status = ${status} WHERE household_id = ${householdId} AND id = ${messageId}
   `);
 
-  return findMessageById(db, messageId);
+  return findMessageById(db, householdId, messageId);
 }
 
 export async function findMessageById(
   db: D1Database,
+  householdId: string,
   messageId: string,
 ): Promise<InboxMessageRow | null> {
   return dbForDatabase(db).get<InboxMessageRow>(sql`
-    SELECT messages.id, providers.provider_key, providers.display_name AS provider_display_name,
+    SELECT messages.id, households.slug AS household_slug, providers.provider_key, providers.display_name AS provider_display_name,
             messages.subject, messages.from_header, messages.text_body,
             messages.extracted_code, messages.status, messages.received_at
     FROM messages
     INNER JOIN providers ON providers.id = messages.provider_id
-    WHERE messages.id = ${messageId}
+    INNER JOIN households ON households.id = messages.household_id
+    WHERE messages.household_id = ${householdId} AND messages.id = ${messageId}
     LIMIT 1
   `);
 }
 
 type QuarantineMessageRecord = {
   id: string;
+  household_id: string;
   message_id: string;
   envelope_from: string;
   envelope_to: string;
@@ -229,27 +249,29 @@ type QuarantineMessageRecord = {
 
 async function findQuarantineMessageRecord(
   db: D1Database,
+  householdId: string,
   messageId: string,
 ): Promise<QuarantineMessageRecord | null> {
   return dbForDatabase(db).get<QuarantineMessageRecord>(sql`
-    SELECT id, message_id, envelope_from, envelope_to, from_header, subject,
+    SELECT id, household_id, message_id, envelope_from, envelope_to, from_header, subject,
             text_body, extracted_code, quarantine_reason, raw_size,
             received_at, delete_after, reviewed_at
     FROM quarantine_messages
-    WHERE id = ${messageId}
+    WHERE household_id = ${householdId} AND id = ${messageId}
     LIMIT 1
   `);
 }
 
 export async function reviewQuarantineMessage(
   db: D1Database,
+  householdId: string,
   messageId: string,
   review: { action: "dismiss" | "release"; providerId?: string },
 ): Promise<{
   reviewedAt: string;
   releasedMessage: InboxMessageRow | null;
 } | null> {
-  const record = await findQuarantineMessageRecord(db, messageId);
+  const record = await findQuarantineMessageRecord(db, householdId, messageId);
   const database = dbForDatabase(db);
 
   if (!record || record.reviewed_at) {
@@ -268,10 +290,10 @@ export async function reviewQuarantineMessage(
 
     await database.run(sql`
       INSERT INTO messages (
-        id, message_id, provider_id, envelope_from, envelope_to, from_header, subject,
+        id, household_id, message_id, provider_id, envelope_from, envelope_to, from_header, subject,
         text_body, extracted_code, status, classification_reason, raw_size, received_at, delete_after
       ) VALUES (
-        ${crypto.randomUUID()}, ${record.message_id}, ${review.providerId}, ${record.envelope_from},
+        ${crypto.randomUUID()}, ${record.household_id}, ${record.message_id}, ${review.providerId}, ${record.envelope_from},
         ${record.envelope_to}, ${record.from_header}, ${record.subject}, ${record.text_body},
         ${record.extracted_code}, ${"new"},
         ${`Released from quarantine by owner review. Original reason: ${record.quarantine_reason}`},
@@ -280,12 +302,13 @@ export async function reviewQuarantineMessage(
     `);
 
     const result = await database.get<InboxMessageRow>(sql`
-      SELECT messages.id, providers.provider_key, providers.display_name AS provider_display_name,
+      SELECT messages.id, households.slug AS household_slug, providers.provider_key, providers.display_name AS provider_display_name,
               messages.subject, messages.from_header, messages.text_body,
               messages.extracted_code, messages.status, messages.received_at
       FROM messages
       INNER JOIN providers ON providers.id = messages.provider_id
-      WHERE messages.message_id = ${record.message_id}
+      INNER JOIN households ON households.id = messages.household_id
+      WHERE messages.household_id = ${record.household_id} AND messages.message_id = ${record.message_id}
       ORDER BY messages.created_at DESC
       LIMIT 1
     `);
@@ -294,7 +317,7 @@ export async function reviewQuarantineMessage(
   }
 
   await database.run(sql`
-    UPDATE quarantine_messages SET reviewed_at = ${reviewedAt} WHERE id = ${messageId}
+    UPDATE quarantine_messages SET reviewed_at = ${reviewedAt} WHERE household_id = ${householdId} AND id = ${messageId}
   `);
 
   return { reviewedAt, releasedMessage };

--- a/src/server/db/repositories/provider-rules.ts
+++ b/src/server/db/repositories/provider-rules.ts
@@ -8,20 +8,29 @@ import type {
 } from "../types";
 
 export type SenderRuleMatch = {
+  householdId: string;
+  householdSlug: string;
   providerId: string;
   providerKey: string;
 };
 
 export async function findProviderMatch(
   db: D1Database,
+  householdId: string,
   fromAddress: string,
 ): Promise<SenderRuleMatch | null> {
   const database = dbForDatabase(db);
   const exact = await database.get<SenderRuleMatch>(sql`
-    SELECT providers.id AS providerId, providers.provider_key AS providerKey
+    SELECT providers.id AS providerId,
+           providers.provider_key AS providerKey,
+           providers.household_id AS householdId,
+           households.slug AS householdSlug
     FROM sender_rules
     INNER JOIN providers ON providers.id = sender_rules.provider_id
-    WHERE sender_rules.match_type = 'exact' AND lower(sender_rules.match_value) = lower(${fromAddress})
+    INNER JOIN households ON households.id = providers.household_id
+    WHERE sender_rules.household_id = ${householdId}
+      AND sender_rules.match_type = 'exact'
+      AND lower(sender_rules.match_value) = lower(${fromAddress})
     LIMIT 1
   `);
 
@@ -35,24 +44,35 @@ export async function findProviderMatch(
   }
 
   return database.get<SenderRuleMatch>(sql`
-    SELECT providers.id AS providerId, providers.provider_key AS providerKey
+    SELECT providers.id AS providerId,
+           providers.provider_key AS providerKey,
+           providers.household_id AS householdId,
+           households.slug AS householdSlug
     FROM sender_rules
     INNER JOIN providers ON providers.id = sender_rules.provider_id
-    WHERE sender_rules.match_type = 'domain' AND lower(sender_rules.match_value) = lower(${domain})
+    INNER JOIN households ON households.id = providers.household_id
+    WHERE sender_rules.household_id = ${householdId}
+      AND sender_rules.match_type = 'domain'
+      AND lower(sender_rules.match_value) = lower(${domain})
     LIMIT 1
   `);
 }
 
 export async function userHasProviderAccess(
   db: D1Database,
+  householdId: string,
   userId: string,
   providerKey: string,
 ): Promise<boolean> {
   const row = await dbForDatabase(db).get<{ allowed: number }>(sql`
     SELECT 1 AS allowed
-    FROM user_provider_access
-    INNER JOIN providers ON providers.id = user_provider_access.provider_id
-    WHERE user_provider_access.user_id = ${userId} AND providers.provider_key = ${providerKey}
+    FROM household_memberships
+    INNER JOIN household_member_provider_access
+      ON household_member_provider_access.household_membership_id = household_memberships.id
+    INNER JOIN providers ON providers.id = household_member_provider_access.provider_id
+    WHERE household_memberships.household_id = ${householdId}
+      AND household_memberships.user_id = ${userId}
+      AND providers.provider_key = ${providerKey}
     LIMIT 1
   `);
 
@@ -61,27 +81,31 @@ export async function userHasProviderAccess(
 
 export async function getProviderByKey(
   db: D1Database,
+  householdId: string,
   providerKey: string,
 ): Promise<ProviderRow | null> {
   return dbForDatabase(db).get<ProviderRow>(sql`
-    SELECT id, provider_key, display_name, created_at
+    SELECT id, household_id, provider_key, display_name, created_at
     FROM providers
-    WHERE provider_key = ${providerKey}
+    WHERE household_id = ${householdId} AND provider_key = ${providerKey}
     LIMIT 1
   `);
 }
 
 export async function listProviderConfigurations(
   db: D1Database,
+  householdId: string,
 ): Promise<ProviderConfigurationRow[]> {
   return dbForDatabase(db).all<ProviderConfigurationRow>(sql`
     SELECT providers.id,
+           providers.household_id,
            providers.provider_key,
            providers.display_name,
            providers.created_at,
            COUNT(sender_rules.id) AS rule_count
     FROM providers
     LEFT JOIN sender_rules ON sender_rules.provider_id = providers.id
+    WHERE providers.household_id = ${householdId}
     GROUP BY providers.id, providers.provider_key, providers.display_name, providers.created_at
     ORDER BY providers.display_name ASC
   `);
@@ -89,27 +113,30 @@ export async function listProviderConfigurations(
 
 export async function listSenderRules(
   db: D1Database,
+  householdId: string,
 ): Promise<SenderRuleRow[]> {
   return dbForDatabase(db).all<SenderRuleRow>(sql`
-    SELECT id, provider_id, match_type, match_value, created_at
+    SELECT id, household_id, provider_id, match_type, match_value, created_at
     FROM sender_rules
+    WHERE household_id = ${householdId}
     ORDER BY created_at ASC, match_value ASC
   `);
 }
 
 export async function createProvider(
   db: D1Database,
+  householdId: string,
   providerKey: string,
   displayName: string,
 ): Promise<ProviderRow> {
   const id = crypto.randomUUID();
 
   await dbForDatabase(db).run(sql`
-    INSERT INTO providers (id, provider_key, display_name)
-    VALUES (${id}, ${providerKey}, ${displayName})
+    INSERT INTO providers (id, household_id, provider_key, display_name)
+    VALUES (${id}, ${householdId}, ${providerKey}, ${displayName})
   `);
 
-  const provider = await getProviderByKey(db, providerKey);
+  const provider = await getProviderByKey(db, householdId, providerKey);
 
   if (!provider) {
     throw new Error("Provider creation failed");
@@ -120,6 +147,7 @@ export async function createProvider(
 
 export async function updateProvider(
   db: D1Database,
+  householdId: string,
   providerId: string,
   providerKey: string,
   displayName: string,
@@ -128,31 +156,37 @@ export async function updateProvider(
     UPDATE providers
     SET provider_key = ${providerKey},
         display_name = ${displayName}
-    WHERE id = ${providerId}
+    WHERE id = ${providerId} AND household_id = ${householdId}
   `);
 }
 
-export async function deleteProvider(db: D1Database, providerId: string) {
+export async function deleteProvider(
+  db: D1Database,
+  householdId: string,
+  providerId: string,
+) {
   await dbForDatabase(db).run(sql`
     DELETE FROM providers
-    WHERE id = ${providerId}
+    WHERE id = ${providerId} AND household_id = ${householdId}
   `);
 }
 
 export async function getProviderById(
   db: D1Database,
+  householdId: string,
   providerId: string,
 ): Promise<ProviderRow | null> {
   return dbForDatabase(db).get<ProviderRow>(sql`
-    SELECT id, provider_key, display_name, created_at
+    SELECT id, household_id, provider_key, display_name, created_at
     FROM providers
-    WHERE id = ${providerId}
+    WHERE id = ${providerId} AND household_id = ${householdId}
     LIMIT 1
   `);
 }
 
 export async function createSenderRule(
   db: D1Database,
+  householdId: string,
   providerId: string,
   matchType: SenderRuleRow["match_type"],
   matchValue: string,
@@ -160,11 +194,11 @@ export async function createSenderRule(
   const id = crypto.randomUUID();
 
   await dbForDatabase(db).run(sql`
-    INSERT INTO sender_rules (id, provider_id, match_type, match_value)
-    VALUES (${id}, ${providerId}, ${matchType}, ${matchValue})
+    INSERT INTO sender_rules (id, household_id, provider_id, match_type, match_value)
+    VALUES (${id}, ${householdId}, ${providerId}, ${matchType}, ${matchValue})
   `);
 
-  const rule = await getSenderRuleById(db, id);
+  const rule = await getSenderRuleById(db, householdId, id);
 
   if (!rule) {
     throw new Error("Sender rule creation failed");
@@ -175,6 +209,7 @@ export async function createSenderRule(
 
 export async function updateSenderRule(
   db: D1Database,
+  householdId: string,
   ruleId: string,
   providerId: string,
   matchType: SenderRuleRow["match_type"],
@@ -182,28 +217,34 @@ export async function updateSenderRule(
 ) {
   await dbForDatabase(db).run(sql`
     UPDATE sender_rules
-    SET provider_id = ${providerId},
+    SET household_id = ${householdId},
+        provider_id = ${providerId},
         match_type = ${matchType},
         match_value = ${matchValue}
-    WHERE id = ${ruleId}
+    WHERE id = ${ruleId} AND household_id = ${householdId}
   `);
 }
 
-export async function deleteSenderRule(db: D1Database, ruleId: string) {
+export async function deleteSenderRule(
+  db: D1Database,
+  householdId: string,
+  ruleId: string,
+) {
   await dbForDatabase(db).run(sql`
     DELETE FROM sender_rules
-    WHERE id = ${ruleId}
+    WHERE id = ${ruleId} AND household_id = ${householdId}
   `);
 }
 
 export async function getSenderRuleById(
   db: D1Database,
+  householdId: string,
   ruleId: string,
 ): Promise<SenderRuleRow | null> {
   return dbForDatabase(db).get<SenderRuleRow>(sql`
-    SELECT id, provider_id, match_type, match_value, created_at
+    SELECT id, household_id, provider_id, match_type, match_value, created_at
     FROM sender_rules
-    WHERE id = ${ruleId}
+    WHERE id = ${ruleId} AND household_id = ${householdId}
     LIMIT 1
   `);
 }

--- a/src/server/db/repositories/settings.ts
+++ b/src/server/db/repositories/settings.ts
@@ -1,8 +1,8 @@
 import { and, eq, ne, sql } from "drizzle-orm";
 
 import { dbForDatabase } from "../client";
-import { listHouseholdsForUser } from "./households";
 import { session, user } from "../schema";
+import { listHouseholdsForUser } from "./households";
 
 function normalizeTimestamp(value: Date | number | null | undefined) {
   if (!value) {

--- a/src/server/db/repositories/settings.ts
+++ b/src/server/db/repositories/settings.ts
@@ -1,6 +1,7 @@
 import { and, eq, ne, sql } from "drizzle-orm";
 
 import { dbForDatabase } from "../client";
+import { listHouseholdsForUser } from "./households";
 import { session, user } from "../schema";
 
 function normalizeTimestamp(value: Date | number | null | undefined) {
@@ -29,7 +30,16 @@ export async function getUserProfile(db: D1Database, userId: string) {
     .where(eq(user.id, userId))
     .limit(1);
 
-  return rows[0] ?? null;
+  const profile = rows[0] ?? null;
+
+  if (!profile) {
+    return null;
+  }
+
+  return {
+    ...profile,
+    households: await listHouseholdsForUser(db, userId),
+  };
 }
 
 export async function updateUserProfile(

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -126,15 +126,90 @@ export const passkey = sqliteTable(
 
 export const providers = sqliteTable("providers", {
   id: text("id").primaryKey(),
-  providerKey: text("provider_key").notNull().unique(),
+  householdId: text("household_id")
+    .notNull()
+    .references(() => households.id, { onDelete: "cascade" }),
+  providerKey: text("provider_key").notNull(),
   displayName: text("display_name").notNull(),
   createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
-});
+}, (table) => [
+  uniqueIndex("providers_household_id_provider_key_unique").on(
+    table.householdId,
+    table.providerKey,
+  ),
+  index("providers_household_id_idx").on(table.householdId),
+]);
+
+export const households = sqliteTable(
+  "households",
+  {
+    id: text("id").primaryKey(),
+    slug: text("slug").notNull().unique(),
+    displayName: text("display_name").notNull(),
+    createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
+    updatedAt: text("updated_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
+  },
+  (table) => [index("households_slug_idx").on(table.slug)],
+);
+
+export const householdMemberships = sqliteTable(
+  "household_memberships",
+  {
+    id: text("id").primaryKey(),
+    householdId: text("household_id")
+      .notNull()
+      .references(() => households.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    role: text("role").$type<"owner" | "member">().notNull(),
+    createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
+    updatedAt: text("updated_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
+  },
+  (table) => [
+    uniqueIndex("household_memberships_household_user_unique").on(
+      table.householdId,
+      table.userId,
+    ),
+    index("household_memberships_household_id_idx").on(table.householdId),
+    index("household_memberships_user_id_idx").on(table.userId),
+    check(
+      "household_memberships_role_check",
+      sql`${table.role} in ('owner', 'member')`,
+    ),
+  ],
+);
+
+export const householdMemberProviderAccess = sqliteTable(
+  "household_member_provider_access",
+  {
+    id: text("id").primaryKey(),
+    householdMembershipId: text("household_membership_id")
+      .notNull()
+      .references(() => householdMemberships.id, { onDelete: "cascade" }),
+    providerId: text("provider_id")
+      .notNull()
+      .references(() => providers.id, { onDelete: "cascade" }),
+    createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
+  },
+  (table) => [
+    uniqueIndex(
+      "household_member_provider_access_membership_provider_unique",
+    ).on(table.householdMembershipId, table.providerId),
+    index("household_member_provider_access_membership_idx").on(
+      table.householdMembershipId,
+    ),
+    index("household_member_provider_access_provider_idx").on(table.providerId),
+  ],
+);
 
 export const senderRules = sqliteTable(
   "sender_rules",
   {
     id: text("id").primaryKey(),
+    householdId: text("household_id")
+      .notNull()
+      .references(() => households.id, { onDelete: "cascade" }),
     providerId: text("provider_id")
       .notNull()
       .references(() => providers.id, { onDelete: "cascade" }),
@@ -143,11 +218,16 @@ export const senderRules = sqliteTable(
     createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
   },
   (table) => [
-    uniqueIndex("sender_rules_match_type_match_value_unique").on(
+    uniqueIndex("sender_rules_household_match_type_match_value_unique").on(
+      table.householdId,
       table.matchType,
       table.matchValue,
     ),
-    index("idx_sender_rules_lookup").on(table.matchType, table.matchValue),
+    index("idx_sender_rules_lookup").on(
+      table.householdId,
+      table.matchType,
+      table.matchValue,
+    ),
     check(
       "sender_rules_match_type_check",
       sql`${table.matchType} in ('exact', 'domain')`,
@@ -178,6 +258,9 @@ export const messages = sqliteTable(
   {
     id: text("id").primaryKey(),
     messageId: text("message_id").notNull().unique(),
+    householdId: text("household_id")
+      .notNull()
+      .references(() => households.id, { onDelete: "cascade" }),
     providerId: text("provider_id")
       .notNull()
       .references(() => providers.id, { onDelete: "cascade" }),
@@ -195,10 +278,16 @@ export const messages = sqliteTable(
     createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
   },
   (table) => [
+    uniqueIndex("messages_household_id_message_id_unique").on(
+      table.householdId,
+      table.messageId,
+    ),
     index("idx_messages_provider_received").on(
+      table.householdId,
       table.providerId,
       table.receivedAt,
     ),
+    index("idx_messages_household_received").on(table.householdId, table.receivedAt),
     index("idx_messages_delete_after").on(table.deleteAfter),
     check(
       "messages_status_check",
@@ -211,7 +300,10 @@ export const quarantineMessages = sqliteTable(
   "quarantine_messages",
   {
     id: text("id").primaryKey(),
-    messageId: text("message_id").notNull().unique(),
+    messageId: text("message_id").notNull(),
+    householdId: text("household_id")
+      .notNull()
+      .references(() => households.id, { onDelete: "cascade" }),
     envelopeFrom: text("envelope_from").notNull(),
     envelopeTo: text("envelope_to").notNull(),
     fromHeader: text("from_header"),
@@ -225,7 +317,14 @@ export const quarantineMessages = sqliteTable(
     reviewedAt: text("reviewed_at"),
     createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
   },
-  (table) => [index("idx_quarantine_delete_after").on(table.deleteAfter)],
+  (table) => [
+    uniqueIndex("quarantine_messages_household_id_message_id_unique").on(
+      table.householdId,
+      table.messageId,
+    ),
+    index("idx_quarantine_household_received").on(table.householdId, table.receivedAt),
+    index("idx_quarantine_delete_after").on(table.deleteAfter),
+  ],
 );
 
 export const auditEvents = sqliteTable("audit_events", {
@@ -264,9 +363,12 @@ export const householdInvitations = sqliteTable(
   "household_invitations",
   {
     id: text("id").primaryKey(),
+    householdId: text("household_id")
+      .notNull()
+      .references(() => households.id, { onDelete: "cascade" }),
     email: text("email").notNull(),
     name: text("name").notNull(),
-    role: text("role").$type<"member" | "admin">().notNull(),
+    role: text("role").$type<"member" | "owner">().notNull(),
     tokenHash: text("token_hash").notNull().unique(),
     status: text("status")
       .$type<"pending" | "accepted" | "cancelled" | "expired">()
@@ -284,12 +386,13 @@ export const householdInvitations = sqliteTable(
     updatedAt: text("updated_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
   },
   (table) => [
+    index("idx_household_invitations_household_id").on(table.householdId),
     index("idx_household_invitations_email").on(table.email),
     index("idx_household_invitations_status").on(table.status),
     index("idx_household_invitations_expires_at").on(table.expiresAt),
     check(
       "household_invitations_role_check",
-      sql`${table.role} in ('member', 'admin')`,
+      sql`${table.role} in ('member', 'owner')`,
     ),
     check(
       "household_invitations_status_check",

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -124,21 +124,25 @@ export const passkey = sqliteTable(
   ],
 );
 
-export const providers = sqliteTable("providers", {
-  id: text("id").primaryKey(),
-  householdId: text("household_id")
-    .notNull()
-    .references(() => households.id, { onDelete: "cascade" }),
-  providerKey: text("provider_key").notNull(),
-  displayName: text("display_name").notNull(),
-  createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
-}, (table) => [
-  uniqueIndex("providers_household_id_provider_key_unique").on(
-    table.householdId,
-    table.providerKey,
-  ),
-  index("providers_household_id_idx").on(table.householdId),
-]);
+export const providers = sqliteTable(
+  "providers",
+  {
+    id: text("id").primaryKey(),
+    householdId: text("household_id")
+      .notNull()
+      .references(() => households.id, { onDelete: "cascade" }),
+    providerKey: text("provider_key").notNull(),
+    displayName: text("display_name").notNull(),
+    createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
+  },
+  (table) => [
+    uniqueIndex("providers_household_id_provider_key_unique").on(
+      table.householdId,
+      table.providerKey,
+    ),
+    index("providers_household_id_idx").on(table.householdId),
+  ],
+);
 
 export const households = sqliteTable(
   "households",
@@ -287,7 +291,10 @@ export const messages = sqliteTable(
       table.providerId,
       table.receivedAt,
     ),
-    index("idx_messages_household_received").on(table.householdId, table.receivedAt),
+    index("idx_messages_household_received").on(
+      table.householdId,
+      table.receivedAt,
+    ),
     index("idx_messages_delete_after").on(table.deleteAfter),
     check(
       "messages_status_check",
@@ -322,7 +329,10 @@ export const quarantineMessages = sqliteTable(
       table.householdId,
       table.messageId,
     ),
-    index("idx_quarantine_household_received").on(table.householdId, table.receivedAt),
+    index("idx_quarantine_household_received").on(
+      table.householdId,
+      table.receivedAt,
+    ),
     index("idx_quarantine_delete_after").on(table.deleteAfter),
   ],
 );

--- a/src/server/db/types.ts
+++ b/src/server/db/types.ts
@@ -1,6 +1,8 @@
 export type ClassificationResult =
   | {
       kind: "matched";
+      householdId: string;
+      householdSlug: string;
       providerId: string;
       providerKey: string;
       code: string | null;
@@ -15,6 +17,7 @@ export type ClassificationResult =
 export type ParsedIncomingEmail = {
   envelopeFrom: string;
   envelopeTo: string;
+  householdSlug: string | null;
   fromHeader: string | null;
   subject: string | null;
   messageId: string | null;
@@ -25,6 +28,7 @@ export type ParsedIncomingEmail = {
 
 export type InboxMessageRow = {
   id: string;
+  household_slug: string;
   provider_key: string;
   provider_display_name: string;
   subject: string | null;
@@ -36,6 +40,7 @@ export type InboxMessageRow = {
 };
 
 export type ProviderSummaryRow = {
+  household_slug: string;
   provider_key: string;
   display_name: string;
   message_count: number;
@@ -45,6 +50,7 @@ export type ProviderSummaryRow = {
 
 export type QuarantineMessageRow = {
   id: string;
+  household_slug: string;
   provider_key: "quarantine";
   provider_display_name: "Quarantine";
   subject: string | null;
@@ -59,6 +65,7 @@ export type QuarantineMessageRow = {
 
 export type ProviderRow = {
   id: string;
+  household_id?: string;
   provider_key: string;
   display_name: string;
   created_at?: string;
@@ -66,6 +73,7 @@ export type ProviderRow = {
 
 export type ProviderConfigurationRow = {
   id: string;
+  household_id: string;
   provider_key: string;
   display_name: string;
   created_at: string;
@@ -74,6 +82,7 @@ export type ProviderConfigurationRow = {
 
 export type SenderRuleRow = {
   id: string;
+  household_id: string;
   provider_id: string;
   match_type: "exact" | "domain";
   match_value: string;
@@ -84,6 +93,7 @@ export type MessageStatus = InboxMessageRow["status"];
 
 export type MemberRecord = {
   id: string;
+  householdRole: "owner" | "member";
   email: string;
   name: string;
   role: string | null;
@@ -93,11 +103,19 @@ export type MemberRecord = {
 
 export type MemberAccessRow = {
   id: string;
+  household_role: "owner" | "member";
   email: string;
   name: string;
   role: string | null;
   provider_key: string | null;
   provider_display_name: string | null;
+};
+
+export type HouseholdSummaryRow = {
+  id: string;
+  slug: string;
+  displayName: string;
+  role: "owner" | "member";
 };
 
 export type InstallationStateRow = {

--- a/src/server/domain/classify-email.ts
+++ b/src/server/domain/classify-email.ts
@@ -1,6 +1,6 @@
+import { getHouseholdBySlug } from "../db/repositories/households";
 import { findProviderMatch } from "../db/repositories/provider-rules";
 import type { ClassificationResult, ParsedIncomingEmail } from "../db/types";
-import { getHouseholdBySlug } from "../db/repositories/households";
 import { extractVerificationCode } from "./extract-code";
 
 export async function classifyEmail(
@@ -36,7 +36,8 @@ export async function classifyEmail(
   if (!providerMatch) {
     return {
       kind: "quarantine",
-      reason: "No sender rule matched the inbound email within the addressed household.",
+      reason:
+        "No sender rule matched the inbound email within the addressed household.",
       code,
     };
   }

--- a/src/server/domain/classify-email.ts
+++ b/src/server/domain/classify-email.ts
@@ -1,24 +1,50 @@
 import { findProviderMatch } from "../db/repositories/provider-rules";
 import type { ClassificationResult, ParsedIncomingEmail } from "../db/types";
+import { getHouseholdBySlug } from "../db/repositories/households";
 import { extractVerificationCode } from "./extract-code";
 
 export async function classifyEmail(
   db: D1Database,
   parsed: ParsedIncomingEmail,
 ): Promise<ClassificationResult> {
-  const providerMatch = await findProviderMatch(db, parsed.envelopeFrom);
   const code = extractVerificationCode(parsed.textBody);
+
+  if (!parsed.householdSlug) {
+    return {
+      kind: "quarantine",
+      reason: "No household slug could be resolved from the recipient address.",
+      code,
+    };
+  }
+
+  const household = await getHouseholdBySlug(db, parsed.householdSlug);
+
+  if (!household) {
+    return {
+      kind: "quarantine",
+      reason: "No household matched the inbound recipient address.",
+      code,
+    };
+  }
+
+  const providerMatch = await findProviderMatch(
+    db,
+    household.id,
+    parsed.envelopeFrom,
+  );
 
   if (!providerMatch) {
     return {
       kind: "quarantine",
-      reason: "No sender rule matched the inbound email.",
+      reason: "No sender rule matched the inbound email within the addressed household.",
       code,
     };
   }
 
   return {
     kind: "matched",
+    householdId: providerMatch.householdId,
+    householdSlug: providerMatch.householdSlug,
     providerId: providerMatch.providerId,
     providerKey: providerMatch.providerKey,
     code,

--- a/src/server/email/handler.ts
+++ b/src/server/email/handler.ts
@@ -2,6 +2,7 @@ import {
   insertMessage,
   insertQuarantineMessage,
 } from "../db/repositories/messages";
+import { getHouseholdBySlug } from "../db/repositories/households";
 import { classifyEmail } from "../domain/classify-email";
 import type { AppContext } from "../runtime/context";
 import { parseIncomingEmail } from "./parse";
@@ -13,14 +14,34 @@ export async function handleIncomingEmail(
   const parsed = await parseIncomingEmail(message);
   const classification = await classifyEmail(appContext.env.DB, parsed);
 
+  if (!parsed.householdSlug) {
+    return;
+  }
+
   if (classification.kind === "quarantine") {
-    await insertQuarantineMessage(appContext.env.DB, parsed, classification);
+    const household = await getHouseholdBySlug(
+      appContext.env.DB,
+      parsed.householdSlug,
+    );
+    const householdId = household?.id ?? null;
+
+    if (!householdId) {
+      return;
+    }
+
+    await insertQuarantineMessage(
+      appContext.env.DB,
+      parsed,
+      householdId,
+      classification,
+    );
     return;
   }
 
   await insertMessage(
     appContext.env.DB,
     parsed,
+    classification.householdId,
     classification.providerId,
     classification,
   );

--- a/src/server/email/handler.ts
+++ b/src/server/email/handler.ts
@@ -1,8 +1,8 @@
+import { getHouseholdBySlug } from "../db/repositories/households";
 import {
   insertMessage,
   insertQuarantineMessage,
 } from "../db/repositories/messages";
-import { getHouseholdBySlug } from "../db/repositories/households";
 import { classifyEmail } from "../domain/classify-email";
 import type { AppContext } from "../runtime/context";
 import { parseIncomingEmail } from "./parse";

--- a/src/server/email/parse.ts
+++ b/src/server/email/parse.ts
@@ -2,6 +2,17 @@ import PostalMime from "postal-mime";
 
 import type { ParsedIncomingEmail } from "../db/types";
 
+function extractHouseholdSlug(address: string): string | null {
+  const normalized = address.trim().toLowerCase();
+  const localPart = normalized.split("@")[0]?.trim();
+
+  if (!localPart) {
+    return null;
+  }
+
+  return /^[a-z0-9-]+$/.test(localPart) ? localPart : null;
+}
+
 function stripHtml(html: string): string {
   return html
     .replace(/<[^>]+>/g, " ")
@@ -24,6 +35,7 @@ export async function parseIncomingEmail(
   return {
     envelopeFrom: message.from,
     envelopeTo: message.to,
+    householdSlug: extractHouseholdSlug(message.to),
     fromHeader:
       parsed.headers.find((header) => header.key.toLowerCase() === "from")
         ?.value ?? null,

--- a/src/server/email/sender.ts
+++ b/src/server/email/sender.ts
@@ -70,14 +70,14 @@ export async function sendHouseholdInvitationEmail(
     inviterEmail: string;
     inviteUrl: string;
     expiresAt: string;
-    role: "member" | "admin";
+    role: "member" | "owner";
   },
 ) {
   const safeInviteeName = escapeHtml(input.inviteeName);
   const safeInviterName = escapeHtml(input.inviterName);
   const safeInviterEmail = escapeHtml(input.inviterEmail);
   const safeInviteUrl = escapeHtml(input.inviteUrl);
-  const roleLabel = input.role === "admin" ? "Owner" : "Member";
+  const roleLabel = input.role === "owner" ? "Owner" : "Member";
 
   return sendTransactionalEmail(env, {
     to: input.to,

--- a/src/server/routes/admin.ts
+++ b/src/server/routes/admin.ts
@@ -1,7 +1,10 @@
 import { Hono } from "hono";
 
-import { authForEnv } from "../auth/auth";
-import { type AppVariables, requireOwner } from "../auth/middleware";
+import {
+  type AppVariables,
+  requireHouseholdContext,
+  requireOwner,
+} from "../auth/middleware";
 import {
   cancelInvitation,
   createHouseholdInvitation,
@@ -10,6 +13,12 @@ import {
   listHouseholdInvitations,
   refreshExpiredInvitations,
 } from "../db/repositories/invitations";
+import {
+  addUserToHousehold,
+  assertProvidersBelongToHousehold,
+  getHouseholdMembership,
+  updateHouseholdMembershipRole,
+} from "../db/repositories/households";
 import {
   grantProviderAccess,
   listMemberProviderAccess,
@@ -40,7 +49,6 @@ type AccessPayload = {
 type CreateMemberPayload = {
   email?: string;
   name?: string;
-  password?: string;
   role?: string;
 };
 
@@ -58,7 +66,7 @@ type SenderRulePayload = {
 type InvitationPayload = {
   email?: string;
   name?: string;
-  role?: InvitationRole;
+  role?: InvitationRole | "admin";
   providerIds?: string[];
 };
 
@@ -66,10 +74,6 @@ export const adminRoutes = new Hono<{
   Bindings: Env;
   Variables: AppVariables;
 }>();
-
-function mapStoredRoleToAppRole(role: string | null | undefined) {
-  return role === "admin" ? "admin" : "member";
-}
 
 function normalizeProviderKey(value: string | undefined) {
   return value?.trim().toLowerCase() ?? "";
@@ -99,12 +103,15 @@ function isValidMatchType(
   return value === "exact" || value === "domain";
 }
 
-adminRoutes.use("*", requireOwner);
+adminRoutes.use("/:slug/*", requireHouseholdContext);
+adminRoutes.use("/:slug/*", requireOwner);
 
-adminRoutes.get("/providers", async (c) => {
+adminRoutes.get("/:slug/providers", async (c) => {
+  const household = c.get("household");
+  if (!household) return c.json({ error: "Forbidden" }, 403);
   const [providers, rules] = await Promise.all([
-    listProviderConfigurations(c.env.DB),
-    listSenderRules(c.env.DB),
+    listProviderConfigurations(c.env.DB, household.id),
+    listSenderRules(c.env.DB, household.id),
   ]);
 
   return c.json({
@@ -113,7 +120,9 @@ adminRoutes.get("/providers", async (c) => {
   });
 });
 
-adminRoutes.post("/providers", async (c) => {
+adminRoutes.post("/:slug/providers", async (c) => {
+  const household = c.get("household");
+  if (!household) return c.json({ error: "Forbidden" }, 403);
   let payload: ProviderPayload;
 
   try {
@@ -129,18 +138,25 @@ adminRoutes.post("/providers", async (c) => {
     return c.json({ error: "providerKey and displayName are required" }, 400);
   }
 
-  const existing = await getProviderByKey(c.env.DB, providerKey);
+  const existing = await getProviderByKey(c.env.DB, household.id, providerKey);
 
   if (existing) {
     return c.json({ error: "Provider key already exists" }, 409);
   }
 
-  const provider = await createProvider(c.env.DB, providerKey, displayName);
+  const provider = await createProvider(
+    c.env.DB,
+    household.id,
+    providerKey,
+    displayName,
+  );
 
   return c.json({ provider }, 201);
 });
 
-adminRoutes.patch("/providers/:providerId", async (c) => {
+adminRoutes.patch("/:slug/providers/:providerId", async (c) => {
+  const household = c.get("household");
+  if (!household) return c.json({ error: "Forbidden" }, 403);
   let payload: ProviderPayload;
 
   try {
@@ -157,39 +173,49 @@ adminRoutes.patch("/providers/:providerId", async (c) => {
     return c.json({ error: "providerKey and displayName are required" }, 400);
   }
 
-  const existing = await getProviderById(c.env.DB, providerId);
+  const existing = await getProviderById(c.env.DB, household.id, providerId);
 
   if (!existing) {
     return c.json({ error: "Provider not found" }, 404);
   }
 
-  const conflict = await getProviderByKey(c.env.DB, providerKey);
+  const conflict = await getProviderByKey(c.env.DB, household.id, providerKey);
 
   if (conflict && conflict.id !== providerId) {
     return c.json({ error: "Provider key already exists" }, 409);
   }
 
-  await updateProvider(c.env.DB, providerId, providerKey, displayName);
+  await updateProvider(
+    c.env.DB,
+    household.id,
+    providerId,
+    providerKey,
+    displayName,
+  );
 
-  const provider = await getProviderById(c.env.DB, providerId);
+  const provider = await getProviderById(c.env.DB, household.id, providerId);
 
   return c.json({ provider });
 });
 
-adminRoutes.delete("/providers/:providerId", async (c) => {
+adminRoutes.delete("/:slug/providers/:providerId", async (c) => {
+  const household = c.get("household");
+  if (!household) return c.json({ error: "Forbidden" }, 403);
   const providerId = c.req.param("providerId");
-  const provider = await getProviderById(c.env.DB, providerId);
+  const provider = await getProviderById(c.env.DB, household.id, providerId);
 
   if (!provider) {
     return c.json({ error: "Provider not found" }, 404);
   }
 
-  await deleteProvider(c.env.DB, providerId);
+  await deleteProvider(c.env.DB, household.id, providerId);
 
   return c.json({ ok: true });
 });
 
-adminRoutes.post("/provider-rules", async (c) => {
+adminRoutes.post("/:slug/provider-rules", async (c) => {
+  const household = c.get("household");
+  if (!household) return c.json({ error: "Forbidden" }, 403);
   let payload: SenderRulePayload;
 
   try {
@@ -211,7 +237,7 @@ adminRoutes.post("/provider-rules", async (c) => {
     return c.json({ error: "matchValue is required" }, 400);
   }
 
-  const provider = await getProviderById(c.env.DB, payload.providerId);
+  const provider = await getProviderById(c.env.DB, household.id, payload.providerId);
 
   if (!provider) {
     return c.json({ error: "Provider not found" }, 404);
@@ -219,6 +245,7 @@ adminRoutes.post("/provider-rules", async (c) => {
 
   const rule = await createSenderRule(
     c.env.DB,
+    household.id,
     payload.providerId,
     payload.matchType,
     matchValue,
@@ -227,7 +254,9 @@ adminRoutes.post("/provider-rules", async (c) => {
   return c.json({ rule }, 201);
 });
 
-adminRoutes.patch("/provider-rules/:ruleId", async (c) => {
+adminRoutes.patch("/:slug/provider-rules/:ruleId", async (c) => {
+  const household = c.get("household");
+  if (!household) return c.json({ error: "Forbidden" }, 403);
   let payload: SenderRulePayload;
 
   try {
@@ -252,8 +281,8 @@ adminRoutes.patch("/provider-rules/:ruleId", async (c) => {
   }
 
   const [provider, existingRule] = await Promise.all([
-    getProviderById(c.env.DB, payload.providerId),
-    getSenderRuleById(c.env.DB, ruleId),
+    getProviderById(c.env.DB, household.id, payload.providerId),
+    getSenderRuleById(c.env.DB, household.id, ruleId),
   ]);
 
   if (!provider) {
@@ -266,35 +295,40 @@ adminRoutes.patch("/provider-rules/:ruleId", async (c) => {
 
   await updateSenderRule(
     c.env.DB,
+    household.id,
     ruleId,
     payload.providerId,
     payload.matchType,
     matchValue,
   );
 
-  const rule = await getSenderRuleById(c.env.DB, ruleId);
+  const rule = await getSenderRuleById(c.env.DB, household.id, ruleId);
 
   return c.json({ rule });
 });
 
-adminRoutes.delete("/provider-rules/:ruleId", async (c) => {
+adminRoutes.delete("/:slug/provider-rules/:ruleId", async (c) => {
+  const household = c.get("household");
+  if (!household) return c.json({ error: "Forbidden" }, 403);
   const ruleId = c.req.param("ruleId");
-  const rule = await getSenderRuleById(c.env.DB, ruleId);
+  const rule = await getSenderRuleById(c.env.DB, household.id, ruleId);
 
   if (!rule) {
     return c.json({ error: "Sender rule not found" }, 404);
   }
 
-  await deleteSenderRule(c.env.DB, ruleId);
+  await deleteSenderRule(c.env.DB, household.id, ruleId);
 
   return c.json({ ok: true });
 });
 
-adminRoutes.get("/members", async (c) => {
+adminRoutes.get("/:slug/members", async (c) => {
+  const household = c.get("household");
+  if (!household) return c.json({ error: "Forbidden" }, 403);
   const [members, accessRows, providers] = await Promise.all([
-    listMembers(c.env.DB),
-    listMemberProviderAccess(c.env.DB),
-    listProviders(c.env.DB),
+    listMembers(c.env.DB, household.id),
+    listMemberProviderAccess(c.env.DB, household.id),
+    listProviders(c.env.DB, household.id),
   ]);
 
   const accessByUserId = new Map<
@@ -318,20 +352,24 @@ adminRoutes.get("/members", async (c) => {
   return c.json({
     members: members.map((member) => ({
       ...member,
-      role: mapStoredRoleToAppRole(member.role),
-      providerAccess: accessByUserId.get(member.id) ?? [],
-    })),
+        role: member.householdRole === "owner" ? "admin" : "member",
+        providerAccess: accessByUserId.get(member.id) ?? [],
+      })),
     providers,
   });
 });
 
-adminRoutes.get("/invitations", async (c) => {
+adminRoutes.get("/:slug/invitations", async (c) => {
+  const household = c.get("household");
+  if (!household) return c.json({ error: "Forbidden" }, 403);
   await refreshExpiredInvitations(c.env.DB);
-  const invitations = await listHouseholdInvitations(c.env.DB);
+  const invitations = await listHouseholdInvitations(c.env.DB, household.id);
   return c.json({ invitations });
 });
 
-adminRoutes.post("/invitations", async (c) => {
+adminRoutes.post("/:slug/invitations", async (c) => {
+  const household = c.get("household");
+  if (!household) return c.json({ error: "Forbidden" }, 403);
   let payload: InvitationPayload;
 
   try {
@@ -342,13 +380,26 @@ adminRoutes.post("/invitations", async (c) => {
 
   const email = normalizeEmail(payload.email);
   const name = normalizeDisplayName(payload.name);
-  const role: InvitationRole = payload.role === "admin" ? "admin" : "member";
+  const role: InvitationRole =
+    payload.role === "owner" || payload.role === "admin"
+      ? "owner"
+      : "member";
   const providerIds = Array.isArray(payload.providerIds)
     ? payload.providerIds.filter((providerId) => Boolean(providerId))
     : [];
 
   if (!email || !name) {
     return c.json({ error: "email and name are required" }, 400);
+  }
+
+  const providersBelong = await assertProvidersBelongToHousehold(
+    c.env.DB,
+    household.id,
+    providerIds,
+  );
+
+  if (!providersBelong) {
+    return c.json({ error: "One or more selected providers do not belong to this household" }, 400);
   }
 
   const inviter = c.get("user");
@@ -362,6 +413,7 @@ adminRoutes.post("/invitations", async (c) => {
     Date.now() + 1000 * 60 * 60 * 24 * 7,
   ).toISOString();
   const invitationId = await createHouseholdInvitation(c.env.DB, {
+    householdId: household.id,
     email,
     name,
     role,
@@ -390,13 +442,19 @@ adminRoutes.post("/invitations", async (c) => {
   return c.json({ invitation }, 201);
 });
 
-adminRoutes.post("/invitations/:invitationId/resend", async (c) => {
+adminRoutes.post("/:slug/invitations/:invitationId/resend", async (c) => {
+  const household = c.get("household");
+  if (!household) return c.json({ error: "Forbidden" }, 403);
   await refreshExpiredInvitations(c.env.DB);
 
   const invitationId = c.req.param("invitationId");
   const invitation = await getInvitationById(c.env.DB, invitationId);
 
-  if (!invitation || invitation.status !== "pending") {
+  if (
+    !invitation ||
+    invitation.householdId !== household.id ||
+    invitation.status !== "pending"
+  ) {
     return c.json({ error: "Invitation not found or not resendable" }, 404);
   }
 
@@ -414,6 +472,7 @@ adminRoutes.post("/invitations/:invitationId/resend", async (c) => {
   await cancelInvitation(c.env.DB, invitationId);
 
   const replacementId = await createHouseholdInvitation(c.env.DB, {
+    householdId: household.id,
     email: invitation.email,
     name: invitation.name,
     role: invitation.role,
@@ -442,11 +501,13 @@ adminRoutes.post("/invitations/:invitationId/resend", async (c) => {
   return c.json({ invitation: replacement });
 });
 
-adminRoutes.delete("/invitations/:invitationId", async (c) => {
+adminRoutes.delete("/:slug/invitations/:invitationId", async (c) => {
+  const household = c.get("household");
+  if (!household) return c.json({ error: "Forbidden" }, 403);
   const invitationId = c.req.param("invitationId");
   const invitation = await getInvitationById(c.env.DB, invitationId);
 
-  if (!invitation) {
+  if (!invitation || invitation.householdId !== household.id) {
     return c.json({ error: "Invitation not found" }, 404);
   }
 
@@ -454,7 +515,9 @@ adminRoutes.delete("/invitations/:invitationId", async (c) => {
   return c.json({ ok: true });
 });
 
-adminRoutes.post("/members", async (c) => {
+adminRoutes.post("/:slug/members", async (c) => {
+  const household = c.get("household");
+  if (!household) return c.json({ error: "Forbidden" }, 403);
   let payload: CreateMemberPayload;
 
   try {
@@ -463,35 +526,54 @@ adminRoutes.post("/members", async (c) => {
     return c.json({ error: "Invalid JSON body" }, 400);
   }
 
-  if (!payload.email || !payload.name || !payload.password) {
-    return c.json({ error: "email, name, and password are required" }, 400);
+  if (!payload.email || !payload.name) {
+    return c.json({ error: "email and name are required" }, 400);
   }
 
-  const role = payload.role === "admin" ? "admin" : "user";
-  const headers = new Headers(c.req.raw.headers);
+  const inviter = c.get("user");
 
-  const created = await authForEnv(c.env).api.createUser({
-    body: {
-      email: payload.email,
-      name: payload.name,
-      password: payload.password,
-      role,
-    },
-    headers,
+  if (!inviter) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const { token, tokenHash } = await createInvitationToken();
+  const expiresAt = new Date(
+    Date.now() + 1000 * 60 * 60 * 24 * 7,
+  ).toISOString();
+  const invitationRole: InvitationRole =
+    payload.role === "admin" ? "owner" : "member";
+
+  const invitationId = await createHouseholdInvitation(c.env.DB, {
+    householdId: household.id,
+    email: normalizeEmail(payload.email),
+    name: payload.name.trim(),
+    role: invitationRole,
+    tokenHash,
+    invitedByUserId: inviter.id,
+    expiresAt,
+    providerIds: [],
   });
 
-  return c.json(
-    {
-      member: {
-        ...created.user,
-        role: mapStoredRoleToAppRole(created.user.role),
-      },
-    },
-    201,
-  );
+  const invitation = await getInvitationById(c.env.DB, invitationId);
+
+  if (!invitation) {
+    return c.json({ error: "Unable to create invitation" }, 500);
+  }
+
+  void sendHouseholdInvitationEmail(c.env, {
+    to: invitation.email,
+    inviteeName: invitation.name,
+    inviterName: inviter.email,
+    inviterEmail: inviter.email,
+    inviteUrl: `${c.env.APP_URL.replace(/\/$/, "")}/invite/${token}`,
+    expiresAt,
+    role: invitation.role,
+  });
+
+  return c.json({ invitation }, 201);
 });
 
-adminRoutes.patch("/members/:userId/role", async (c) => {
+adminRoutes.patch("/:slug/members/:userId/role", async (c) => {
   const userId = c.req.param("userId");
   const currentUser = c.get("user");
 
@@ -514,43 +596,30 @@ adminRoutes.patch("/members/:userId/role", async (c) => {
     return c.json({ error: "role must be admin or member" }, 400);
   }
 
-  await authForEnv(c.env).api.setRole({
-    body: {
-      userId,
-      role: payload.role === "admin" ? "admin" : "user",
-    },
-    headers: new Headers(c.req.raw.headers),
+  const household = c.get("household");
+
+  if (!household) {
+    return c.json({ error: "Forbidden" }, 403);
+  }
+
+  const membership = await getHouseholdMembership(c.env.DB, userId, household.id);
+
+  if (!membership) {
+    return c.json({ error: "Member not found" }, 404);
+  }
+
+  await updateHouseholdMembershipRole(c.env.DB, {
+    householdId: household.id,
+    userId,
+    role: payload.role === "admin" ? "owner" : "member",
   });
 
   return c.json({ ok: true });
 });
 
-adminRoutes.patch("/members/:userId/password", async (c) => {
-  const userId = c.req.param("userId");
-  let payload: { password?: string };
-
-  try {
-    payload = await c.req.json<{ password?: string }>();
-  } catch {
-    return c.json({ error: "Invalid JSON body" }, 400);
-  }
-
-  if (!payload.password) {
-    return c.json({ error: "password is required" }, 400);
-  }
-
-  await authForEnv(c.env).api.setUserPassword({
-    body: {
-      userId,
-      newPassword: payload.password,
-    },
-    headers: new Headers(c.req.raw.headers),
-  });
-
-  return c.json({ ok: true });
-});
-
-adminRoutes.post("/members/:userId/provider-access", async (c) => {
+adminRoutes.post("/:slug/members/:userId/provider-access", async (c) => {
+  const household = c.get("household");
+  if (!household) return c.json({ error: "Forbidden" }, 403);
   const userId = c.req.param("userId");
   let payload: AccessPayload;
 
@@ -564,17 +633,25 @@ adminRoutes.post("/members/:userId/provider-access", async (c) => {
     return c.json({ error: "providerKey is required" }, 400);
   }
 
-  const provider = await getProviderByKey(c.env.DB, payload.providerKey);
+  const provider = await getProviderByKey(c.env.DB, household.id, payload.providerKey);
 
   if (!provider) {
     return c.json({ error: "Provider not found" }, 404);
   }
 
-  await grantProviderAccess(c.env.DB, userId, provider.id);
+  const membership = await getHouseholdMembership(c.env.DB, userId, household.id);
+
+  if (!membership) {
+    return c.json({ error: "Member not found" }, 404);
+  }
+
+  await grantProviderAccess(c.env.DB, household.id, userId, provider.id);
   return c.json({ ok: true });
 });
 
-adminRoutes.delete("/members/:userId/provider-access", async (c) => {
+adminRoutes.delete("/:slug/members/:userId/provider-access", async (c) => {
+  const household = c.get("household");
+  if (!household) return c.json({ error: "Forbidden" }, 403);
   const userId = c.req.param("userId");
   let payload: AccessPayload;
 
@@ -588,12 +665,18 @@ adminRoutes.delete("/members/:userId/provider-access", async (c) => {
     return c.json({ error: "providerKey is required" }, 400);
   }
 
-  const provider = await getProviderByKey(c.env.DB, payload.providerKey);
+  const provider = await getProviderByKey(c.env.DB, household.id, payload.providerKey);
 
   if (!provider) {
     return c.json({ error: "Provider not found" }, 404);
   }
 
-  await revokeProviderAccess(c.env.DB, userId, provider.id);
+  const membership = await getHouseholdMembership(c.env.DB, userId, household.id);
+
+  if (!membership) {
+    return c.json({ error: "Member not found" }, 404);
+  }
+
+  await revokeProviderAccess(c.env.DB, household.id, userId, provider.id);
   return c.json({ ok: true });
 });

--- a/src/server/routes/admin.ts
+++ b/src/server/routes/admin.ts
@@ -6,6 +6,11 @@ import {
   requireOwner,
 } from "../auth/middleware";
 import {
+  assertProvidersBelongToHousehold,
+  getHouseholdMembership,
+  updateHouseholdMembershipRole,
+} from "../db/repositories/households";
+import {
   cancelInvitation,
   createHouseholdInvitation,
   getInvitationById,
@@ -13,12 +18,6 @@ import {
   listHouseholdInvitations,
   refreshExpiredInvitations,
 } from "../db/repositories/invitations";
-import {
-  addUserToHousehold,
-  assertProvidersBelongToHousehold,
-  getHouseholdMembership,
-  updateHouseholdMembershipRole,
-} from "../db/repositories/households";
 import {
   grantProviderAccess,
   listMemberProviderAccess,
@@ -237,7 +236,11 @@ adminRoutes.post("/:slug/provider-rules", async (c) => {
     return c.json({ error: "matchValue is required" }, 400);
   }
 
-  const provider = await getProviderById(c.env.DB, household.id, payload.providerId);
+  const provider = await getProviderById(
+    c.env.DB,
+    household.id,
+    payload.providerId,
+  );
 
   if (!provider) {
     return c.json({ error: "Provider not found" }, 404);
@@ -352,9 +355,9 @@ adminRoutes.get("/:slug/members", async (c) => {
   return c.json({
     members: members.map((member) => ({
       ...member,
-        role: member.householdRole === "owner" ? "admin" : "member",
-        providerAccess: accessByUserId.get(member.id) ?? [],
-      })),
+      role: member.householdRole === "owner" ? "admin" : "member",
+      providerAccess: accessByUserId.get(member.id) ?? [],
+    })),
     providers,
   });
 });
@@ -381,9 +384,7 @@ adminRoutes.post("/:slug/invitations", async (c) => {
   const email = normalizeEmail(payload.email);
   const name = normalizeDisplayName(payload.name);
   const role: InvitationRole =
-    payload.role === "owner" || payload.role === "admin"
-      ? "owner"
-      : "member";
+    payload.role === "owner" || payload.role === "admin" ? "owner" : "member";
   const providerIds = Array.isArray(payload.providerIds)
     ? payload.providerIds.filter((providerId) => Boolean(providerId))
     : [];
@@ -399,7 +400,12 @@ adminRoutes.post("/:slug/invitations", async (c) => {
   );
 
   if (!providersBelong) {
-    return c.json({ error: "One or more selected providers do not belong to this household" }, 400);
+    return c.json(
+      {
+        error: "One or more selected providers do not belong to this household",
+      },
+      400,
+    );
   }
 
   const inviter = c.get("user");
@@ -602,7 +608,11 @@ adminRoutes.patch("/:slug/members/:userId/role", async (c) => {
     return c.json({ error: "Forbidden" }, 403);
   }
 
-  const membership = await getHouseholdMembership(c.env.DB, userId, household.id);
+  const membership = await getHouseholdMembership(
+    c.env.DB,
+    userId,
+    household.id,
+  );
 
   if (!membership) {
     return c.json({ error: "Member not found" }, 404);
@@ -633,13 +643,21 @@ adminRoutes.post("/:slug/members/:userId/provider-access", async (c) => {
     return c.json({ error: "providerKey is required" }, 400);
   }
 
-  const provider = await getProviderByKey(c.env.DB, household.id, payload.providerKey);
+  const provider = await getProviderByKey(
+    c.env.DB,
+    household.id,
+    payload.providerKey,
+  );
 
   if (!provider) {
     return c.json({ error: "Provider not found" }, 404);
   }
 
-  const membership = await getHouseholdMembership(c.env.DB, userId, household.id);
+  const membership = await getHouseholdMembership(
+    c.env.DB,
+    userId,
+    household.id,
+  );
 
   if (!membership) {
     return c.json({ error: "Member not found" }, 404);
@@ -665,13 +683,21 @@ adminRoutes.delete("/:slug/members/:userId/provider-access", async (c) => {
     return c.json({ error: "providerKey is required" }, 400);
   }
 
-  const provider = await getProviderByKey(c.env.DB, household.id, payload.providerKey);
+  const provider = await getProviderByKey(
+    c.env.DB,
+    household.id,
+    payload.providerKey,
+  );
 
   if (!provider) {
     return c.json({ error: "Provider not found" }, 404);
   }
 
-  const membership = await getHouseholdMembership(c.env.DB, userId, household.id);
+  const membership = await getHouseholdMembership(
+    c.env.DB,
+    userId,
+    household.id,
+  );
 
   if (!membership) {
     return c.json({ error: "Member not found" }, 404);

--- a/src/server/routes/households.ts
+++ b/src/server/routes/households.ts
@@ -60,7 +60,10 @@ householdRoutes.post("/", async (c) => {
 
   if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
     return c.json(
-      { error: "slug is required and may only contain lowercase letters, numbers, and hyphens" },
+      {
+        error:
+          "slug is required and may only contain lowercase letters, numbers, and hyphens",
+      },
       400,
     );
   }

--- a/src/server/routes/households.ts
+++ b/src/server/routes/households.ts
@@ -1,0 +1,85 @@
+import { Hono } from "hono";
+
+import {
+  type AppVariables,
+  requireAuthenticatedUser,
+} from "../auth/middleware";
+import {
+  createHousehold,
+  getHouseholdBySlug,
+  listHouseholdsForUser,
+} from "../db/repositories/households";
+
+type CreateHouseholdPayload = {
+  slug?: string;
+  displayName?: string;
+};
+
+function normalizeSlug(value: string | undefined) {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+function normalizeDisplayName(value: string | undefined) {
+  return value?.trim() ?? "";
+}
+
+export const householdRoutes = new Hono<{
+  Bindings: Env;
+  Variables: AppVariables;
+}>();
+
+householdRoutes.use("*", requireAuthenticatedUser);
+
+householdRoutes.get("/me", async (c) => {
+  const user = c.get("user");
+
+  if (!user) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  return c.json({ households: await listHouseholdsForUser(c.env.DB, user.id) });
+});
+
+householdRoutes.post("/", async (c) => {
+  const user = c.get("user");
+
+  if (!user) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  let payload: CreateHouseholdPayload;
+
+  try {
+    payload = await c.req.json<CreateHouseholdPayload>();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+
+  const slug = normalizeSlug(payload.slug);
+  const displayName = normalizeDisplayName(payload.displayName);
+
+  if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
+    return c.json(
+      { error: "slug is required and may only contain lowercase letters, numbers, and hyphens" },
+      400,
+    );
+  }
+
+  if (!displayName) {
+    return c.json({ error: "displayName is required" }, 400);
+  }
+
+  const existing = await getHouseholdBySlug(c.env.DB, slug);
+
+  if (existing) {
+    return c.json({ error: "Household slug already exists" }, 409);
+  }
+
+  const household = await createHousehold(c.env.DB, {
+    slug,
+    displayName,
+    ownerUserId: user.id,
+  });
+
+  return c.json({ household }, 201);
+});

--- a/src/server/routes/inbox.ts
+++ b/src/server/routes/inbox.ts
@@ -2,8 +2,8 @@ import { Hono } from "hono";
 
 import {
   type AppVariables,
-  requireHouseholdContext,
   requireAuthenticatedUser,
+  requireHouseholdContext,
   requireOwner,
 } from "../auth/middleware";
 import {
@@ -104,7 +104,11 @@ inboxRoutes.patch("/:slug/messages/:messageId/status", async (c) => {
     return c.json({ error: "Unauthorized" }, 401);
   }
 
-  const existingMessage = await findMessageById(c.env.DB, household.id, messageId);
+  const existingMessage = await findMessageById(
+    c.env.DB,
+    household.id,
+    messageId,
+  );
 
   if (!existingMessage) {
     return c.json({ error: "Message not found" }, 404);
@@ -206,10 +210,15 @@ inboxRoutes.post("/:slug/quarantine/:messageId/review", async (c) => {
     providerId = provider.id;
   }
 
-  const result = await reviewQuarantineMessage(c.env.DB, household.id, messageId, {
-    action: payload.action,
-    providerId,
-  });
+  const result = await reviewQuarantineMessage(
+    c.env.DB,
+    household.id,
+    messageId,
+    {
+      action: payload.action,
+      providerId,
+    },
+  );
 
   if (!result) {
     return c.json({ error: "Quarantine message not found" }, 404);

--- a/src/server/routes/inbox.ts
+++ b/src/server/routes/inbox.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 
 import {
   type AppVariables,
+  requireHouseholdContext,
   requireAuthenticatedUser,
   requireOwner,
 } from "../auth/middleware";
@@ -32,48 +33,59 @@ export const inboxRoutes = new Hono<{
 }>();
 
 inboxRoutes.use("/providers", requireAuthenticatedUser);
-inboxRoutes.use("/providers/:providerKey", requireAuthenticatedUser);
-inboxRoutes.use("/messages/:messageId/status", requireAuthenticatedUser);
-inboxRoutes.use("/quarantine", requireOwner);
-inboxRoutes.use("/quarantine/:messageId/review", requireOwner);
+inboxRoutes.use("/:slug/*", requireAuthenticatedUser);
+inboxRoutes.use("/:slug/*", requireHouseholdContext);
+inboxRoutes.use("/:slug/quarantine", requireOwner);
+inboxRoutes.use("/:slug/quarantine/:messageId/review", requireOwner);
 
-inboxRoutes.get("/providers", async (c) => {
+inboxRoutes.get("/:slug/providers", async (c) => {
   const user = c.get("user");
+  const household = c.get("household");
 
-  if (!user) {
+  if (!user || !household) {
     return c.json({ error: "Unauthorized" }, 401);
   }
 
   const providers = await listProviderSummariesForUser(
     c.env.DB,
+    household.id,
     user.id,
-    user.role,
   );
   return c.json({ providers });
 });
 
-inboxRoutes.get("/providers/:providerKey", async (c) => {
+inboxRoutes.get("/:slug/providers/:providerKey", async (c) => {
   const providerKey = c.req.param("providerKey");
   const user = c.get("user");
+  const household = c.get("household");
 
-  if (!user) {
+  if (!user || !household) {
     return c.json({ error: "Unauthorized" }, 401);
   }
 
-  if (user.role !== "admin") {
-    const allowed = await userHasProviderAccess(c.env.DB, user.id, providerKey);
+  if (household.role !== "owner") {
+    const allowed = await userHasProviderAccess(
+      c.env.DB,
+      household.id,
+      user.id,
+      providerKey,
+    );
     if (!allowed) {
       return c.json({ error: "Forbidden" }, 403);
     }
   }
 
-  const provider = await getProviderByKey(c.env.DB, providerKey);
+  const provider = await getProviderByKey(c.env.DB, household.id, providerKey);
 
   if (!provider) {
     return c.json({ error: "Provider not found" }, 404);
   }
 
-  const messages = await listMessagesForProvider(c.env.DB, providerKey);
+  const messages = await listMessagesForProvider(
+    c.env.DB,
+    household.id,
+    providerKey,
+  );
   return c.json({
     provider: {
       providerKey: provider.provider_key,
@@ -83,23 +95,25 @@ inboxRoutes.get("/providers/:providerKey", async (c) => {
   });
 });
 
-inboxRoutes.patch("/messages/:messageId/status", async (c) => {
+inboxRoutes.patch("/:slug/messages/:messageId/status", async (c) => {
   const user = c.get("user");
+  const household = c.get("household");
   const messageId = c.req.param("messageId");
 
-  if (!user) {
+  if (!user || !household) {
     return c.json({ error: "Unauthorized" }, 401);
   }
 
-  const existingMessage = await findMessageById(c.env.DB, messageId);
+  const existingMessage = await findMessageById(c.env.DB, household.id, messageId);
 
   if (!existingMessage) {
     return c.json({ error: "Message not found" }, 404);
   }
 
-  if (user.role !== "admin") {
+  if (household.role !== "owner") {
     const allowed = await userHasProviderAccess(
       c.env.DB,
+      household.id,
       user.id,
       existingMessage.provider_key,
     );
@@ -123,6 +137,7 @@ inboxRoutes.patch("/messages/:messageId/status", async (c) => {
 
   const message = await updateMessageStatus(
     c.env.DB,
+    household.id,
     messageId,
     payload.status,
   );
@@ -134,13 +149,24 @@ inboxRoutes.patch("/messages/:messageId/status", async (c) => {
   return c.json({ message });
 });
 
-inboxRoutes.get("/quarantine", async (c) => {
-  const messages = await listQuarantineMessages(c.env.DB);
+inboxRoutes.get("/:slug/quarantine", async (c) => {
+  const household = c.get("household");
+
+  if (!household) {
+    return c.json({ error: "Forbidden" }, 403);
+  }
+
+  const messages = await listQuarantineMessages(c.env.DB, household.id);
   return c.json({ messages });
 });
 
-inboxRoutes.post("/quarantine/:messageId/review", async (c) => {
+inboxRoutes.post("/:slug/quarantine/:messageId/review", async (c) => {
+  const household = c.get("household");
   const messageId = c.req.param("messageId");
+
+  if (!household) {
+    return c.json({ error: "Forbidden" }, 403);
+  }
 
   let payload: { action?: "dismiss" | "release"; providerKey?: string };
 
@@ -167,7 +193,11 @@ inboxRoutes.post("/quarantine/:messageId/review", async (c) => {
       );
     }
 
-    const provider = await getProviderByKey(c.env.DB, payload.providerKey);
+    const provider = await getProviderByKey(
+      c.env.DB,
+      household.id,
+      payload.providerKey,
+    );
 
     if (!provider) {
       return c.json({ error: "Provider not found" }, 404);
@@ -176,7 +206,7 @@ inboxRoutes.post("/quarantine/:messageId/review", async (c) => {
     providerId = provider.id;
   }
 
-  const result = await reviewQuarantineMessage(c.env.DB, messageId, {
+  const result = await reviewQuarantineMessage(c.env.DB, household.id, messageId, {
     action: payload.action,
     providerId,
   });

--- a/src/server/routes/invitations.ts
+++ b/src/server/routes/invitations.ts
@@ -1,8 +1,9 @@
 import { isAPIError } from "better-auth/api";
 import { Hono } from "hono";
 
-import { authForEnv } from "../auth/auth";
+import { provisioningAuthForEnv } from "../auth/auth";
 import { loadAuthSession, requireAuthenticatedUser } from "../auth/middleware";
+import { getHouseholdById } from "../db/repositories/households";
 import {
   acceptInvitation,
   getInvitationByTokenHash,
@@ -25,7 +26,10 @@ function withoutToken(
   return invitation;
 }
 
-export const invitationRoutes = new Hono<{ Bindings: Env }>();
+export const invitationRoutes = new Hono<{
+  Bindings: Env;
+  Variables: import("../auth/middleware").AppVariables;
+}>();
 
 invitationRoutes.use("*", loadAuthSession);
 
@@ -68,47 +72,80 @@ invitationRoutes.post("/:token/accept", async (c) => {
     return c.json({ error: "Invitation not found or no longer valid" }, 404);
   }
 
-  const auth = authForEnv(c.env);
+  const auth = provisioningAuthForEnv(c.env);
+  const currentUser = c.get("user");
 
-  try {
-    const created = await auth.api.createUser({
-      body: {
-        email: invitation.email,
-        name: payload.name.trim(),
-        password: payload.password,
-        role: invitation.role === "admin" ? "admin" : "user",
-      },
-    });
+  if (currentUser) {
+    if (currentUser.email.toLowerCase() !== invitation.email.toLowerCase()) {
+      return c.json(
+        {
+          error:
+            "You are signed in as a different account. Sign out and accept the invitation with the invited email address.",
+        },
+        403,
+      );
+    }
 
     await acceptInvitation(c.env.DB, {
       invitationId: invitation.id,
-      acceptedByUserId: created.user.id,
-      providerIds: invitation.providers.map((provider) => provider.id),
+      householdId: invitation.householdId,
+      acceptedByUserId: currentUser.id,
+      role: invitation.role,
     });
 
-    const signInResult = await auth.api.signInEmail({
+    const household = await getHouseholdById(c.env.DB, invitation.householdId);
+
+    return c.json(
+      {
+        member: {
+          id: currentUser.id,
+          email: currentUser.email,
+          name: payload.name.trim(),
+          role: invitation.role,
+        },
+        household,
+      },
+      200,
+    );
+  }
+
+  try {
+    const signUpResult = await auth.api.signUpEmail({
       body: {
         email: invitation.email,
+        name: payload.name.trim(),
         password: payload.password,
       },
       headers: new Headers(c.req.raw.headers),
       returnHeaders: true,
     });
 
+    const createdUser = signUpResult.response.user;
+
+    await acceptInvitation(c.env.DB, {
+      invitationId: invitation.id,
+      householdId: invitation.householdId,
+      acceptedByUserId: createdUser.id,
+      role: invitation.role,
+    });
+
+    const household = await getHouseholdById(c.env.DB, invitation.householdId);
+
     const response = c.json(
       {
         member: {
-          id: created.user.id,
-          email: created.user.email,
-          name: created.user.name,
+          id: createdUser.id,
+          email: createdUser.email,
+          name: createdUser.name,
           role: invitation.role,
         },
-        session: signInResult.response,
+        household,
+        session: signUpResult.response,
       },
       201,
     );
 
-    for (const cookie of signInResult.headers.getSetCookie()) {
+    for (const cookie of signUpResult.headers.getSetCookie()) {
       response.headers.append("set-cookie", cookie);
     }
 

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -43,6 +43,16 @@ settingsRoutes.get("/", async (c) => {
   return c.json({ profile, sessions });
 });
 
+settingsRoutes.get("/households", async (c) => {
+  const currentUser = c.get("user");
+
+  if (!currentUser) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  return c.json({ households: currentUser.households });
+});
+
 settingsRoutes.patch("/profile", async (c) => {
   const currentUser = c.get("user");
 

--- a/src/server/routes/setup.ts
+++ b/src/server/routes/setup.ts
@@ -1,18 +1,21 @@
 import { isAPIError } from "better-auth/api";
 import { Hono } from "hono";
 
-import { authForEnv } from "../auth/auth";
+import { provisioningAuthForEnv } from "../auth/auth";
 import {
   beginInstallationSetup,
   completeInstallationSetup,
   getInstallationState,
   resetInstallationSetup,
 } from "../db/repositories/installation-state";
+import { createHousehold } from "../db/repositories/households";
 
 type SetupPayload = {
   email?: string;
   name?: string;
   password?: string;
+  householdName?: string;
+  householdSlug?: string;
   setupSecret?: string;
 };
 
@@ -36,6 +39,10 @@ function mapInstallationStatus(
     status: row.status,
     ownerEmail: row.owner_email,
   };
+}
+
+function normalizeSlug(value: string | undefined) {
+  return value?.trim().toLowerCase() ?? "";
 }
 
 setupRoutes.get("/status", async (c) => {
@@ -66,10 +73,15 @@ setupRoutes.post("/complete", async (c) => {
     !payload.email ||
     !payload.name ||
     !payload.password ||
+    !payload.householdName ||
+    !payload.householdSlug ||
     !payload.setupSecret
   ) {
     return c.json(
-      { error: "email, name, password, and setupSecret are required" },
+      {
+        error:
+          "email, name, password, householdName, householdSlug, and setupSecret are required",
+      },
       400,
     );
   }
@@ -89,6 +101,18 @@ setupRoutes.post("/complete", async (c) => {
     return c.json({ error: "Password must be at least 12 characters" }, 400);
   }
 
+  const householdSlug = normalizeSlug(payload.householdSlug);
+
+  if (!/^[a-z0-9-]+$/.test(householdSlug)) {
+    return c.json(
+      {
+        error:
+          "householdSlug may only contain lowercase letters, numbers, and hyphens",
+      },
+      400,
+    );
+  }
+
   const state = await getInstallationState(c.env.DB);
 
   if (state.status === "complete") {
@@ -104,43 +128,44 @@ setupRoutes.post("/complete", async (c) => {
     );
   }
 
-  const auth = authForEnv(c.env);
+  const auth = provisioningAuthForEnv(c.env);
 
   try {
-    const created = await auth.api.createUser({
+    const signUpResult = await auth.api.signUpEmail({
       body: {
         email: requestedEmail,
         name: payload.name.trim(),
-        password: payload.password,
-        role: "admin",
-      },
-    });
-
-    await completeInstallationSetup(c.env.DB, created.user.id, requestedEmail);
-
-    const signInResult = await auth.api.signInEmail({
-      body: {
-        email: requestedEmail,
         password: payload.password,
       },
       headers: new Headers(c.req.raw.headers),
       returnHeaders: true,
     });
 
+    const createdUser = signUpResult.response.user;
+
+    const household = await createHousehold(c.env.DB, {
+      slug: householdSlug,
+      displayName: payload.householdName.trim(),
+      ownerUserId: createdUser.id,
+    });
+
+    await completeInstallationSetup(c.env.DB, createdUser.id, requestedEmail);
+
     const response = c.json(
       {
         member: {
-          id: created.user.id,
-          email: created.user.email,
-          name: created.user.name,
-          role: "admin",
+          id: createdUser.id,
+          email: createdUser.email,
+          name: createdUser.name,
+          role: "owner",
         },
-        session: signInResult.response,
+        household,
+        session: signUpResult.response,
       },
       201,
     );
 
-    for (const cookie of signInResult.headers.getSetCookie()) {
+    for (const cookie of signUpResult.headers.getSetCookie()) {
       response.headers.append("set-cookie", cookie);
     }
 

--- a/src/server/routes/setup.ts
+++ b/src/server/routes/setup.ts
@@ -2,13 +2,13 @@ import { isAPIError } from "better-auth/api";
 import { Hono } from "hono";
 
 import { provisioningAuthForEnv } from "../auth/auth";
+import { createHousehold } from "../db/repositories/households";
 import {
   beginInstallationSetup,
   completeInstallationSetup,
   getInstallationState,
   resetInstallationSetup,
 } from "../db/repositories/installation-state";
-import { createHousehold } from "../db/repositories/households";
 
 type SetupPayload = {
   email?: string;

--- a/test/classify-email.test.ts
+++ b/test/classify-email.test.ts
@@ -4,14 +4,12 @@ import type { ParsedIncomingEmail } from "../src/server/db/types";
 import { classifyEmail } from "../src/server/domain/classify-email";
 
 function createDbStub(
-  match:
-    | {
-        householdId: string;
-        householdSlug: string;
-        providerId: string;
-        providerKey: string;
-      }
-    | null,
+  match: {
+    householdId: string;
+    householdSlug: string;
+    providerId: string;
+    providerKey: string;
+  } | null,
 ): D1Database {
   let call = 0;
 

--- a/test/classify-email.test.ts
+++ b/test/classify-email.test.ts
@@ -4,13 +4,39 @@ import type { ParsedIncomingEmail } from "../src/server/db/types";
 import { classifyEmail } from "../src/server/domain/classify-email";
 
 function createDbStub(
-  match: { providerId: string; providerKey: string } | null,
+  match:
+    | {
+        householdId: string;
+        householdSlug: string;
+        providerId: string;
+        providerKey: string;
+      }
+    | null,
 ): D1Database {
+  let call = 0;
+
+  const nextResult = () => {
+    call += 1;
+
+    if (call === 1) {
+      return { id: "household-1", slug: "codes", displayName: "Codes" };
+    }
+
+    return match;
+  };
+
   return {
     prepare: () => ({
       bind: () => ({
-        all: async () => ({ results: match ? [match] : [] }),
-        first: async () => match,
+        all: async () => {
+          const result = nextResult();
+          return { results: result ? [result] : [] };
+        },
+        first: async () => nextResult(),
+        raw: async () => {
+          const result = nextResult();
+          return result ? [result] : [];
+        },
       }),
     }),
   } as unknown as D1Database;
@@ -22,6 +48,7 @@ function createParsedEmail(
   return {
     envelopeFrom: "login@service.example",
     envelopeTo: "codes@example.com",
+    householdSlug: "codes",
     fromHeader: "Service <login@service.example>",
     subject: "Your verification code",
     messageId: "<test-1@example.com>",
@@ -35,12 +62,19 @@ function createParsedEmail(
 describe("classifyEmail", () => {
   it("matches a configured provider and extracts the code", async () => {
     const result = await classifyEmail(
-      createDbStub({ providerId: "provider-1", providerKey: "netflix" }),
+      createDbStub({
+        householdId: "household-1",
+        householdSlug: "codes",
+        providerId: "provider-1",
+        providerKey: "netflix",
+      }),
       createParsedEmail(),
     );
 
     expect(result).toEqual({
       kind: "matched",
+      householdId: "household-1",
+      householdSlug: "codes",
       providerId: "provider-1",
       providerKey: "netflix",
       code: "123456",
@@ -54,7 +88,8 @@ describe("classifyEmail", () => {
 
     expect(result).toEqual({
       kind: "quarantine",
-      reason: "No sender rule matched the inbound email.",
+      reason:
+        "No sender rule matched the inbound email within the addressed household.",
       code: "123456",
     });
   });

--- a/test/email-handler.test.ts
+++ b/test/email-handler.test.ts
@@ -1,22 +1,84 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { handleIncomingEmail } from "../src/server/email/handler";
-import type { AppContext } from "../src/server/runtime/context";
+const parseState = vi.hoisted(() => ({
+  result: {
+    envelopeFrom: "login@service.example",
+    envelopeTo: "codes@example.com",
+    householdSlug: "codes",
+    fromHeader: "Service <login@service.example>",
+    subject: "Verification code",
+    messageId: "<message-1@test>",
+    dateHeader: "2026-05-10T12:00:00.000Z",
+    textBody: "Your verification code is 123456",
+    rawSize: 128,
+  },
+}));
 
-function createMessage(
-  raw: string,
-  overrides?: Partial<ForwardableEmailMessage>,
-) {
+const classifyState = vi.hoisted(() => ({
+  result: {
+    kind: "matched",
+    householdId: "household-1",
+    householdSlug: "codes",
+    providerId: "provider-1",
+    providerKey: "netflix",
+    code: "123456",
+    reason: "Sender matched a configured rule and a likely verification code was found.",
+  } as
+    | {
+        kind: "matched";
+        householdId: string;
+        householdSlug: string;
+        providerId: string;
+        providerKey: string;
+        code: string | null;
+        reason: string;
+      }
+    | {
+        kind: "quarantine";
+        reason: string;
+        code: string | null;
+      },
+}));
+
+const messageRepoState = vi.hoisted(() => ({
+  insertMessage: vi.fn(),
+  insertQuarantineMessage: vi.fn(),
+}));
+
+const householdRepoState = vi.hoisted(() => ({
+  getHouseholdBySlug: vi.fn(),
+}));
+
+vi.mock("../src/server/email/parse", () => ({
+  parseIncomingEmail: vi.fn(async () => parseState.result),
+}));
+
+vi.mock("../src/server/domain/classify-email", () => ({
+  classifyEmail: vi.fn(async () => classifyState.result),
+}));
+
+vi.mock("../src/server/db/repositories/messages", () => ({
+  insertMessage: messageRepoState.insertMessage,
+  insertQuarantineMessage: messageRepoState.insertQuarantineMessage,
+}));
+
+vi.mock("../src/server/db/repositories/households", () => ({
+  getHouseholdBySlug: householdRepoState.getHouseholdBySlug,
+}));
+
+const { handleIncomingEmail } = await import("../src/server/email/handler");
+
+function createMessage(): ForwardableEmailMessage {
   return {
     from: "login@service.example",
     to: "codes@example.com",
     raw: new ReadableStream<Uint8Array>({
       start(controller) {
-        controller.enqueue(new TextEncoder().encode(raw));
+        controller.enqueue(new TextEncoder().encode("raw"));
         controller.close();
       },
     }),
-    rawSize: raw.length,
+    rawSize: 128,
     headers: new Headers(),
     setReject() {},
     forward() {
@@ -25,34 +87,13 @@ function createMessage(
     reply() {
       return Promise.resolve();
     },
-    ...overrides,
   } as unknown as ForwardableEmailMessage;
 }
 
-function createDb(match: { providerId: string; providerKey: string } | null) {
-  const run = vi.fn(async () => ({ results: [] }));
-  const first = vi.fn(async () => match);
-  const all = vi.fn(async () => ({ results: match ? [match] : [] }));
-  const bind = vi.fn(() => ({ all, first, run }));
-  const prepare = vi.fn(() => ({ bind, all, first, run }));
-
-  return {
-    db: {
-      prepare,
-      batch: vi.fn(async () => []),
-    } as unknown as D1Database,
-    prepare,
-    bind,
-    all,
-    first,
-    run,
-  };
-}
-
-function createAppContext(db: D1Database): AppContext {
+function createAppContext(): import("../src/server/runtime/context").AppContext {
   return {
     env: {
-      DB: db,
+      DB: {} as D1Database,
     } as Env,
     executionContext: {
       waitUntil() {},
@@ -63,92 +104,89 @@ function createAppContext(db: D1Database): AppContext {
 }
 
 describe("handleIncomingEmail", () => {
-  it("persists a matched email to messages without a second provider lookup", async () => {
-    const db = createDb({ providerId: "provider-1", providerKey: "netflix" });
-
-    await handleIncomingEmail(
-      createMessage(
-        [
-          "From: Service <login@service.example>",
-          "To: codes@example.com",
-          "Subject: Verification code",
-          "",
-          "Your verification code is 123456",
-        ].join("\n"),
-      ),
-      createAppContext(db.db),
-    );
-
-    expect(db.run).toHaveBeenCalledTimes(1);
-    expect(db.prepare).toHaveBeenCalledWith(
-      expect.stringContaining("INSERT INTO messages"),
-    );
-  });
-
-  it("routes unmatched senders into quarantine", async () => {
-    const db = createDb(null);
-
-    await handleIncomingEmail(
-      createMessage(
-        [
-          "From: Unknown <unknown@example.net>",
-          "To: codes@example.com",
-          "Subject: Sign in",
-          "",
-          "Use 654321 to continue.",
-        ].join("\n"),
-        { from: "unknown@example.net" },
-      ),
-      createAppContext(db.db),
-    );
-
-    expect(db.run).toHaveBeenCalledTimes(1);
-    expect(db.prepare).toHaveBeenCalledWith(
-      expect.stringContaining("INSERT INTO quarantine_messages"),
-    );
-  });
-
-  it("ignores duplicate message deliveries without failing the handler", async () => {
-    const duplicateError = new Error(
-      "UNIQUE constraint failed: messages.message_id",
-    );
-    const run = vi.fn(async () => {
-      throw duplicateError;
-    });
-    const first = vi.fn(async () => ({
+  beforeEach(() => {
+    parseState.result = {
+      envelopeFrom: "login@service.example",
+      envelopeTo: "codes@example.com",
+      householdSlug: "codes",
+      fromHeader: "Service <login@service.example>",
+      subject: "Verification code",
+      messageId: "<message-1@test>",
+      dateHeader: "2026-05-10T12:00:00.000Z",
+      textBody: "Your verification code is 123456",
+      rawSize: 128,
+    };
+    classifyState.result = {
+      kind: "matched",
+      householdId: "household-1",
+      householdSlug: "codes",
       providerId: "provider-1",
       providerKey: "netflix",
-    }));
-    const all = vi.fn(async () => ({
-      results: [{ providerId: "provider-1", providerKey: "netflix" }],
-    }));
-    const bind = vi.fn(() => ({ all, first, run }));
-    const prepare = vi.fn(() => ({ bind, all, first, run }));
+      code: "123456",
+      reason: "Sender matched a configured rule and a likely verification code was found.",
+    };
+    messageRepoState.insertMessage.mockReset();
+    messageRepoState.insertQuarantineMessage.mockReset();
+    householdRepoState.getHouseholdBySlug.mockReset();
+    householdRepoState.getHouseholdBySlug.mockResolvedValue({
+      id: "household-1",
+      slug: "codes",
+      displayName: "Codes",
+    });
+  });
 
-    const db = {
-      prepare,
-      batch: vi.fn(async () => []),
-    } as unknown as D1Database;
+  it("persists matched emails to messages", async () => {
+    await handleIncomingEmail(createMessage(), createAppContext());
 
-    await expect(
-      handleIncomingEmail(
-        createMessage(
-          [
-            "From: Service <login@service.example>",
-            "To: codes@example.com",
-            "Subject: Verification code",
-            "Message-ID: <duplicate@test>",
-            "",
-            "Your verification code is 123456",
-          ].join("\n"),
-        ),
-        createAppContext(db),
-      ),
-    ).resolves.toBeUndefined();
-
-    expect(prepare).toHaveBeenCalledWith(
-      expect.stringContaining("INSERT INTO messages"),
+    expect(messageRepoState.insertMessage).toHaveBeenCalledWith(
+      expect.anything(),
+      parseState.result,
+      "household-1",
+      "provider-1",
+      classifyState.result,
     );
-    expect(run).toHaveBeenCalledTimes(1);
+    expect(messageRepoState.insertQuarantineMessage).not.toHaveBeenCalled();
+  });
+
+  it("routes unmatched senders into quarantine within the resolved household", async () => {
+    classifyState.result = {
+      kind: "quarantine",
+      reason: "No sender rule matched the inbound email within the addressed household.",
+      code: "654321",
+    };
+    parseState.result = {
+      ...parseState.result,
+      envelopeFrom: "unknown@example.net",
+      fromHeader: "Unknown <unknown@example.net>",
+      textBody: "Use 654321 to continue.",
+    };
+
+    await handleIncomingEmail(createMessage(), createAppContext());
+
+    expect(householdRepoState.getHouseholdBySlug).toHaveBeenCalledWith(
+      expect.anything(),
+      "codes",
+    );
+    expect(messageRepoState.insertQuarantineMessage).toHaveBeenCalledWith(
+      expect.anything(),
+      parseState.result,
+      "household-1",
+      classifyState.result,
+    );
+    expect(messageRepoState.insertMessage).not.toHaveBeenCalled();
+  });
+
+  it("drops quarantined emails when no household can be resolved", async () => {
+    classifyState.result = {
+      kind: "quarantine",
+      reason: "No household matched the inbound recipient address.",
+      code: "654321",
+    };
+    householdRepoState.getHouseholdBySlug.mockResolvedValue(null);
+
+    await handleIncomingEmail(createMessage(), createAppContext());
+
+    expect(messageRepoState.insertQuarantineMessage).not.toHaveBeenCalled();
+    expect(messageRepoState.insertMessage).not.toHaveBeenCalled();
   });
 });

--- a/test/email-handler.test.ts
+++ b/test/email-handler.test.ts
@@ -22,7 +22,8 @@ const classifyState = vi.hoisted(() => ({
     providerId: "provider-1",
     providerKey: "netflix",
     code: "123456",
-    reason: "Sender matched a configured rule and a likely verification code was found.",
+    reason:
+      "Sender matched a configured rule and a likely verification code was found.",
   } as
     | {
         kind: "matched";
@@ -123,7 +124,8 @@ describe("handleIncomingEmail", () => {
       providerId: "provider-1",
       providerKey: "netflix",
       code: "123456",
-      reason: "Sender matched a configured rule and a likely verification code was found.",
+      reason:
+        "Sender matched a configured rule and a likely verification code was found.",
     };
     messageRepoState.insertMessage.mockReset();
     messageRepoState.insertQuarantineMessage.mockReset();
@@ -151,7 +153,8 @@ describe("handleIncomingEmail", () => {
   it("routes unmatched senders into quarantine within the resolved household", async () => {
     classifyState.result = {
       kind: "quarantine",
-      reason: "No sender rule matched the inbound email within the addressed household.",
+      reason:
+        "No sender rule matched the inbound email within the addressed household.",
       code: "654321",
     };
     parseState.result = {

--- a/test/email-sender.test.ts
+++ b/test/email-sender.test.ts
@@ -94,7 +94,7 @@ describe("email sender helpers", () => {
       inviterEmail: "morgan@example.com",
       inviteUrl: "https://example.com/invite/token-123",
       expiresAt: "2026-05-31T12:00:00.000Z",
-      role: "admin",
+      role: "owner",
     });
 
     expect(send).toHaveBeenCalledWith(

--- a/test/inbox-routes.test.ts
+++ b/test/inbox-routes.test.ts
@@ -4,15 +4,54 @@ type SessionUser = {
   id: string;
   email: string;
   role: string;
+  name?: string;
 };
 
-type DbRunner = {
-  all?: () => Promise<{ results: unknown[] }>;
-  first?: () => Promise<unknown>;
-  run?: () => Promise<{ results: unknown[] }>;
+type UserRecord = {
+  id: string;
+  email: string;
+  name: string;
+  role: string;
 };
 
-type DbResolver = (sql: string, params: unknown[]) => DbRunner;
+type HouseholdRecord = {
+  id: string;
+  slug: string;
+  displayName: string;
+};
+
+type MembershipRecord = {
+  householdId: string;
+  userId: string;
+  role: "owner" | "member";
+};
+
+type ProviderRecord = {
+  id: string;
+  household_id: string;
+  provider_key: string;
+  display_name: string;
+  created_at?: string;
+  rule_count?: number;
+};
+
+type InvitationRecord = {
+  id: string;
+  householdId: string;
+  email: string;
+  name: string;
+  role: "owner" | "member";
+  status: "pending" | "accepted" | "cancelled" | "expired";
+  invitedByUserId: string;
+  acceptedByUserId: string | null;
+  expiresAt: string;
+  acceptedAt: string | null;
+  cancelledAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  tokenHash: string;
+  providerIds: string[];
+};
 
 const sessionState = vi.hoisted(() => ({
   current: null as {
@@ -22,38 +61,124 @@ const sessionState = vi.hoisted(() => ({
 }));
 
 const authApiState = vi.hoisted(() => ({
-  createUserCalls: [] as unknown[],
-  listUsersCalls: [] as unknown[],
-  signInEmailCalls: [] as unknown[],
-  setRoleCalls: [] as unknown[],
-  setPasswordCalls: [] as unknown[],
-  listUsersResponse: {
-    users: [] as Array<{ id: string; email: string; role: string }>,
-    total: 0,
-  },
+  signUpEmailCalls: [] as unknown[],
 }));
 
 const invitationEmailState = vi.hoisted(() => ({
   calls: [] as unknown[],
 }));
 
-const settingsRepoState = vi.hoisted(() => ({
-  getUserProfile: vi.fn(),
-  listUserSessions: vi.fn(),
-  updateUserProfile: vi.fn(),
-  deleteOtherSessions: vi.fn(),
-  deleteSessionById: vi.fn(),
+const repoState = vi.hoisted(() => ({
+  users: [] as UserRecord[],
+  households: [] as HouseholdRecord[],
+  memberships: [] as MembershipRecord[],
+  providers: [] as ProviderRecord[],
+  providerAccess: [] as Array<{ householdId: string; userId: string; providerId: string }>,
+  messages: [] as Array<{
+    id: string;
+    household_slug: string;
+    householdId: string;
+    provider_key: string;
+    provider_display_name: string;
+    subject: string;
+    from_header: string;
+    text_body: string;
+    extracted_code: string | null;
+    status: "new" | "used" | "expired";
+    received_at: string;
+  }>,
+  quarantine: [] as Array<{
+    id: string;
+    household_slug: string;
+    householdId: string;
+    provider_key: string;
+    provider_display_name: string;
+    subject: string;
+    from_header: string;
+    envelope_from: string;
+    text_body: string;
+    extracted_code: string | null;
+    quarantine_reason: string;
+    received_at: string;
+    reviewed: boolean;
+  }>,
+  invitations: [] as InvitationRecord[],
+  senderRules: [] as Array<{
+    id: string;
+    household_id: string;
+    provider_id: string;
+    match_type: "exact" | "domain";
+    match_value: string;
+    created_at: string;
+  }>,
+  createHouseholdCalls: [] as unknown[],
+  createInvitationCalls: [] as unknown[],
+  acceptInvitationCalls: [] as unknown[],
+  updateRoleCalls: [] as unknown[],
+  grantAccessCalls: [] as unknown[],
+  reviewCalls: [] as unknown[],
+  setupState: {
+    status: "pending",
+    owner_user_id: null,
+    owner_email: null,
+  } as {
+    status: "pending" | "in_progress" | "complete";
+    owner_user_id: string | null;
+    owner_email: string | null;
+  },
+  beginSetupResult: true,
 }));
 
-const invitationsRepoState = vi.hoisted(() => ({
-  createHouseholdInvitation: vi.fn(),
-  getInvitationById: vi.fn(),
-  getInvitationByTokenHash: vi.fn(),
-  listHouseholdInvitations: vi.fn(),
-  refreshExpiredInvitations: vi.fn(),
-  cancelInvitation: vi.fn(),
-  acceptInvitation: vi.fn(),
-}));
+function getUser(userId: string) {
+  return repoState.users.find((user) => user.id === userId) ?? null;
+}
+
+function getHouseholdBySlug(slug: string) {
+  return repoState.households.find((household) => household.slug === slug) ?? null;
+}
+
+function getHouseholdByIdValue(id: string) {
+  return repoState.households.find((household) => household.id === id) ?? null;
+}
+
+function getMembership(userId: string, householdId: string) {
+  return (
+    repoState.memberships.find(
+      (membership) =>
+        membership.userId === userId && membership.householdId === householdId,
+    ) ?? null
+  );
+}
+
+function getInvitationProviders(providerIds: string[]) {
+  return providerIds
+    .map((providerId) => repoState.providers.find((provider) => provider.id === providerId))
+    .filter((provider): provider is ProviderRecord => Boolean(provider))
+    .map((provider) => ({
+      id: provider.id,
+      provider_key: provider.provider_key,
+      display_name: provider.display_name,
+    }));
+}
+
+function invitationSummary(invitation: InvitationRecord) {
+  return {
+    id: invitation.id,
+    householdId: invitation.householdId,
+    email: invitation.email,
+    name: invitation.name,
+    role: invitation.role,
+    status: invitation.status,
+    invitedByUserId: invitation.invitedByUserId,
+    acceptedByUserId: invitation.acceptedByUserId,
+    expiresAt: invitation.expiresAt,
+    acceptedAt: invitation.acceptedAt,
+    cancelledAt: invitation.cancelledAt,
+    createdAt: invitation.createdAt,
+    updatedAt: invitation.updatedAt,
+    providers: getInvitationProviders(invitation.providerIds),
+  };
+}
 
 vi.mock("../src/server/email/sender", () => ({
   sendHouseholdInvitationEmail: async (env: unknown, input: unknown) => {
@@ -63,12 +188,399 @@ vi.mock("../src/server/email/sender", () => ({
   sendTransactionalEmail: async () => {},
 }));
 
-vi.mock("../src/server/db/repositories/settings", () => ({
-  getUserProfile: settingsRepoState.getUserProfile,
-  listUserSessions: settingsRepoState.listUserSessions,
-  updateUserProfile: settingsRepoState.updateUserProfile,
-  deleteOtherSessions: settingsRepoState.deleteOtherSessions,
-  deleteSessionById: settingsRepoState.deleteSessionById,
+vi.mock("../src/server/security/tokens", () => ({
+  createInvitationToken: async () => ({
+    token: "invite-token",
+    tokenHash: "hash:invite-token",
+  }),
+  hashInvitationToken: async (token: string) => `hash:${token}`,
+}));
+
+vi.mock("../src/server/db/repositories/installation-state", () => ({
+  getInstallationState: async () => ({
+    id: 1,
+    status: repoState.setupState.status,
+    owner_user_id: repoState.setupState.owner_user_id,
+    owner_email: repoState.setupState.owner_email,
+    completed_at: null,
+    created_at: "2026-05-10T12:00:00.000Z",
+    updated_at: "2026-05-10T12:00:00.000Z",
+  }),
+  beginInstallationSetup: async () => repoState.beginSetupResult,
+  completeInstallationSetup: async (
+    _db: D1Database,
+    ownerUserId: string,
+    ownerEmail: string,
+  ) => {
+    repoState.setupState = {
+      status: "complete",
+      owner_user_id: ownerUserId,
+      owner_email: ownerEmail,
+    };
+  },
+  resetInstallationSetup: async () => {
+    repoState.setupState = {
+      status: "pending",
+      owner_user_id: null,
+      owner_email: null,
+    };
+  },
+}));
+
+vi.mock("../src/server/db/repositories/households", async () => {
+  const actual = await vi.importActual<
+    typeof import("../src/server/db/repositories/households")
+  >("../src/server/db/repositories/households");
+
+  return {
+    ...actual,
+    listHouseholdsForUser: async (_db: D1Database, userId: string) =>
+      repoState.memberships
+        .filter((membership) => membership.userId === userId)
+        .map((membership) => {
+          const household = getHouseholdByIdValue(membership.householdId);
+          return {
+            id: membership.householdId,
+            slug: household?.slug ?? "unknown",
+            displayName: household?.displayName ?? "Unknown",
+            role: membership.role,
+          };
+        }),
+    userBelongsToHousehold: async (
+      _db: D1Database,
+      userId: string,
+      householdSlug: string,
+    ) => {
+      const household = getHouseholdBySlug(householdSlug);
+      if (!household) return null;
+      const membership = getMembership(userId, household.id);
+      if (!membership) return null;
+      return {
+        householdId: household.id,
+        role: membership.role,
+        slug: household.slug,
+      };
+    },
+    getHouseholdMembership: async (
+      _db: D1Database,
+      userId: string,
+      householdId: string,
+    ) => {
+      const membership = getMembership(userId, householdId);
+      const household = getHouseholdByIdValue(householdId);
+      if (!membership || !household) return null;
+      return {
+        householdId,
+        userId,
+        role: membership.role,
+        slug: household.slug,
+        displayName: household.displayName,
+      };
+    },
+    updateHouseholdMembershipRole: async (
+      _db: D1Database,
+      input: { householdId: string; userId: string; role: "owner" | "member" },
+    ) => {
+      repoState.updateRoleCalls.push(input);
+      const membership = getMembership(input.userId, input.householdId);
+      if (membership) {
+        membership.role = input.role;
+      }
+    },
+    createHousehold: async (
+      _db: D1Database,
+      input: { slug: string; displayName: string; ownerUserId: string },
+    ) => {
+      repoState.createHouseholdCalls.push(input);
+      const household = {
+        id: "household-created",
+        slug: input.slug,
+        displayName: input.displayName,
+      };
+      repoState.households.push(household);
+      repoState.memberships.push({
+        householdId: household.id,
+        userId: input.ownerUserId,
+        role: "owner",
+      });
+      return household;
+    },
+    getHouseholdById: async (_db: D1Database, id: string) => getHouseholdByIdValue(id),
+    assertProvidersBelongToHousehold: async (
+      _db: D1Database,
+      householdId: string,
+      providerIds: string[],
+    ) =>
+      providerIds.every((providerId) =>
+        repoState.providers.some(
+          (provider) =>
+            provider.id === providerId && provider.household_id === householdId,
+        ),
+      ),
+  };
+});
+
+vi.mock("../src/server/db/repositories/member-access", () => ({
+  listMembers: async (_db: D1Database, householdId: string) =>
+    repoState.memberships
+      .filter((membership) => membership.householdId === householdId)
+      .map((membership) => {
+        const user = getUser(membership.userId);
+        return {
+          id: membership.userId,
+          householdRole: membership.role,
+          email: user?.email ?? `${membership.userId}@example.com`,
+          name: user?.name ?? membership.userId,
+          role: user?.role ?? "user",
+          createdAt: "2026-05-10T12:00:00.000Z",
+          updatedAt: "2026-05-10T12:00:00.000Z",
+        };
+      }),
+  listMemberProviderAccess: async (_db: D1Database, householdId: string) =>
+    repoState.memberships.flatMap((membership) => {
+      if (membership.householdId !== householdId) return [];
+      const user = getUser(membership.userId);
+      const accessRows = repoState.providerAccess.filter(
+        (entry) =>
+          entry.householdId === householdId && entry.userId === membership.userId,
+      );
+      if (accessRows.length === 0) {
+        return [
+          {
+            id: membership.userId,
+            household_role: membership.role,
+            email: user?.email ?? `${membership.userId}@example.com`,
+            name: user?.name ?? membership.userId,
+            role: user?.role ?? "user",
+            provider_key: null,
+            provider_display_name: null,
+          },
+        ];
+      }
+      return accessRows.map((entry) => {
+        const provider = repoState.providers.find(
+          (candidate) => candidate.id === entry.providerId,
+        );
+        return {
+          id: membership.userId,
+          household_role: membership.role,
+          email: user?.email ?? `${membership.userId}@example.com`,
+          name: user?.name ?? membership.userId,
+          role: user?.role ?? "user",
+          provider_key: provider?.provider_key ?? null,
+          provider_display_name: provider?.display_name ?? null,
+        };
+      });
+    }),
+  listProviders: async (_db: D1Database, householdId: string) =>
+    repoState.providers.filter((provider) => provider.household_id === householdId),
+  grantProviderAccess: async (
+    _db: D1Database,
+    householdId: string,
+    userId: string,
+    providerId: string,
+  ) => {
+    repoState.grantAccessCalls.push({ householdId, userId, providerId });
+    repoState.providerAccess.push({ householdId, userId, providerId });
+  },
+  revokeProviderAccess: async (
+    _db: D1Database,
+    householdId: string,
+    userId: string,
+    providerId: string,
+  ) => {
+    repoState.providerAccess = repoState.providerAccess.filter(
+      (entry) =>
+        !(
+          entry.householdId === householdId &&
+          entry.userId === userId &&
+          entry.providerId === providerId
+        ),
+    );
+  },
+}));
+
+vi.mock("../src/server/db/repositories/provider-rules", () => ({
+  userHasProviderAccess: async (
+    _db: D1Database,
+    householdId: string,
+    userId: string,
+    providerKey: string,
+  ) => {
+    const provider = repoState.providers.find(
+      (candidate) =>
+        candidate.household_id === householdId &&
+        candidate.provider_key === providerKey,
+    );
+    if (!provider) return false;
+    return repoState.providerAccess.some(
+      (entry) =>
+        entry.householdId === householdId &&
+        entry.userId === userId &&
+        entry.providerId === provider.id,
+    );
+  },
+  getProviderByKey: async (
+    _db: D1Database,
+    householdId: string,
+    providerKey: string,
+  ) =>
+    repoState.providers.find(
+      (provider) =>
+        provider.household_id === householdId && provider.provider_key === providerKey,
+    ) ?? null,
+  getProviderById: async (
+    _db: D1Database,
+    householdId: string,
+    providerId: string,
+  ) =>
+    repoState.providers.find(
+      (provider) =>
+        provider.household_id === householdId && provider.id === providerId,
+    ) ?? null,
+  listProviderConfigurations: async (_db: D1Database, householdId: string) =>
+    repoState.providers
+      .filter((provider) => provider.household_id === householdId)
+      .map((provider) => ({ ...provider, rule_count: provider.rule_count ?? 0 })),
+  listSenderRules: async (_db: D1Database, householdId: string) =>
+    repoState.senderRules.filter((rule) => rule.household_id === householdId),
+  createProvider: async (
+    _db: D1Database,
+    householdId: string,
+    providerKey: string,
+    displayName: string,
+  ) => {
+    const provider = {
+      id: `provider-${repoState.providers.length + 1}`,
+      household_id: householdId,
+      provider_key: providerKey,
+      display_name: displayName,
+      created_at: "2026-05-10T12:00:00.000Z",
+      rule_count: 0,
+    };
+    repoState.providers.push(provider);
+    return provider;
+  },
+  createSenderRule: async (
+    _db: D1Database,
+    householdId: string,
+    providerId: string,
+    matchType: "exact" | "domain",
+    matchValue: string,
+  ) => {
+    const rule = {
+      id: `rule-${repoState.senderRules.length + 1}`,
+      household_id: householdId,
+      provider_id: providerId,
+      match_type: matchType,
+      match_value: matchValue,
+      created_at: "2026-05-10T12:00:00.000Z",
+    };
+    repoState.senderRules.push(rule);
+    return rule;
+  },
+  updateProvider: async () => {},
+  updateSenderRule: async () => {},
+  deleteProvider: async () => {},
+  deleteSenderRule: async () => {},
+  getSenderRuleById: async () => null,
+}));
+
+vi.mock("../src/server/db/repositories/messages", () => ({
+  listProviderSummariesForUser: async (
+    _db: D1Database,
+    householdId: string,
+    userId: string,
+  ) => {
+    const membership = getMembership(userId, householdId);
+    if (!membership) return [];
+    const visibleProviders = repoState.providers.filter((provider) => {
+      if (provider.household_id !== householdId) return false;
+      if (membership.role === "owner") return true;
+      return repoState.providerAccess.some(
+        (entry) => entry.householdId === householdId && entry.userId === userId && entry.providerId === provider.id,
+      );
+    });
+
+    return visibleProviders.map((provider) => {
+      const providerMessages = repoState.messages.filter(
+        (message) =>
+          message.householdId === householdId && message.provider_key === provider.provider_key,
+      );
+      return {
+        household_slug: getHouseholdByIdValue(householdId)?.slug ?? "unknown",
+        provider_key: provider.provider_key,
+        display_name: provider.display_name,
+        message_count: providerMessages.length,
+        new_count: providerMessages.filter((message) => message.status === "new").length,
+        latest_received_at: providerMessages[0]?.received_at ?? null,
+      };
+    });
+  },
+  listMessagesForProvider: async (
+    _db: D1Database,
+    householdId: string,
+    providerKey: string,
+  ) =>
+    repoState.messages.filter(
+      (message) =>
+        message.householdId === householdId && message.provider_key === providerKey,
+    ),
+  findMessageById: async (
+    _db: D1Database,
+    householdId: string,
+    messageId: string,
+  ) =>
+    repoState.messages.find(
+      (message) => message.householdId === householdId && message.id === messageId,
+    ) ?? null,
+  updateMessageStatus: async (
+    _db: D1Database,
+    householdId: string,
+    messageId: string,
+    status: "new" | "used" | "expired",
+  ) => {
+    const message = repoState.messages.find(
+      (candidate) => candidate.householdId === householdId && candidate.id === messageId,
+    );
+    if (!message) return null;
+    message.status = status;
+    return message;
+  },
+  listQuarantineMessages: async (_db: D1Database, householdId: string) =>
+    repoState.quarantine.filter(
+      (message) => message.householdId === householdId && !message.reviewed,
+    ),
+  reviewQuarantineMessage: async (
+    _db: D1Database,
+    householdId: string,
+    messageId: string,
+    input: { action: "dismiss" | "release"; providerId?: string },
+  ) => {
+    repoState.reviewCalls.push({ householdId, messageId, input });
+    const message = repoState.quarantine.find(
+      (candidate) => candidate.householdId === householdId && candidate.id === messageId,
+    );
+    if (!message) return null;
+    message.reviewed = true;
+    if (input.action === "release") {
+      const provider = repoState.providers.find(
+        (candidate) => candidate.id === input.providerId,
+      );
+      return {
+        reviewedAt: "2026-05-10T12:30:00.000Z",
+        releasedMessage: {
+          id: "released-1",
+          provider_key: provider?.provider_key ?? "unknown",
+          status: "new",
+        },
+      };
+    }
+    return {
+      reviewedAt: "2026-05-10T12:30:00.000Z",
+      dismissed: true,
+    };
+  },
 }));
 
 vi.mock("../src/server/db/repositories/invitations", async () => {
@@ -78,13 +590,90 @@ vi.mock("../src/server/db/repositories/invitations", async () => {
 
   return {
     ...actual,
-    createHouseholdInvitation: invitationsRepoState.createHouseholdInvitation,
-    getInvitationById: invitationsRepoState.getInvitationById,
-    getInvitationByTokenHash: invitationsRepoState.getInvitationByTokenHash,
-    listHouseholdInvitations: invitationsRepoState.listHouseholdInvitations,
-    refreshExpiredInvitations: invitationsRepoState.refreshExpiredInvitations,
-    cancelInvitation: invitationsRepoState.cancelInvitation,
-    acceptInvitation: invitationsRepoState.acceptInvitation,
+    createHouseholdInvitation: async (
+      _db: D1Database,
+      input: {
+        householdId: string;
+        email: string;
+        name: string;
+        role: "owner" | "member";
+        tokenHash: string;
+        invitedByUserId: string;
+        expiresAt: string;
+        providerIds: string[];
+      },
+    ) => {
+      repoState.createInvitationCalls.push(input);
+      const invitationId = `invite-${repoState.invitations.length + 1}`;
+      repoState.invitations.push({
+        id: invitationId,
+        householdId: input.householdId,
+        email: input.email,
+        name: input.name,
+        role: input.role,
+        status: "pending",
+        invitedByUserId: input.invitedByUserId,
+        acceptedByUserId: null,
+        expiresAt: input.expiresAt,
+        acceptedAt: null,
+        cancelledAt: null,
+        createdAt: "2026-05-10T12:00:00.000Z",
+        updatedAt: "2026-05-10T12:00:00.000Z",
+        tokenHash: input.tokenHash,
+        providerIds: input.providerIds,
+      });
+      return invitationId;
+    },
+    getInvitationById: async (_db: D1Database, invitationId: string) => {
+      const invitation = repoState.invitations.find(
+        (candidate) => candidate.id === invitationId,
+      );
+      return invitation ? invitationSummary(invitation) : null;
+    },
+    getInvitationByTokenHash: async (_db: D1Database, tokenHash: string) => {
+      const invitation = repoState.invitations.find(
+        (candidate) => candidate.tokenHash === tokenHash,
+      );
+      return invitation ? invitationSummary(invitation) : null;
+    },
+    listHouseholdInvitations: async (_db: D1Database, householdId?: string) =>
+      repoState.invitations
+        .filter((invitation) =>
+          householdId ? invitation.householdId === householdId : true,
+        )
+        .map(invitationSummary),
+    refreshExpiredInvitations: async () => {},
+    cancelInvitation: async (_db: D1Database, invitationId: string) => {
+      const invitation = repoState.invitations.find(
+        (candidate) => candidate.id === invitationId,
+      );
+      if (invitation) {
+        invitation.status = "cancelled";
+      }
+    },
+    acceptInvitation: async (
+      _db: D1Database,
+      input: {
+        invitationId: string;
+        householdId: string;
+        acceptedByUserId: string;
+        role: "owner" | "member";
+      },
+    ) => {
+      repoState.acceptInvitationCalls.push(input);
+      repoState.memberships.push({
+        householdId: input.householdId,
+        userId: input.acceptedByUserId,
+        role: input.role,
+      });
+      const invitation = repoState.invitations.find(
+        (candidate) => candidate.id === input.invitationId,
+      );
+      if (invitation) {
+        invitation.status = "accepted";
+        invitation.acceptedByUserId = input.acceptedByUserId;
+      }
+    },
   };
 });
 
@@ -93,44 +682,35 @@ vi.mock("../src/server/auth/auth", () => ({
     handler: () => new Response("auth"),
     api: {
       getSession: async () => sessionState.current,
-      createUser: async (input: unknown) => {
-        authApiState.createUserCalls.push(input);
-
-        return {
-          user: {
-            id: "created-user-1",
-            email: "new@example.com",
-            name: "New Person",
-            role: "member",
-          },
+    },
+  }),
+  provisioningAuthForEnv: () => ({
+    handler: () => new Response("auth"),
+    api: {
+      signUpEmail: async (input: unknown) => {
+        authApiState.signUpEmailCalls.push(input);
+        const body = (input as { body: { email: string; name: string } }).body;
+        const createdUser = {
+          id: "created-user-1",
+          email: body.email,
+          name: body.name,
+          role: "user",
         };
-      },
-      setRole: async (input: unknown) => {
-        authApiState.setRoleCalls.push(input);
-        return { ok: true };
-      },
-      listUsers: async (input: unknown) => {
-        authApiState.listUsersCalls.push(input);
-        return authApiState.listUsersResponse;
-      },
-      signInEmail: async (input: unknown) => {
-        authApiState.signInEmailCalls.push(input);
+        repoState.users.push(createdUser);
         return {
           response: {
+            user: createdUser,
             session: {
-              id: "setup-session-1",
-              userId: "created-user-1",
+              id: "session-created-1",
+              userId: createdUser.id,
             },
           },
-          headers: new Headers({
-            "set-cookie":
+          headers: {
+            getSetCookie: () => [
               "better-auth.session_token=test-token; Path=/; HttpOnly",
-          }),
+            ],
+          },
         };
-      },
-      setUserPassword: async (input: unknown) => {
-        authApiState.setPasswordCalls.push(input);
-        return { ok: true };
       },
     },
   }),
@@ -140,64 +720,22 @@ const { default: worker } = await import("../src/index");
 
 type WorkerFetch = NonNullable<typeof worker.fetch>;
 
-function createDbStub(resolve: DbResolver): D1Database {
-  function toResults(runner: DbRunner) {
-    return async () => {
-      if (runner.all) {
-        return (await runner.all()).results;
-      }
-
-      if (runner.run) {
-        return (await runner.run()).results;
-      }
-
-      const first = await runner.first?.();
-      return first === undefined ? [] : [first];
-    };
-  }
-
+function createDbStub(): D1Database {
   return {
-    prepare(sql: string) {
+    prepare() {
       return {
-        bind(...params: unknown[]) {
-          const runner = resolve(sql.trim(), params);
-          const raw = toResults(runner);
-
+        bind() {
           return {
-            all: async () => {
-              if (runner.all) {
-                return runner.all();
-              }
-
-              if (runner.run) {
-                return runner.run();
-              }
-
-              const first = await runner.first?.();
-              return { results: first === undefined ? [] : [first] };
-            },
-            first: async () => runner.first?.(),
-            raw,
-            run: async () => runner.run?.() ?? { results: [] },
+            all: async () => ({ results: [] }),
+            first: async () => null,
+            raw: async () => [],
+            run: async () => ({ results: [] }),
           };
         },
-        all: async () => {
-          const runner = resolve(sql.trim(), []);
-
-          if (runner.all) {
-            return runner.all();
-          }
-
-          if (runner.run) {
-            return runner.run();
-          }
-
-          const first = await runner.first?.();
-          return { results: first === undefined ? [] : [first] };
-        },
-        first: async () => resolve(sql.trim(), []).first?.(),
-        raw: async () => toResults(resolve(sql.trim(), []))(),
-        run: async () => resolve(sql.trim(), []).run?.() ?? { results: [] },
+        all: async () => ({ results: [] }),
+        first: async () => null,
+        raw: async () => [],
+        run: async () => ({ results: [] }),
       };
     },
     batch: async () => [],
@@ -221,6 +759,8 @@ function createEnv(db: D1Database, overrides?: Partial<Env>): Env {
     DB: db,
     EMAIL: email,
     ENVIRONMENT: "test",
+    OWNER_EMAIL: "owner@example.com",
+    SETUP_SECRET: "setup-secret",
     ...overrides,
   };
 }
@@ -237,108 +777,179 @@ function getWorkerFetch(): WorkerFetch {
   if (!worker.fetch) {
     throw new Error("Worker fetch handler is unavailable");
   }
-
   return worker.fetch;
 }
 
 async function invokeWorker(
   path: string,
-  options: RequestInit | undefined,
-  db: D1Database,
+  options?: RequestInit,
   envOverrides?: Partial<Env>,
 ) {
   const fetchHandler = getWorkerFetch();
-  const request = new Request(
-    `http://localhost:8787${path}`,
-    options,
-  ) as Parameters<WorkerFetch>[0];
-
-  return fetchHandler(
-    request,
-    createEnv(db, envOverrides),
-    createExecutionContext(),
-  );
+  const db = createDbStub();
+  const request = new Request(`http://localhost:8787${path}`, options) as Parameters<
+    WorkerFetch
+  >[0];
+  return fetchHandler(request, createEnv(db, envOverrides), createExecutionContext());
 }
 
 describe("worker routes", () => {
   beforeEach(() => {
     sessionState.current = null;
-    authApiState.createUserCalls = [];
-    authApiState.listUsersCalls = [];
-    authApiState.signInEmailCalls = [];
-    authApiState.setRoleCalls = [];
-    authApiState.setPasswordCalls = [];
-    authApiState.listUsersResponse = {
-      users: [],
-      total: 0,
-    };
+    authApiState.signUpEmailCalls = [];
     invitationEmailState.calls = [];
-    settingsRepoState.getUserProfile.mockReset();
-    settingsRepoState.listUserSessions.mockReset();
-    settingsRepoState.updateUserProfile.mockReset();
-    settingsRepoState.deleteOtherSessions.mockReset();
-    settingsRepoState.deleteSessionById.mockReset();
-    invitationsRepoState.createHouseholdInvitation.mockReset();
-    invitationsRepoState.getInvitationById.mockReset();
-    invitationsRepoState.getInvitationByTokenHash.mockReset();
-    invitationsRepoState.listHouseholdInvitations.mockReset();
-    invitationsRepoState.refreshExpiredInvitations.mockReset();
-    invitationsRepoState.cancelInvitation.mockReset();
-    invitationsRepoState.acceptInvitation.mockReset();
+    repoState.users = [
+      {
+        id: "owner-home",
+        email: "owner@example.com",
+        name: "Home Owner",
+        role: "user",
+      },
+      {
+        id: "member-home",
+        email: "member@example.com",
+        name: "Household Member",
+        role: "user",
+      },
+      {
+        id: "owner-away",
+        email: "away-owner@example.com",
+        name: "Away Owner",
+        role: "user",
+      },
+      {
+        id: "member-away",
+        email: "away-member@example.com",
+        name: "Away Member",
+        role: "user",
+      },
+    ];
+    repoState.households = [
+      { id: "household-home", slug: "home", displayName: "Home" },
+      { id: "household-away", slug: "away", displayName: "Away" },
+    ];
+    repoState.memberships = [
+      { householdId: "household-home", userId: "owner-home", role: "owner" },
+      { householdId: "household-home", userId: "member-home", role: "member" },
+      { householdId: "household-away", userId: "owner-away", role: "owner" },
+      { householdId: "household-away", userId: "member-away", role: "member" },
+    ];
+    repoState.providers = [
+      {
+        id: "provider-home-netflix",
+        household_id: "household-home",
+        provider_key: "netflix",
+        display_name: "Netflix",
+        created_at: "2026-05-10T12:00:00.000Z",
+        rule_count: 1,
+      },
+      {
+        id: "provider-away-hulu",
+        household_id: "household-away",
+        provider_key: "hulu",
+        display_name: "Hulu",
+        created_at: "2026-05-10T12:00:00.000Z",
+        rule_count: 0,
+      },
+    ];
+    repoState.providerAccess = [
+      {
+        householdId: "household-home",
+        userId: "member-home",
+        providerId: "provider-home-netflix",
+      },
+    ];
+    repoState.messages = [
+      {
+        id: "msg-home-1",
+        household_slug: "home",
+        householdId: "household-home",
+        provider_key: "netflix",
+        provider_display_name: "Netflix",
+        subject: "Your code",
+        from_header: "Netflix <no-reply@netflix.com>",
+        text_body: "Code 123456",
+        extracted_code: "123456",
+        status: "new",
+        received_at: "2026-05-10T12:00:00.000Z",
+      },
+    ];
+    repoState.quarantine = [
+      {
+        id: "quarantine-home-1",
+        household_slug: "home",
+        householdId: "household-home",
+        provider_key: "quarantine",
+        provider_display_name: "Quarantine",
+        subject: "Review this",
+        from_header: "Unknown <unknown@example.com>",
+        envelope_from: "unknown@example.com",
+        text_body: "Unclassified message",
+        extracted_code: null,
+        quarantine_reason: "unknown_sender",
+        received_at: "2026-05-10T12:10:00.000Z",
+        reviewed: false,
+      },
+    ];
+    repoState.invitations = [
+      {
+        id: "invite-existing",
+        householdId: "household-home",
+        email: "invitee@example.com",
+        name: "Invitee",
+        role: "member",
+        status: "pending",
+        invitedByUserId: "owner-home",
+        acceptedByUserId: null,
+        expiresAt: "2026-05-31T12:00:00.000Z",
+        acceptedAt: null,
+        cancelledAt: null,
+        createdAt: "2026-05-10T12:00:00.000Z",
+        updatedAt: "2026-05-10T12:00:00.000Z",
+        tokenHash: "hash:test-token",
+        providerIds: ["provider-home-netflix"],
+      },
+    ];
+    repoState.senderRules = [
+      {
+        id: "rule-home-1",
+        household_id: "household-home",
+        provider_id: "provider-home-netflix",
+        match_type: "domain",
+        match_value: "netflix.com",
+        created_at: "2026-05-10T12:00:00.000Z",
+      },
+    ];
+    repoState.createHouseholdCalls = [];
+    repoState.createInvitationCalls = [];
+    repoState.acceptInvitationCalls = [];
+    repoState.updateRoleCalls = [];
+    repoState.grantAccessCalls = [];
+    repoState.reviewCalls = [];
+    repoState.setupState = {
+      status: "pending",
+      owner_user_id: null,
+      owner_email: null,
+    };
+    repoState.beginSetupResult = true;
   });
 
-  it("returns liveness health", async () => {
-    const db = createDbStub((sql) => {
-      if (sql.includes("SELECT 1 AS ok")) {
-        return {
-          first: async () => ({ ok: 1 }),
-        };
-      }
-
-      return {};
-    });
-
-    const response = await invokeWorker("/api/health/live", undefined, db);
-
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ status: "ok" });
-  });
-
-  it("lists providers available to the signed-in user", async () => {
+  it("lists providers for a member in their own household", async () => {
     sessionState.current = {
-      user: { id: "user-1", email: "member@example.com", role: "member" },
-      session: { id: "session-1", userId: "user-1" },
+      user: { id: "member-home", email: "member@example.com", role: "user" },
+      session: { id: "session-1", userId: "member-home" },
     };
 
-    const db = createDbStub((sql) => {
-      if (sql.includes("GROUP BY providers.id")) {
-        return {
-          run: async () => ({
-            results: [
-              {
-                provider_key: "netflix",
-                display_name: "Netflix",
-                message_count: 2,
-                new_count: 1,
-                latest_received_at: "2026-05-10T12:00:00.000Z",
-              },
-            ],
-          }),
-        };
-      }
-
-      return {};
-    });
-
-    const response = await invokeWorker("/api/inbox/providers", undefined, db);
+    const response = await invokeWorker("/api/inbox/home/providers");
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
       providers: [
         {
+          household_slug: "home",
           provider_key: "netflix",
           display_name: "Netflix",
-          message_count: 2,
+          message_count: 1,
           new_count: 1,
           latest_received_at: "2026-05-10T12:00:00.000Z",
         },
@@ -346,442 +957,102 @@ describe("worker routes", () => {
     });
   });
 
-  it("updates message status for a permitted provider member", async () => {
+  it("denies inbox access across household boundaries", async () => {
     sessionState.current = {
-      user: { id: "user-1", email: "member@example.com", role: "member" },
-      session: { id: "session-1", userId: "user-1" },
-    };
-
-    const db = createDbStub((sql, params) => {
-      if (sql.includes("WHERE messages.id = ?") && sql.includes("LIMIT 1")) {
-        return {
-          first: async () => ({
-            id: params[0],
-            provider_key: "netflix",
-            provider_display_name: "Netflix",
-            subject: "Your latest code",
-            from_header: "Netflix <login@netflix.example>",
-            text_body: "Use 123456 to continue",
-            extracted_code: "123456",
-            status: "used",
-            received_at: "2026-05-10T12:00:00.000Z",
-          }),
-        };
-      }
-
-      if (sql.includes("SELECT 1 AS allowed")) {
-        return {
-          first: async () => ({ allowed: 1 }),
-        };
-      }
-
-      if (sql.startsWith("UPDATE messages SET status = ?")) {
-        return {
-          run: async () => ({ results: [] }),
-        };
-      }
-
-      return {};
-    });
-
-    const response = await invokeWorker(
-      "/api/inbox/messages/msg-1/status",
-      {
-        method: "PATCH",
-        body: JSON.stringify({ status: "used" }),
+      user: {
+        id: "owner-away",
+        email: "away-owner@example.com",
+        role: "user",
       },
-      db,
-    );
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
-      message: {
-        id: "msg-1",
-        provider_key: "netflix",
-        provider_display_name: "Netflix",
-        subject: "Your latest code",
-        from_header: "Netflix <login@netflix.example>",
-        text_body: "Use 123456 to continue",
-        extracted_code: "123456",
-        status: "used",
-        received_at: "2026-05-10T12:00:00.000Z",
-      },
-    });
-  });
-
-  it("rejects invalid status payloads", async () => {
-    sessionState.current = {
-      user: { id: "admin-1", email: "owner@example.com", role: "admin" },
-      session: { id: "session-1", userId: "admin-1" },
+      session: { id: "session-1", userId: "owner-away" },
     };
 
-    const db = createDbStub((sql, params) => {
-      if (sql.includes("WHERE messages.id = ?") && sql.includes("LIMIT 1")) {
-        return {
-          first: async () => ({
-            id: params[0],
-            provider_key: "netflix",
-            provider_display_name: "Netflix",
-            subject: "Your latest code",
-            from_header: "Netflix <login@netflix.example>",
-            text_body: "Use 123456 to continue",
-            extracted_code: "123456",
-            status: "new",
-            received_at: "2026-05-10T12:00:00.000Z",
-          }),
-        };
-      }
-
-      return {};
-    });
-
-    const response = await invokeWorker(
-      "/api/inbox/messages/msg-1/status",
-      {
-        method: "PATCH",
-        body: JSON.stringify({ status: "archived" }),
-      },
-      db,
-    );
-
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toEqual({
-      error: "Invalid message status",
-    });
-  });
-
-  it("allows an owner to release a quarantined message to a provider", async () => {
-    sessionState.current = {
-      user: { id: "admin-1", email: "owner@example.com", role: "admin" },
-      session: { id: "session-1", userId: "admin-1" },
-    };
-
-    const db = createDbStub((sql, params) => {
-      if (
-        sql.includes("FROM providers") &&
-        sql.includes("WHERE provider_key = ?")
-      ) {
-        return {
-          first: async () => ({
-            id: "provider-1",
-            provider_key: "netflix",
-            display_name: "Netflix",
-          }),
-        };
-      }
-
-      if (
-        sql.includes("FROM quarantine_messages") &&
-        sql.includes("WHERE id = ?")
-      ) {
-        return {
-          first: async () => ({
-            id: params[0],
-            message_id: "message-123",
-            envelope_from: "login@netflix.example",
-            envelope_to: "codes@example.com",
-            from_header: "Netflix <login@netflix.example>",
-            subject: "Netflix code",
-            text_body: "Use 123456",
-            extracted_code: "123456",
-            quarantine_reason: "No sender rule matched",
-            raw_size: 512,
-            received_at: "2026-05-10T12:00:00.000Z",
-            delete_after: "2026-06-09T12:00:00.000Z",
-            reviewed_at: null,
-          }),
-        };
-      }
-
-      if (sql.startsWith("INSERT INTO messages")) {
-        return {
-          run: async () => ({ results: [] }),
-        };
-      }
-
-      if (sql.includes("WHERE messages.message_id = ?")) {
-        return {
-          first: async () => ({
-            id: "released-1",
-            provider_key: "netflix",
-            provider_display_name: "Netflix",
-            subject: "Netflix code",
-            from_header: "Netflix <login@netflix.example>",
-            text_body: "Use 123456",
-            extracted_code: "123456",
-            status: "new",
-            received_at: "2026-05-10T12:00:00.000Z",
-          }),
-        };
-      }
-
-      if (sql.startsWith("UPDATE quarantine_messages SET reviewed_at = ?")) {
-        return {
-          run: async () => ({ results: [] }),
-        };
-      }
-
-      return {};
-    });
-
-    const response = await invokeWorker(
-      "/api/inbox/quarantine/quarantine-1/review",
-      {
-        method: "POST",
-        body: JSON.stringify({ action: "release", providerKey: "netflix" }),
-      },
-      db,
-    );
-
-    expect(response.status).toBe(200);
-
-    const payload = (await response.json()) as {
-      reviewedAt: string;
-      releasedMessage: { id: string; provider_key: string; status: string };
-    };
-
-    expect(payload.reviewedAt).toMatch(/T/);
-    expect(payload.releasedMessage).toMatchObject({
-      id: "released-1",
-      provider_key: "netflix",
-      status: "new",
-    });
-  });
-
-  it("keeps quarantine owner-only", async () => {
-    sessionState.current = {
-      user: { id: "user-1", email: "member@example.com", role: "member" },
-      session: { id: "session-1", userId: "user-1" },
-    };
-
-    const db = createDbStub(() => ({}));
-
-    const response = await invokeWorker("/api/inbox/quarantine", undefined, db);
+    const response = await invokeWorker("/api/inbox/home/providers");
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({ error: "Forbidden" });
   });
 
-  it("bootstraps OWNER_EMAIL to admin via direct D1 update", async () => {
+  it("allows a permitted member to update message status in their household", async () => {
     sessionState.current = {
-      user: { id: "user-1", email: "owner@example.com", role: "member" },
-      session: { id: "session-1", userId: "user-1" },
+      user: { id: "member-home", email: "member@example.com", role: "user" },
+      session: { id: "session-1", userId: "member-home" },
     };
 
-    const dbCalls: Array<{ sql: string; params: unknown[] }> = [];
-
-    const db = createDbStub((sql, params) => {
-      dbCalls.push({ sql, params });
-
-      if (sql.includes("GROUP BY providers.id")) {
-        return {
-          run: async () => ({ results: [] }),
-        };
-      }
-
-      if (sql.includes("UPDATE user SET role = 'admin' WHERE id = ?")) {
-        return {
-          run: async () => ({ results: [] }),
-        };
-      }
-
-      return {};
-    });
-
-    const response = await invokeWorker("/api/inbox/providers", undefined, db, {
-      OWNER_EMAIL: "owner@example.com",
+    const response = await invokeWorker("/api/inbox/home/messages/msg-home-1/status", {
+      method: "PATCH",
+      body: JSON.stringify({ status: "used" }),
     });
 
     expect(response.status).toBe(200);
-
-    const roleUpdate = dbCalls.find((c) =>
-      c.sql.includes("UPDATE user SET role = 'admin' WHERE id = ?"),
-    );
-    expect(roleUpdate).toBeDefined();
-    expect(roleUpdate?.params).toEqual(["user-1"]);
+    await expect(response.json()).resolves.toEqual({
+      message: expect.objectContaining({ id: "msg-home-1", status: "used" }),
+    });
   });
 
-  it("does NOT auto-promote when user is not the owner", async () => {
+  it("denies quarantine review to members in the same household", async () => {
     sessionState.current = {
-      user: { id: "user-2", email: "member@example.com", role: "member" },
-      session: { id: "session-2", userId: "user-2" },
+      user: { id: "member-home", email: "member@example.com", role: "user" },
+      session: { id: "session-1", userId: "member-home" },
     };
 
-    const dbCalls: Array<{ sql: string; params: unknown[] }> = [];
+    const response = await invokeWorker("/api/inbox/home/quarantine");
 
-    const db = createDbStub((sql, params) => {
-      dbCalls.push({ sql, params });
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "Forbidden" });
+  });
 
-      if (sql.includes("GROUP BY providers.id")) {
-        return {
-          run: async () => ({ results: [] }),
-        };
-      }
+  it("allows an owner to review quarantine within their household", async () => {
+    sessionState.current = {
+      user: { id: "owner-home", email: "owner@example.com", role: "user" },
+      session: { id: "session-1", userId: "owner-home" },
+    };
 
-      return {};
-    });
-
-    const response = await invokeWorker("/api/inbox/providers", undefined, db, {
-      OWNER_EMAIL: "owner@example.com",
-    });
+    const response = await invokeWorker(
+      "/api/inbox/home/quarantine/quarantine-home-1/review",
+      {
+        method: "POST",
+        body: JSON.stringify({ action: "release", providerKey: "netflix" }),
+      },
+    );
 
     expect(response.status).toBe(200);
-
-    const roleUpdate = dbCalls.find((c) =>
-      c.sql.includes("UPDATE user SET role = 'admin' WHERE id = ?"),
-    );
-    expect(roleUpdate).toBeUndefined();
+    await expect(response.json()).resolves.toEqual({
+      reviewedAt: "2026-05-10T12:30:00.000Z",
+      releasedMessage: {
+        id: "released-1",
+        provider_key: "netflix",
+        status: "new",
+      },
+    });
   });
 
-  it("does NOT auto-promote when owner already has admin role", async () => {
+  it("allows an owner to list members in their household", async () => {
     sessionState.current = {
-      user: { id: "user-1", email: "owner@example.com", role: "admin" },
-      session: { id: "session-1", userId: "user-1" },
+      user: { id: "owner-home", email: "owner@example.com", role: "user" },
+      session: { id: "session-1", userId: "owner-home" },
     };
 
-    const dbCalls: Array<{ sql: string; params: unknown[] }> = [];
-
-    const db = createDbStub((sql, params) => {
-      dbCalls.push({ sql, params });
-
-      if (sql.includes("GROUP BY providers.id")) {
-        return {
-          run: async () => ({ results: [] }),
-        };
-      }
-
-      return {};
-    });
-
-    const response = await invokeWorker("/api/inbox/providers", undefined, db, {
-      OWNER_EMAIL: "owner@example.com",
-    });
-
-    expect(response.status).toBe(200);
-
-    const roleUpdate = dbCalls.find((c) =>
-      c.sql.includes("UPDATE user SET role = 'admin' WHERE id = ?"),
-    );
-    expect(roleUpdate).toBeUndefined();
-  });
-
-  it("auto-promotes owner case-insensitively", async () => {
-    sessionState.current = {
-      user: { id: "user-1", email: "Owner@Example.COM", role: "member" },
-      session: { id: "session-1", userId: "user-1" },
-    };
-
-    const dbCalls: Array<{ sql: string; params: unknown[] }> = [];
-
-    const db = createDbStub((sql, params) => {
-      dbCalls.push({ sql, params });
-
-      if (sql.includes("GROUP BY providers.id")) {
-        return {
-          run: async () => ({ results: [] }),
-        };
-      }
-
-      if (sql.includes("UPDATE user SET role = 'admin' WHERE id = ?")) {
-        return {
-          run: async () => ({ results: [] }),
-        };
-      }
-
-      return {};
-    });
-
-    const response = await invokeWorker("/api/inbox/providers", undefined, db, {
-      OWNER_EMAIL: "owner@example.com",
-    });
-
-    expect(response.status).toBe(200);
-
-    const roleUpdate = dbCalls.find((c) =>
-      c.sql.includes("UPDATE user SET role = 'admin' WHERE id = ?"),
-    );
-    expect(roleUpdate).toBeDefined();
-    expect(roleUpdate?.params).toEqual(["user-1"]);
-  });
-
-  it("lists members and provider access for owners", async () => {
-    sessionState.current = {
-      user: { id: "admin-1", email: "owner@example.com", role: "admin" },
-      session: { id: "session-1", userId: "admin-1" },
-    };
-
-    const db = createDbStub((sql) => {
-      if (
-        sql.includes("SELECT id, email, name, role, createdAt, updatedAt") &&
-        sql.includes("FROM user") &&
-        sql.includes("ORDER BY createdAt ASC")
-      ) {
-        return {
-          run: async () => ({
-            results: [
-              {
-                id: "member-1",
-                email: "member@example.com",
-                name: "Family Member",
-                role: "member",
-                createdAt: "2026-05-10T12:00:00.000Z",
-                updatedAt: "2026-05-10T12:00:00.000Z",
-              },
-            ],
-          }),
-        };
-      }
-
-      if (
-        sql.includes("LEFT JOIN user_provider_access") &&
-        sql.includes("LEFT JOIN providers")
-      ) {
-        return {
-          run: async () => ({
-            results: [
-              {
-                id: "member-1",
-                email: "member@example.com",
-                name: "Family Member",
-                role: "member",
-                provider_key: "netflix",
-                provider_display_name: "Netflix",
-              },
-            ],
-          }),
-        };
-      }
-
-      if (
-        sql.includes("SELECT id, provider_key, display_name") &&
-        sql.includes("FROM providers") &&
-        sql.includes("ORDER BY display_name ASC")
-      ) {
-        return {
-          run: async () => ({
-            results: [
-              {
-                id: "provider-1",
-                provider_key: "netflix",
-                display_name: "Netflix",
-              },
-            ],
-          }),
-        };
-      }
-
-      return {};
-    });
-
-    const response = await invokeWorker("/api/admin/members", undefined, db);
+    const response = await invokeWorker("/api/admin/home/members");
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
       members: [
         {
-          id: "member-1",
+          id: "owner-home",
+          email: "owner@example.com",
+          name: "Home Owner",
+          householdRole: "owner",
+          role: "admin",
+          createdAt: "2026-05-10T12:00:00.000Z",
+          updatedAt: "2026-05-10T12:00:00.000Z",
+          providerAccess: [],
+        },
+        {
+          id: "member-home",
           email: "member@example.com",
-          name: "Family Member",
+          name: "Household Member",
+          householdRole: "member",
           role: "member",
           createdAt: "2026-05-10T12:00:00.000Z",
           updatedAt: "2026-05-10T12:00:00.000Z",
@@ -794,970 +1065,199 @@ describe("worker routes", () => {
         },
       ],
       providers: [
-        {
-          id: "provider-1",
+        expect.objectContaining({
+          id: "provider-home-netflix",
           provider_key: "netflix",
           display_name: "Netflix",
-        },
-      ],
-    });
-  });
-
-  it("creates a household member from the admin route", async () => {
-    sessionState.current = {
-      user: { id: "admin-1", email: "owner@example.com", role: "admin" },
-      session: { id: "session-1", userId: "admin-1" },
-    };
-
-    const db = createDbStub(() => ({}));
-
-    const response = await invokeWorker(
-      "/api/admin/members",
-      {
-        method: "POST",
-        body: JSON.stringify({
-          email: "new@example.com",
-          name: "New Person",
-          password: "temporary-password-123",
-          role: "member",
         }),
-      },
-      db,
-    );
-
-    expect(response.status).toBe(201);
-    expect(authApiState.createUserCalls).toHaveLength(1);
-    expect(authApiState.createUserCalls[0]).toMatchObject({
-      body: {
-        email: "new@example.com",
-        name: "New Person",
-        password: "temporary-password-123",
-        role: "user",
-      },
-    });
-  });
-
-  it("returns settings profile and sessions for the authenticated user", async () => {
-    sessionState.current = {
-      user: { id: "user-1", email: "member@example.com", role: "member" },
-      session: { id: "session-1", userId: "user-1" },
-    };
-
-    const db = createDbStub(() => ({}));
-    settingsRepoState.getUserProfile.mockResolvedValue({
-      id: "user-1",
-      email: "member@example.com",
-      name: "Member Person",
-      image: "https://example.com/avatar.png",
-      role: "user",
-      twoFactorEnabled: true,
-    });
-    settingsRepoState.listUserSessions.mockResolvedValue([
-      {
-        id: "session-1",
-        token: "token-1",
-        expiresAt: "2026-06-01T12:00:00.000Z",
-        ipAddress: "127.0.0.1",
-        userAgent: "Safari",
-        createdAt: "2026-05-01T12:00:00.000Z",
-        updatedAt: "2026-05-02T12:00:00.000Z",
-        impersonatedBy: null,
-      },
-    ]);
-
-    const response = await invokeWorker("/api/settings", undefined, db);
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
-      profile: {
-        id: "user-1",
-        email: "member@example.com",
-        name: "Member Person",
-        image: "https://example.com/avatar.png",
-        role: "user",
-        twoFactorEnabled: true,
-      },
-      sessions: [
-        {
-          id: "session-1",
-          token: "token-1",
-          expiresAt: "2026-06-01T12:00:00.000Z",
-          ipAddress: "127.0.0.1",
-          userAgent: "Safari",
-          createdAt: "2026-05-01T12:00:00.000Z",
-          updatedAt: "2026-05-02T12:00:00.000Z",
-          impersonatedBy: null,
-        },
-      ],
-    });
-    expect(settingsRepoState.getUserProfile).toHaveBeenCalledWith(db, "user-1");
-    expect(settingsRepoState.listUserSessions).toHaveBeenCalledWith(
-      db,
-      "user-1",
-    );
-  });
-
-  it("updates the authenticated user profile", async () => {
-    sessionState.current = {
-      user: { id: "user-1", email: "member@example.com", role: "member" },
-      session: { id: "session-1", userId: "user-1" },
-    };
-
-    const db = createDbStub(() => ({}));
-    settingsRepoState.updateUserProfile.mockResolvedValue({
-      id: "user-1",
-      email: "member@example.com",
-      name: "Updated Member",
-      image: "https://example.com/new.png",
-      role: "user",
-      twoFactorEnabled: false,
-    });
-
-    const response = await invokeWorker(
-      "/api/settings/profile",
-      {
-        method: "PATCH",
-        body: JSON.stringify({
-          name: "Updated Member",
-          image: "https://example.com/new.png",
-        }),
-      },
-      db,
-    );
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
-      profile: {
-        id: "user-1",
-        email: "member@example.com",
-        name: "Updated Member",
-        image: "https://example.com/new.png",
-        role: "user",
-        twoFactorEnabled: false,
-      },
-    });
-    expect(settingsRepoState.updateUserProfile).toHaveBeenCalledWith(
-      db,
-      "user-1",
-      {
-        name: "Updated Member",
-        image: "https://example.com/new.png",
-      },
-    );
-  });
-
-  it("deletes all other sessions for the authenticated user", async () => {
-    sessionState.current = {
-      user: { id: "user-1", email: "member@example.com", role: "member" },
-      session: { id: "session-keep", userId: "user-1" },
-    };
-
-    const db = createDbStub(() => ({}));
-
-    const response = await invokeWorker(
-      "/api/settings/sessions/others",
-      { method: "DELETE" },
-      db,
-    );
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true });
-    expect(settingsRepoState.deleteOtherSessions).toHaveBeenCalledWith(
-      db,
-      "user-1",
-      "session-keep",
-    );
-  });
-
-  it("creates an invitation and sends an invite email", async () => {
-    sessionState.current = {
-      user: { id: "admin-1", email: "owner@example.com", role: "admin" },
-      session: { id: "session-1", userId: "admin-1" },
-    };
-
-    const db = createDbStub(() => ({}));
-    invitationsRepoState.createHouseholdInvitation.mockResolvedValue(
-      "invite-1",
-    );
-    invitationsRepoState.getInvitationById.mockResolvedValue({
-      id: "invite-1",
-      email: "invitee@example.com",
-      name: "Invitee",
-      role: "member",
-      status: "pending",
-      invitedByUserId: "admin-1",
-      acceptedByUserId: null,
-      expiresAt: "2026-05-31T12:00:00.000Z",
-      acceptedAt: null,
-      cancelledAt: null,
-      createdAt: "2026-05-10T12:00:00.000Z",
-      updatedAt: "2026-05-10T12:00:00.000Z",
-      providers: [
-        {
-          id: "provider-1",
-          provider_key: "netflix",
-          display_name: "Netflix",
-        },
-      ],
-    });
-
-    const response = await invokeWorker(
-      "/api/admin/invitations",
-      {
-        method: "POST",
-        body: JSON.stringify({
-          email: "invitee@example.com",
-          name: "Invitee",
-          role: "member",
-          providerIds: ["provider-1"],
-        }),
-      },
-      db,
-    );
-
-    expect(response.status).toBe(201);
-    const payload = (await response.json()) as { invitation: { id: string } };
-    expect(payload.invitation.id).toBe("invite-1");
-    expect(invitationEmailState.calls).toHaveLength(1);
-    expect(invitationsRepoState.createHouseholdInvitation).toHaveBeenCalled();
-    expect(invitationEmailState.calls[0]).toMatchObject({
-      input: expect.objectContaining({
-        to: "invitee@example.com",
-        inviteeName: "Invitee",
-        inviterEmail: "owner@example.com",
-        role: "member",
-      }),
-    });
-  });
-
-  it("lists invitations for owners", async () => {
-    sessionState.current = {
-      user: { id: "admin-1", email: "owner@example.com", role: "admin" },
-      session: { id: "session-1", userId: "admin-1" },
-    };
-
-    const db = createDbStub(() => ({}));
-    invitationsRepoState.listHouseholdInvitations.mockResolvedValue([
-      {
-        id: "invite-1",
-        email: "invitee@example.com",
-        name: "Invitee",
-        role: "member",
-        status: "pending",
-        invitedByUserId: "admin-1",
-        acceptedByUserId: null,
-        expiresAt: "2026-05-31T12:00:00.000Z",
-        acceptedAt: null,
-        cancelledAt: null,
-        createdAt: "2026-05-10T12:00:00.000Z",
-        updatedAt: "2026-05-10T12:00:00.000Z",
-        providers: [
-          {
-            id: "provider-1",
-            provider_key: "netflix",
-            display_name: "Netflix",
-          },
-        ],
-      },
-    ]);
-
-    const response = await invokeWorker(
-      "/api/admin/invitations",
-      undefined,
-      db,
-    );
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
-      invitations: [
-        {
-          id: "invite-1",
-          email: "invitee@example.com",
-          name: "Invitee",
-          role: "member",
-          status: "pending",
-          invitedByUserId: "admin-1",
-          acceptedByUserId: null,
-          expiresAt: "2026-05-31T12:00:00.000Z",
-          acceptedAt: null,
-          cancelledAt: null,
-          createdAt: "2026-05-10T12:00:00.000Z",
-          updatedAt: "2026-05-10T12:00:00.000Z",
-          providers: [
-            {
-              id: "provider-1",
-              provider_key: "netflix",
-              display_name: "Netflix",
-            },
-          ],
-        },
-      ],
-    });
-    expect(invitationsRepoState.listHouseholdInvitations).toHaveBeenCalledWith(
-      db,
-    );
-  });
-
-  it("accepts an invitation and signs the user in", async () => {
-    const db = createDbStub(() => ({}));
-    invitationsRepoState.getInvitationByTokenHash.mockResolvedValue({
-      id: "invite-1",
-      email: "invitee@example.com",
-      name: "Invitee",
-      role: "member",
-      status: "pending",
-      invitedByUserId: "admin-1",
-      acceptedByUserId: null,
-      expiresAt: "2026-05-31T12:00:00.000Z",
-      acceptedAt: null,
-      cancelledAt: null,
-      createdAt: "2026-05-10T12:00:00.000Z",
-      updatedAt: "2026-05-10T12:00:00.000Z",
-      providers: [
-        {
-          id: "provider-1",
-          provider_key: "netflix",
-          display_name: "Netflix",
-        },
-      ],
-    });
-    invitationsRepoState.acceptInvitation.mockResolvedValue(undefined);
-
-    const response = await invokeWorker(
-      "/api/invitations/test-token/accept",
-      {
-        method: "POST",
-        body: JSON.stringify({
-          name: "Invited Person",
-          password: "super-secure-password",
-        }),
-      },
-      db,
-    );
-
-    expect(response.status).toBe(201);
-    expect(authApiState.createUserCalls.at(-1)).toMatchObject({
-      body: expect.objectContaining({
-        email: "invitee@example.com",
-        name: "Invited Person",
-        password: "super-secure-password",
-        role: "user",
-      }),
-    });
-    expect(authApiState.signInEmailCalls.at(-1)).toMatchObject({
-      body: {
-        email: "invitee@example.com",
-        password: "super-secure-password",
-      },
-    });
-    expect(response.headers.get("set-cookie")).toContain(
-      "better-auth.session_token=test-token",
-    );
-    expect(invitationsRepoState.acceptInvitation).toHaveBeenCalledWith(db, {
-      invitationId: "invite-1",
-      acceptedByUserId: "created-user-1",
-      providerIds: ["provider-1"],
-    });
-  });
-
-  it("lists provider configuration for owners", async () => {
-    sessionState.current = {
-      user: { id: "admin-1", email: "owner@example.com", role: "admin" },
-      session: { id: "session-1", userId: "admin-1" },
-    };
-
-    const db = createDbStub((sql) => {
-      if (sql.includes("COUNT(sender_rules.id) AS rule_count")) {
-        return {
-          run: async () => ({
-            results: [
-              {
-                id: "provider-1",
-                provider_key: "netflix",
-                display_name: "Netflix",
-                created_at: "2026-05-10T12:00:00.000Z",
-                rule_count: 2,
-              },
-            ],
-          }),
-        };
-      }
-
-      if (
-        sql.includes(
-          "SELECT id, provider_id, match_type, match_value, created_at",
-        ) &&
-        sql.includes("FROM sender_rules")
-      ) {
-        return {
-          run: async () => ({
-            results: [
-              {
-                id: "rule-1",
-                provider_id: "provider-1",
-                match_type: "domain",
-                match_value: "netflix.com",
-                created_at: "2026-05-10T12:00:00.000Z",
-              },
-            ],
-          }),
-        };
-      }
-
-      return {};
-    });
-
-    const response = await invokeWorker("/api/admin/providers", undefined, db);
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
-      providers: [
-        {
-          id: "provider-1",
-          provider_key: "netflix",
-          display_name: "Netflix",
-          created_at: "2026-05-10T12:00:00.000Z",
-          rule_count: 2,
-        },
-      ],
-      rules: [
-        {
-          id: "rule-1",
-          provider_id: "provider-1",
-          match_type: "domain",
-          match_value: "netflix.com",
-          created_at: "2026-05-10T12:00:00.000Z",
-        },
       ],
     });
   });
 
-  it("creates a provider from the admin route", async () => {
+  it("denies admin routes to members in the same household", async () => {
     sessionState.current = {
-      user: { id: "admin-1", email: "owner@example.com", role: "admin" },
-      session: { id: "session-1", userId: "admin-1" },
+      user: { id: "member-home", email: "member@example.com", role: "user" },
+      session: { id: "session-1", userId: "member-home" },
     };
 
-    let providerInserted = false;
-
-    const db = createDbStub((sql, params) => {
-      if (sql.includes("WHERE provider_key = ?") && sql.includes("LIMIT 1")) {
-        const providerKey = params[0];
-
-        if (providerKey === "hulu" && providerInserted) {
-          return {
-            first: async () => ({
-              id: "provider-1",
-              provider_key: "hulu",
-              display_name: "Hulu",
-              created_at: "2026-05-10T12:00:00.000Z",
-            }),
-          };
-        }
-
-        return {
-          first: async () => null,
-        };
-      }
-
-      if (sql.startsWith("INSERT INTO providers")) {
-        return {
-          run: async () => {
-            providerInserted = true;
-            return { results: [] };
-          },
-        };
-      }
-
-      return {};
-    });
-
-    const response = await invokeWorker(
-      "/api/admin/providers",
-      {
-        method: "POST",
-        body: JSON.stringify({
-          providerKey: "hulu",
-          displayName: "Hulu",
-        }),
-      },
-      db,
-    );
-
-    expect(response.status).toBe(201);
-    await expect(response.json()).resolves.toEqual({
-      provider: {
-        id: "provider-1",
-        provider_key: "hulu",
-        display_name: "Hulu",
-        created_at: "2026-05-10T12:00:00.000Z",
-      },
-    });
-  });
-
-  it("creates a sender rule from the admin route", async () => {
-    sessionState.current = {
-      user: { id: "admin-1", email: "owner@example.com", role: "admin" },
-      session: { id: "session-1", userId: "admin-1" },
-    };
-
-    const db = createDbStub((sql, params) => {
-      if (sql.includes("WHERE id = ?") && sql.includes("FROM providers")) {
-        return {
-          first: async () => ({
-            id: params[0],
-            provider_key: "netflix",
-            display_name: "Netflix",
-            created_at: "2026-05-10T12:00:00.000Z",
-          }),
-        };
-      }
-
-      if (sql.startsWith("INSERT INTO sender_rules")) {
-        return {
-          run: async () => ({ results: [] }),
-        };
-      }
-
-      if (sql.includes("FROM sender_rules") && sql.includes("WHERE id = ?")) {
-        return {
-          first: async () => ({
-            id: params[0],
-            provider_id: "provider-1",
-            match_type: "domain",
-            match_value: "netflix.com",
-            created_at: "2026-05-10T12:00:00.000Z",
-          }),
-        };
-      }
-
-      return {};
-    });
-
-    const response = await invokeWorker(
-      "/api/admin/provider-rules",
-      {
-        method: "POST",
-        body: JSON.stringify({
-          providerId: "provider-1",
-          matchType: "domain",
-          matchValue: "@Netflix.com",
-        }),
-      },
-      db,
-    );
-
-    expect(response.status).toBe(201);
-    await expect(response.json()).resolves.toEqual({
-      rule: {
-        id: expect.any(String),
-        provider_id: "provider-1",
-        match_type: "domain",
-        match_value: "netflix.com",
-        created_at: "2026-05-10T12:00:00.000Z",
-      },
-    });
-  });
-
-  it("grants provider access from the admin route", async () => {
-    sessionState.current = {
-      user: { id: "admin-1", email: "owner@example.com", role: "admin" },
-      session: { id: "session-1", userId: "admin-1" },
-    };
-
-    const db = createDbStub((sql) => {
-      if (
-        sql.includes("FROM providers") &&
-        sql.includes("WHERE provider_key = ?")
-      ) {
-        return {
-          first: async () => ({
-            id: "provider-1",
-            provider_key: "netflix",
-            display_name: "Netflix",
-          }),
-        };
-      }
-
-      if (sql.startsWith("INSERT OR IGNORE INTO user_provider_access")) {
-        return {
-          run: async () => ({ results: [] }),
-        };
-      }
-
-      return {};
-    });
-
-    const response = await invokeWorker(
-      "/api/admin/members/member-1/provider-access",
-      {
-        method: "POST",
-        body: JSON.stringify({ providerKey: "netflix" }),
-      },
-      db,
-    );
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true });
-  });
-
-  it("keeps admin routes owner-only", async () => {
-    sessionState.current = {
-      user: { id: "user-1", email: "member@example.com", role: "member" },
-      session: { id: "session-1", userId: "user-1" },
-    };
-
-    const db = createDbStub(() => ({}));
-
-    const response = await invokeWorker("/api/admin/members", undefined, db);
+    const response = await invokeWorker("/api/admin/home/members");
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({ error: "Forbidden" });
   });
 
-  it("changes another member's role to admin", async () => {
+  it("denies admin routes across household boundaries even for another owner", async () => {
     sessionState.current = {
-      user: { id: "admin-1", email: "owner@example.com", role: "admin" },
-      session: { id: "session-1", userId: "admin-1" },
+      user: {
+        id: "owner-away",
+        email: "away-owner@example.com",
+        role: "user",
+      },
+      session: { id: "session-1", userId: "owner-away" },
     };
 
-    const db = createDbStub(() => ({}));
-
-    const response = await invokeWorker(
-      "/api/admin/members/member-1/role",
-      {
-        method: "PATCH",
-        body: JSON.stringify({ role: "admin" }),
-      },
-      db,
-    );
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true });
-    expect(authApiState.setRoleCalls).toHaveLength(1);
-    expect(authApiState.setRoleCalls[0]).toMatchObject({
-      body: { userId: "member-1", role: "admin" },
-    });
-  });
-
-  it("changes another member's role to member", async () => {
-    sessionState.current = {
-      user: { id: "admin-1", email: "owner@example.com", role: "admin" },
-      session: { id: "session-1", userId: "admin-1" },
-    };
-
-    const db = createDbStub(() => ({}));
-
-    const response = await invokeWorker(
-      "/api/admin/members/other-admin-2/role",
-      {
-        method: "PATCH",
-        body: JSON.stringify({ role: "member" }),
-      },
-      db,
-    );
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true });
-    expect(authApiState.setRoleCalls).toHaveLength(1);
-    expect(authApiState.setRoleCalls[0]).toMatchObject({
-      body: { userId: "other-admin-2", role: "user" },
-    });
-  });
-
-  it("prevents admin from changing their own role", async () => {
-    sessionState.current = {
-      user: { id: "admin-1", email: "owner@example.com", role: "admin" },
-      session: { id: "session-1", userId: "admin-1" },
-    };
-
-    const db = createDbStub(() => ({}));
-
-    const response = await invokeWorker(
-      "/api/admin/members/admin-1/role",
-      {
-        method: "PATCH",
-        body: JSON.stringify({ role: "member" }),
-      },
-      db,
-    );
+    const response = await invokeWorker("/api/admin/home/members");
 
     expect(response.status).toBe(403);
-    await expect(response.json()).resolves.toEqual({
-      error: "Cannot change your own role. Ask another admin.",
-    });
-    expect(authApiState.setRoleCalls).toHaveLength(0);
+    await expect(response.json()).resolves.toEqual({ error: "Forbidden" });
   });
 
-  it("rejects invalid role value", async () => {
+  it("creates an invitation instead of provisioning a passworded member account", async () => {
     sessionState.current = {
-      user: { id: "admin-1", email: "owner@example.com", role: "admin" },
-      session: { id: "session-1", userId: "admin-1" },
+      user: { id: "owner-home", email: "owner@example.com", role: "user" },
+      session: { id: "session-1", userId: "owner-home" },
     };
 
-    const db = createDbStub(() => ({}));
-
-    const response = await invokeWorker(
-      "/api/admin/members/member-1/role",
-      {
-        method: "PATCH",
-        body: JSON.stringify({ role: "superuser" }),
-      },
-      db,
-    );
-
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toEqual({
-      error: "role must be admin or member",
+    const response = await invokeWorker("/api/admin/home/members", {
+      method: "POST",
+      body: JSON.stringify({
+        email: "new@example.com",
+        name: "New Person",
+        role: "member",
+      }),
     });
-  });
-
-  it("reports that first-run setup is still needed", async () => {
-    const db = createDbStub((sql) => {
-      if (sql.startsWith("INSERT INTO app_installation")) {
-        return {
-          run: async () => ({ results: [] }),
-        };
-      }
-
-      if (sql.includes("FROM app_installation")) {
-        return {
-          first: async () => ({
-            id: 1,
-            status: "pending",
-            owner_user_id: null,
-            owner_email: null,
-            completed_at: null,
-            created_at: "2026-05-10T12:00:00.000Z",
-            updated_at: "2026-05-10T12:00:00.000Z",
-          }),
-        };
-      }
-
-      return {};
-    });
-
-    const response = await invokeWorker("/api/setup/status", undefined, db, {
-      OWNER_EMAIL: "owner@example.com",
-      SETUP_SECRET: "setup-secret",
-    });
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
-      needsSetup: true,
-      setupLocked: false,
-      isConfigured: true,
-      status: "pending",
-      ownerEmail: null,
-    });
-  });
-
-  it("creates the initial owner through the one-time setup flow", async () => {
-    const db = createDbStub((sql) => {
-      if (sql.startsWith("INSERT INTO app_installation")) {
-        return {
-          run: async () => ({ results: [] }),
-        };
-      }
-
-      if (
-        sql.startsWith("UPDATE app_installation") &&
-        sql.includes("status = 'in_progress'")
-      ) {
-        return {
-          run: async () => ({
-            results: [],
-            meta: { changes: 1 },
-          }),
-        };
-      }
-
-      if (
-        sql.startsWith("UPDATE app_installation") &&
-        sql.includes("status = 'complete'")
-      ) {
-        return {
-          run: async () => ({ results: [] }),
-        };
-      }
-
-      if (sql.includes("FROM app_installation")) {
-        return {
-          first: async () => ({
-            id: 1,
-            status: "pending",
-            owner_user_id: null,
-            owner_email: null,
-            completed_at: null,
-            created_at: "2026-05-10T12:00:00.000Z",
-            updated_at: "2026-05-10T12:00:00.000Z",
-          }),
-        };
-      }
-
-      return {};
-    });
-
-    const response = await invokeWorker(
-      "/api/setup/complete",
-      {
-        method: "POST",
-        body: JSON.stringify({
-          email: "owner@example.com",
-          name: "Owner Person",
-          password: "super-secure-password",
-          setupSecret: "setup-secret",
-        }),
-      },
-      db,
-      {
-        OWNER_EMAIL: "owner@example.com",
-        SETUP_SECRET: "setup-secret",
-      },
-    );
 
     expect(response.status).toBe(201);
-    expect(authApiState.createUserCalls).toHaveLength(1);
-    expect(authApiState.createUserCalls[0]).toMatchObject({
-      body: {
-        email: "owner@example.com",
-        name: "Owner Person",
-        password: "super-secure-password",
-        role: "admin",
-      },
+    expect(authApiState.signUpEmailCalls).toHaveLength(0);
+    expect(repoState.createInvitationCalls).toHaveLength(1);
+    expect(repoState.createInvitationCalls[0]).toMatchObject({
+      householdId: "household-home",
+      email: "new@example.com",
+      name: "New Person",
+      role: "member",
     });
-    expect(authApiState.signInEmailCalls).toHaveLength(1);
-    expect(authApiState.signInEmailCalls[0]).toMatchObject({
-      body: {
-        email: "owner@example.com",
-        password: "super-secure-password",
-      },
+    expect(invitationEmailState.calls).toHaveLength(1);
+    await expect(response.json()).resolves.toEqual({
+      invitation: expect.objectContaining({
+        email: "new@example.com",
+        role: "member",
+        status: "pending",
+      }),
+    });
+  });
+
+  it("rejects role changes for a user outside the active household", async () => {
+    sessionState.current = {
+      user: { id: "owner-home", email: "owner@example.com", role: "user" },
+      session: { id: "session-1", userId: "owner-home" },
+    };
+
+    const response = await invokeWorker("/api/admin/home/members/member-away/role", {
+      method: "PATCH",
+      body: JSON.stringify({ role: "admin" }),
     });
 
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Member not found" });
+  });
+
+  it("rejects provider-access changes for a user outside the active household", async () => {
+    sessionState.current = {
+      user: { id: "owner-home", email: "owner@example.com", role: "user" },
+      session: { id: "session-1", userId: "owner-home" },
+    };
+
+    const response = await invokeWorker(
+      "/api/admin/home/members/member-away/provider-access",
+      {
+        method: "POST",
+        body: JSON.stringify({ providerKey: "netflix" }),
+      },
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Member not found" });
+  });
+
+  it("accepts an invitation via provisioning signup and attaches the user to the invited household", async () => {
+    const response = await invokeWorker("/api/invitations/test-token/accept", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "Invited Person",
+        password: "super-secure-password",
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(authApiState.signUpEmailCalls).toHaveLength(1);
+    expect(authApiState.signUpEmailCalls[0]).toMatchObject({
+      body: {
+        email: "invitee@example.com",
+        name: "Invited Person",
+        password: "super-secure-password",
+      },
+    });
+    expect(repoState.acceptInvitationCalls).toEqual([
+      {
+        invitationId: "invite-existing",
+        householdId: "household-home",
+        acceptedByUserId: "created-user-1",
+        role: "member",
+      },
+    ]);
+
     const payload = (await response.json()) as {
-      member: { email: string; role: string };
+      member: { id: string; email: string; role: string };
+      household: { slug: string };
       session: { session: { userId: string } };
     };
 
     expect(payload.member).toEqual({
       id: "created-user-1",
-      email: "new@example.com",
-      name: "New Person",
-      role: "admin",
+      email: "invitee@example.com",
+      name: "Invited Person",
+      role: "member",
     });
+    expect(payload.household.slug).toBe("home");
     expect(payload.session.session.userId).toBe("created-user-1");
     expect(response.headers.get("set-cookie")).toContain(
-      "better-auth.session_token",
+      "better-auth.session_token=test-token",
     );
   });
 
-  it("rejects setup when the secret is wrong", async () => {
-    const db = createDbStub((sql) => {
-      if (sql.startsWith("INSERT INTO app_installation")) {
-        return {
-          run: async () => ({ results: [] }),
-        };
-      }
-
-      if (sql.includes("FROM app_installation")) {
-        return {
-          first: async () => ({
-            id: 1,
-            status: "pending",
-            owner_user_id: null,
-            owner_email: null,
-            completed_at: null,
-            created_at: "2026-05-10T12:00:00.000Z",
-            updated_at: "2026-05-10T12:00:00.000Z",
-          }),
-        };
-      }
-
-      return {};
+  it("creates the initial owner through the provisioning signup flow", async () => {
+    const response = await invokeWorker("/api/setup/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        email: "owner@example.com",
+        name: "Owner Person",
+        password: "super-secure-password",
+        householdName: "Home",
+        householdSlug: "home-setup",
+        setupSecret: "setup-secret",
+      }),
     });
 
-    const response = await invokeWorker(
-      "/api/setup/complete",
-      {
-        method: "POST",
-        body: JSON.stringify({
-          email: "owner@example.com",
-          name: "Owner Person",
-          password: "super-secure-password",
-          setupSecret: "wrong-secret",
-        }),
+    expect(response.status).toBe(201);
+    expect(authApiState.signUpEmailCalls).toHaveLength(1);
+    expect(authApiState.signUpEmailCalls[0]).toMatchObject({
+      body: {
+        email: "owner@example.com",
+        name: "Owner Person",
+        password: "super-secure-password",
       },
-      db,
-      {
-        OWNER_EMAIL: "owner@example.com",
-        SETUP_SECRET: "setup-secret",
-      },
-    );
-
-    expect(response.status).toBe(403);
-    await expect(response.json()).resolves.toEqual({
-      error: "Invalid setup secret",
     });
-  });
-
-  it("keeps setup closed after completion", async () => {
-    const db = createDbStub((sql) => {
-      if (sql.startsWith("INSERT INTO app_installation")) {
-        return {
-          run: async () => ({ results: [] }),
-        };
-      }
-
-      if (sql.includes("FROM app_installation")) {
-        return {
-          first: async () => ({
-            id: 1,
-            status: "complete",
-            owner_user_id: "owner-1",
-            owner_email: "owner@example.com",
-            completed_at: "2026-05-10T12:30:00.000Z",
-            created_at: "2026-05-10T12:00:00.000Z",
-            updated_at: "2026-05-10T12:30:00.000Z",
-          }),
-        };
-      }
-
-      if (
-        sql.startsWith("UPDATE app_installation") &&
-        sql.includes("status = 'in_progress'")
-      ) {
-        return {
-          run: async () => ({
-            results: [],
-            meta: { changes: 0 },
-          }),
-        };
-      }
-
-      return {};
-    });
-
-    const response = await invokeWorker(
-      "/api/setup/complete",
+    expect(repoState.createHouseholdCalls).toEqual([
       {
-        method: "POST",
-        body: JSON.stringify({
-          email: "owner@example.com",
-          name: "Owner Person",
-          password: "super-secure-password",
-          setupSecret: "setup-secret",
-        }),
+        slug: "home-setup",
+        displayName: "Home",
+        ownerUserId: "created-user-1",
       },
-      db,
-      {
-        OWNER_EMAIL: "owner@example.com",
-        SETUP_SECRET: "setup-secret",
-      },
-    );
+    ]);
 
-    expect(response.status).toBe(409);
-    await expect(response.json()).resolves.toEqual({
-      error: "Setup has already been completed",
+    const payload = (await response.json()) as {
+      member: { role: string; email: string };
+      household: { slug: string };
+      session: { session: { userId: string } };
+    };
+
+    expect(payload.member).toEqual({
+      id: "created-user-1",
+      email: "owner@example.com",
+      name: "Owner Person",
+      role: "owner",
     });
+    expect(payload.household.slug).toBe("home-setup");
+    expect(payload.session.session.userId).toBe("created-user-1");
   });
 });

--- a/test/inbox-routes.test.ts
+++ b/test/inbox-routes.test.ts
@@ -73,7 +73,11 @@ const repoState = vi.hoisted(() => ({
   households: [] as HouseholdRecord[],
   memberships: [] as MembershipRecord[],
   providers: [] as ProviderRecord[],
-  providerAccess: [] as Array<{ householdId: string; userId: string; providerId: string }>,
+  providerAccess: [] as Array<{
+    householdId: string;
+    userId: string;
+    providerId: string;
+  }>,
   messages: [] as Array<{
     id: string;
     household_slug: string;
@@ -134,7 +138,9 @@ function getUser(userId: string) {
 }
 
 function getHouseholdBySlug(slug: string) {
-  return repoState.households.find((household) => household.slug === slug) ?? null;
+  return (
+    repoState.households.find((household) => household.slug === slug) ?? null
+  );
 }
 
 function getHouseholdByIdValue(id: string) {
@@ -152,7 +158,9 @@ function getMembership(userId: string, householdId: string) {
 
 function getInvitationProviders(providerIds: string[]) {
   return providerIds
-    .map((providerId) => repoState.providers.find((provider) => provider.id === providerId))
+    .map((providerId) =>
+      repoState.providers.find((provider) => provider.id === providerId),
+    )
     .filter((provider): provider is ProviderRecord => Boolean(provider))
     .map((provider) => ({
       id: provider.id,
@@ -305,7 +313,8 @@ vi.mock("../src/server/db/repositories/households", async () => {
       });
       return household;
     },
-    getHouseholdById: async (_db: D1Database, id: string) => getHouseholdByIdValue(id),
+    getHouseholdById: async (_db: D1Database, id: string) =>
+      getHouseholdByIdValue(id),
     assertProvidersBelongToHousehold: async (
       _db: D1Database,
       householdId: string,
@@ -342,7 +351,8 @@ vi.mock("../src/server/db/repositories/member-access", () => ({
       const user = getUser(membership.userId);
       const accessRows = repoState.providerAccess.filter(
         (entry) =>
-          entry.householdId === householdId && entry.userId === membership.userId,
+          entry.householdId === householdId &&
+          entry.userId === membership.userId,
       );
       if (accessRows.length === 0) {
         return [
@@ -373,7 +383,9 @@ vi.mock("../src/server/db/repositories/member-access", () => ({
       });
     }),
   listProviders: async (_db: D1Database, householdId: string) =>
-    repoState.providers.filter((provider) => provider.household_id === householdId),
+    repoState.providers.filter(
+      (provider) => provider.household_id === householdId,
+    ),
   grantProviderAccess: async (
     _db: D1Database,
     householdId: string,
@@ -427,7 +439,8 @@ vi.mock("../src/server/db/repositories/provider-rules", () => ({
   ) =>
     repoState.providers.find(
       (provider) =>
-        provider.household_id === householdId && provider.provider_key === providerKey,
+        provider.household_id === householdId &&
+        provider.provider_key === providerKey,
     ) ?? null,
   getProviderById: async (
     _db: D1Database,
@@ -441,7 +454,10 @@ vi.mock("../src/server/db/repositories/provider-rules", () => ({
   listProviderConfigurations: async (_db: D1Database, householdId: string) =>
     repoState.providers
       .filter((provider) => provider.household_id === householdId)
-      .map((provider) => ({ ...provider, rule_count: provider.rule_count ?? 0 })),
+      .map((provider) => ({
+        ...provider,
+        rule_count: provider.rule_count ?? 0,
+      })),
   listSenderRules: async (_db: D1Database, householdId: string) =>
     repoState.senderRules.filter((rule) => rule.household_id === householdId),
   createProvider: async (
@@ -498,21 +514,27 @@ vi.mock("../src/server/db/repositories/messages", () => ({
       if (provider.household_id !== householdId) return false;
       if (membership.role === "owner") return true;
       return repoState.providerAccess.some(
-        (entry) => entry.householdId === householdId && entry.userId === userId && entry.providerId === provider.id,
+        (entry) =>
+          entry.householdId === householdId &&
+          entry.userId === userId &&
+          entry.providerId === provider.id,
       );
     });
 
     return visibleProviders.map((provider) => {
       const providerMessages = repoState.messages.filter(
         (message) =>
-          message.householdId === householdId && message.provider_key === provider.provider_key,
+          message.householdId === householdId &&
+          message.provider_key === provider.provider_key,
       );
       return {
         household_slug: getHouseholdByIdValue(householdId)?.slug ?? "unknown",
         provider_key: provider.provider_key,
         display_name: provider.display_name,
         message_count: providerMessages.length,
-        new_count: providerMessages.filter((message) => message.status === "new").length,
+        new_count: providerMessages.filter(
+          (message) => message.status === "new",
+        ).length,
         latest_received_at: providerMessages[0]?.received_at ?? null,
       };
     });
@@ -524,7 +546,8 @@ vi.mock("../src/server/db/repositories/messages", () => ({
   ) =>
     repoState.messages.filter(
       (message) =>
-        message.householdId === householdId && message.provider_key === providerKey,
+        message.householdId === householdId &&
+        message.provider_key === providerKey,
     ),
   findMessageById: async (
     _db: D1Database,
@@ -532,7 +555,8 @@ vi.mock("../src/server/db/repositories/messages", () => ({
     messageId: string,
   ) =>
     repoState.messages.find(
-      (message) => message.householdId === householdId && message.id === messageId,
+      (message) =>
+        message.householdId === householdId && message.id === messageId,
     ) ?? null,
   updateMessageStatus: async (
     _db: D1Database,
@@ -541,7 +565,8 @@ vi.mock("../src/server/db/repositories/messages", () => ({
     status: "new" | "used" | "expired",
   ) => {
     const message = repoState.messages.find(
-      (candidate) => candidate.householdId === householdId && candidate.id === messageId,
+      (candidate) =>
+        candidate.householdId === householdId && candidate.id === messageId,
     );
     if (!message) return null;
     message.status = status;
@@ -559,7 +584,8 @@ vi.mock("../src/server/db/repositories/messages", () => ({
   ) => {
     repoState.reviewCalls.push({ householdId, messageId, input });
     const message = repoState.quarantine.find(
-      (candidate) => candidate.householdId === householdId && candidate.id === messageId,
+      (candidate) =>
+        candidate.householdId === householdId && candidate.id === messageId,
     );
     if (!message) return null;
     message.reviewed = true;
@@ -787,10 +813,15 @@ async function invokeWorker(
 ) {
   const fetchHandler = getWorkerFetch();
   const db = createDbStub();
-  const request = new Request(`http://localhost:8787${path}`, options) as Parameters<
-    WorkerFetch
-  >[0];
-  return fetchHandler(request, createEnv(db, envOverrides), createExecutionContext());
+  const request = new Request(
+    `http://localhost:8787${path}`,
+    options,
+  ) as Parameters<WorkerFetch>[0];
+  return fetchHandler(
+    request,
+    createEnv(db, envOverrides),
+    createExecutionContext(),
+  );
 }
 
 describe("worker routes", () => {
@@ -979,10 +1010,13 @@ describe("worker routes", () => {
       session: { id: "session-1", userId: "member-home" },
     };
 
-    const response = await invokeWorker("/api/inbox/home/messages/msg-home-1/status", {
-      method: "PATCH",
-      body: JSON.stringify({ status: "used" }),
-    });
+    const response = await invokeWorker(
+      "/api/inbox/home/messages/msg-home-1/status",
+      {
+        method: "PATCH",
+        body: JSON.stringify({ status: "used" }),
+      },
+    );
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
@@ -1142,13 +1176,18 @@ describe("worker routes", () => {
       session: { id: "session-1", userId: "owner-home" },
     };
 
-    const response = await invokeWorker("/api/admin/home/members/member-away/role", {
-      method: "PATCH",
-      body: JSON.stringify({ role: "admin" }),
-    });
+    const response = await invokeWorker(
+      "/api/admin/home/members/member-away/role",
+      {
+        method: "PATCH",
+        body: JSON.stringify({ role: "admin" }),
+      },
+    );
 
     expect(response.status).toBe(404);
-    await expect(response.json()).resolves.toEqual({ error: "Member not found" });
+    await expect(response.json()).resolves.toEqual({
+      error: "Member not found",
+    });
   });
 
   it("rejects provider-access changes for a user outside the active household", async () => {
@@ -1166,7 +1205,9 @@ describe("worker routes", () => {
     );
 
     expect(response.status).toBe(404);
-    await expect(response.json()).resolves.toEqual({ error: "Member not found" });
+    await expect(response.json()).resolves.toEqual({
+      error: "Member not found",
+    });
   });
 
   it("accepts an invitation via provisioning signup and attaches the user to the invited household", async () => {

--- a/test/messages-repository.test.ts
+++ b/test/messages-repository.test.ts
@@ -12,6 +12,7 @@ function createParsedEmail(
   return {
     envelopeFrom: "login@service.example",
     envelopeTo: "codes@example.com",
+    householdSlug: "codes",
     fromHeader: "Service <login@service.example>",
     subject: "Your verification code",
     messageId: "<message-1@test>",
@@ -43,12 +44,16 @@ function createDb(runImpl: () => Promise<unknown>) {
 describe("messages repository inserts", () => {
   it("ignores duplicate inbox message ids", async () => {
     const db = createDb(async () => {
-      throw new Error("UNIQUE constraint failed: messages.message_id");
+      throw new Error(
+        "UNIQUE constraint failed: messages.household_id, messages.message_id",
+      );
     });
 
     await expect(
-      insertMessage(db.db, createParsedEmail(), "provider-1", {
+      insertMessage(db.db, createParsedEmail(), "household-1", "provider-1", {
         kind: "matched",
+        householdId: "household-1",
+        householdSlug: "codes",
         providerId: "provider-1",
         providerKey: "netflix",
         code: "123456",
@@ -69,12 +74,12 @@ describe("messages repository inserts", () => {
   it("ignores duplicate quarantine message ids", async () => {
     const db = createDb(async () => {
       throw new Error(
-        "UNIQUE constraint failed: quarantine_messages.message_id",
+        "UNIQUE constraint failed: quarantine_messages.household_id, quarantine_messages.message_id",
       );
     });
 
     await expect(
-      insertQuarantineMessage(db.db, createParsedEmail(), {
+      insertQuarantineMessage(db.db, createParsedEmail(), "household-1", {
         kind: "quarantine",
         reason: "No sender rule matched the inbound email.",
         code: "123456",
@@ -96,8 +101,10 @@ describe("messages repository inserts", () => {
     });
 
     await expect(
-      insertMessage(db.db, createParsedEmail(), "provider-1", {
+      insertMessage(db.db, createParsedEmail(), "household-1", "provider-1", {
         kind: "matched",
+        householdId: "household-1",
+        householdSlug: "codes",
         providerId: "provider-1",
         providerKey: "netflix",
         code: "123456",


### PR DESCRIPTION
## Summary
- add household-scoped data model, routes, and client navigation so the app operates against URL slugs instead of a single global household
- replace removed Better Auth admin user provisioning with an internal signup-only provisioning flow for setup/invites and convert admin-created members to invitation-only onboarding
- harden tenant boundaries across inbox/admin flows and rewrite tests to prove same-household success plus cross-household denial behavior

## Validation
- npm run typecheck
- npm run test