### PR TITLE
fix: correct household API routes

### DIFF
--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -7,6 +7,15 @@ export function buildHouseholdPath(slug: string, path: string = "") {
 
 export function buildHouseholdApiPath(slug: string, path: string) {
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+
+  if (normalizedPath.startsWith("/inbox/") || normalizedPath === "/inbox") {
+    return `/api/inbox/${slug}${normalizedPath.slice("/inbox".length)}`;
+  }
+
+  if (normalizedPath.startsWith("/admin/") || normalizedPath === "/admin") {
+    return `/api/admin/${slug}${normalizedPath.slice("/admin".length)}`;
+  }
+
   return `/api${buildHouseholdPath(slug, normalizedPath)}`;
 }
 
@@ -45,6 +54,14 @@ export async function fetchJson<T>(
 
     throw new Error(
       payload?.error ?? `Request failed with status ${response.status}`,
+    );
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) {
+    const text = await response.text();
+    throw new Error(
+      `Expected JSON response but received ${contentType || "unknown content type"}: ${text.slice(0, 120)}`,
     );
   }
 

--- a/test/client-utils.test.ts
+++ b/test/client-utils.test.ts
@@ -1,6 +1,29 @@
 import { describe, expect, it } from "vitest";
 
-import { getProviderAccessToggleRequest } from "../src/client/utils";
+import {
+  buildHouseholdApiPath,
+  getProviderAccessToggleRequest,
+} from "../src/client/utils";
+
+describe("buildHouseholdApiPath", () => {
+  it("builds inbox household routes under /api/inbox/:slug", () => {
+    expect(buildHouseholdApiPath("home", "/inbox/providers")).toBe(
+      "/api/inbox/home/providers",
+    );
+  });
+
+  it("builds admin household routes under /api/admin/:slug", () => {
+    expect(buildHouseholdApiPath("home", "/admin/members")).toBe(
+      "/api/admin/home/members",
+    );
+  });
+
+  it("keeps non-household APIs under /api/:slug for other scoped paths", () => {
+    expect(buildHouseholdApiPath("home", "/settings")).toBe(
+      "/api/home/settings",
+    );
+  });
+});
 
 describe("getProviderAccessToggleRequest", () => {
   it("uses POST and a granted message when access should be enabled", () => {


### PR DESCRIPTION
## Summary
- route household inbox API requests to `/api/inbox/:slug/...` instead of `/api/:slug/inbox/...`
- route household admin API requests to `/api/admin/:slug/...` instead of `/api/:slug/admin/...`
- fail early with a clearer error when `fetchJson()` receives HTML instead of JSON, and add tests for the route builder

## Verification
- `npm run typecheck`
- `vitest test/client-utils.test.ts`