### PR TITLE
feat: move account actions to topbar menu

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
   "files": {
-    "includes": ["**", "!dist"]
+    "includes": ["**", "!dist", "!.wrangler"]
   },
   "formatter": {
     "enabled": true,

--- a/src/client/components/Layout.tsx
+++ b/src/client/components/Layout.tsx
@@ -13,6 +13,7 @@ import {
 } from "@mui/icons-material";
 import {
   AppBar,
+  Avatar,
   Box,
   ButtonBase,
   Divider,
@@ -35,7 +36,7 @@ import { useContext, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { ColorModeContext } from "../theme";
 import type { HouseholdSummary, SessionData } from "../types";
-import { buildHouseholdPath, getDisplayName } from "../utils";
+import { buildHouseholdPath, getDisplayName, getUserInitials } from "../utils";
 
 const DRAWER_WIDTH = 280;
 
@@ -50,6 +51,113 @@ interface LayoutProps {
   onSelectHousehold: (household: HouseholdSummary) => void;
   onCreateHousehold: () => void;
   onLogout: () => void;
+}
+
+interface UserAccountMenuProps {
+  session: SessionData | null | undefined;
+  householdSlug: string;
+  mode: "light" | "dark";
+  onSettingsClick: () => void;
+  onToggleColorMode: () => void;
+  onLogout: () => void;
+}
+
+export function UserAccountMenuContent({
+  session,
+  householdSlug,
+  mode,
+  onSettingsClick,
+  onToggleColorMode,
+  onLogout,
+}: UserAccountMenuProps) {
+  return (
+    <>
+      <Box sx={{ px: 2, pt: 1.5, pb: 1 }}>
+        <Typography variant="subtitle2" sx={{ fontWeight: 700 }} noWrap>
+          {getDisplayName(session)}
+        </Typography>
+        <Typography variant="body2" color="text.secondary" noWrap>
+          {session?.user?.email ?? ""}
+        </Typography>
+      </Box>
+      <Divider />
+      <MenuItem
+        component={Link}
+        to={buildHouseholdPath(householdSlug, "/settings")}
+        onClick={onSettingsClick}
+        sx={{ py: 1.25 }}
+      >
+        <ListItemIcon>
+          <ManageAccountsIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText
+          primary={<Typography sx={{ fontWeight: 600 }}>Settings</Typography>}
+        />
+      </MenuItem>
+      <MenuItem onClick={onToggleColorMode} sx={{ py: 1.25 }}>
+        <ListItemIcon>
+          {mode === "dark" ? (
+            <Brightness7 fontSize="small" />
+          ) : (
+            <Brightness4 fontSize="small" />
+          )}
+        </ListItemIcon>
+        <ListItemText
+          primary={
+            <Typography sx={{ fontWeight: 600 }}>
+              {mode === "dark" ? "Light mode" : "Dark mode"}
+            </Typography>
+          }
+        />
+      </MenuItem>
+      <Divider />
+      <MenuItem onClick={onLogout} sx={{ py: 1.25 }}>
+        <ListItemIcon>
+          <LogoutIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText
+          primary={<Typography sx={{ fontWeight: 600 }}>Sign out</Typography>}
+        />
+      </MenuItem>
+    </>
+  );
+}
+
+interface UserAccountMenuWrapperProps
+  extends Omit<UserAccountMenuProps, "onSettingsClick"> {
+  anchorEl: HTMLElement | null;
+  open: boolean;
+  onClose: () => void;
+}
+
+function UserAccountMenu({
+  anchorEl,
+  open,
+  onClose,
+  ...contentProps
+}: UserAccountMenuWrapperProps) {
+  return (
+    <Menu
+      id="user-account-menu"
+      anchorEl={anchorEl}
+      open={open}
+      onClose={onClose}
+      anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+      transformOrigin={{ vertical: "top", horizontal: "right" }}
+      slotProps={{
+        paper: {
+          sx: {
+            width: 280,
+            maxWidth: "calc(100vw - 32px)",
+            borderRadius: 3,
+            mt: 1,
+          },
+        },
+      }}
+    >
+      <UserAccountMenuContent {...contentProps} onSettingsClick={onClose} />
+    </Menu>
+  );
 }
 
 export function Layout({
@@ -80,11 +188,15 @@ export function Layout({
   const [mobileOpen, setMobileOpen] = useState(false);
   const [householdMenuAnchor, setHouseholdMenuAnchor] =
     useState<null | HTMLElement>(null);
+  const [userMenuAnchor, setUserMenuAnchor] = useState<null | HTMLElement>(
+    null,
+  );
 
   const activeHousehold =
     households.find((household) => household.slug === householdSlug) ?? null;
   const roleLabel = householdRole === "owner" ? "Owner" : "Member";
   const isHouseholdMenuOpen = Boolean(householdMenuAnchor);
+  const isUserMenuOpen = Boolean(userMenuAnchor);
 
   const handleDrawerToggle = () => {
     setMobileOpen(!mobileOpen);
@@ -114,6 +226,24 @@ export function Layout({
     handleCloseHouseholdMenu();
     handleNavClick();
     onCreateHousehold();
+  };
+
+  const handleOpenUserMenu = (event: React.MouseEvent<HTMLElement>) => {
+    setUserMenuAnchor(event.currentTarget);
+  };
+
+  const handleCloseUserMenu = () => {
+    setUserMenuAnchor(null);
+  };
+
+  const handleToggleColorMode = () => {
+    handleCloseUserMenu();
+    colorMode.toggleColorMode();
+  };
+
+  const handleLogoutClick = () => {
+    handleCloseUserMenu();
+    onLogout();
   };
 
   const drawerContent = (
@@ -151,33 +281,6 @@ export function Layout({
                   }}
                 >
                   Inbox
-                </Typography>
-              }
-            />
-          </ListItemButton>
-        </ListItem>
-
-        <ListItem disablePadding sx={{ mb: 1 }}>
-          <ListItemButton
-            selected={activeView === "settings"}
-            component={Link}
-            to={buildHouseholdPath(householdSlug, "/settings")}
-            onClick={handleNavClick}
-            sx={{ borderRadius: 2 }}
-          >
-            <ListItemIcon>
-              <ManageAccountsIcon
-                color={activeView === "settings" ? "primary" : "inherit"}
-              />
-            </ListItemIcon>
-            <ListItemText
-              primary={
-                <Typography
-                  sx={{
-                    fontWeight: activeView === "settings" ? "bold" : "normal",
-                  }}
-                >
-                  Settings
                 </Typography>
               }
             />
@@ -394,28 +497,33 @@ export function Layout({
 
           <Box sx={{ flexGrow: 1 }} />
 
-          <Typography
-            variant="body2"
-            sx={{ mr: 2, display: { xs: "none", sm: "block" } }}
-          >
-            {getDisplayName(session)}
-          </Typography>
-
           <IconButton
-            sx={{ ml: 1 }}
-            onClick={colorMode.toggleColorMode}
+            onClick={handleOpenUserMenu}
             color="inherit"
+            aria-label="Open account menu"
+            aria-controls={isUserMenuOpen ? "user-account-menu" : undefined}
+            aria-expanded={isUserMenuOpen ? "true" : undefined}
+            aria-haspopup="true"
+            sx={{ p: 0.5 }}
           >
-            {theme.palette.mode === "dark" ? <Brightness7 /> : <Brightness4 />}
+            <Avatar
+              src={session?.user?.image ?? undefined}
+              alt={getDisplayName(session)}
+              sx={{ width: 36, height: 36, bgcolor: "primary.main" }}
+            >
+              {getUserInitials(session)}
+            </Avatar>
           </IconButton>
-          <IconButton
-            sx={{ ml: 1 }}
-            onClick={onLogout}
-            color="inherit"
-            title="Sign out"
-          >
-            <LogoutIcon />
-          </IconButton>
+          <UserAccountMenu
+            session={session}
+            householdSlug={householdSlug}
+            anchorEl={userMenuAnchor}
+            open={isUserMenuOpen}
+            mode={theme.palette.mode}
+            onClose={handleCloseUserMenu}
+            onToggleColorMode={handleToggleColorMode}
+            onLogout={handleLogoutClick}
+          />
         </Toolbar>
       </AppBar>
 

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -95,3 +95,34 @@ export function getDisplayName(
 
   return session?.user?.email ?? "family member";
 }
+
+export function getUserInitials(
+  session: SessionData | null | undefined,
+): string {
+  const name = session?.user?.name?.trim();
+  if (name) {
+    const parts = name.split(/\s+/).filter(Boolean);
+
+    if (parts.length === 1) {
+      return parts[0].slice(0, 2).toUpperCase();
+    }
+
+    return `${parts[0][0] ?? ""}${parts.at(-1)?.[0] ?? ""}`.toUpperCase();
+  }
+
+  const email = session?.user?.email?.trim();
+  if (!email) {
+    return "FM";
+  }
+
+  const localPart = email.split("@")[0] ?? email;
+  const tokens = localPart.split(/[^A-Za-z0-9]+/).filter(Boolean);
+
+  if (tokens.length >= 2) {
+    return `${tokens[0][0] ?? ""}${tokens.at(-1)?.[0] ?? ""}`.toUpperCase();
+  }
+
+  const fallback = localPart.replace(/[^A-Za-z0-9]/g, "").slice(0, 2);
+
+  return (fallback || "FM").toUpperCase();
+}

--- a/test/layout.test.tsx
+++ b/test/layout.test.tsx
@@ -1,0 +1,111 @@
+import { CssBaseline, MenuList, ThemeProvider } from "@mui/material";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  Layout,
+  UserAccountMenuContent,
+} from "../src/client/components/Layout";
+import { ColorModeContext, getTheme } from "../src/client/theme";
+import { getUserInitials } from "../src/client/utils";
+
+describe("Layout", () => {
+  it("keeps settings out of the sidebar and shows avatar initials fallback", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter initialEntries={["/home/inbox"]}>
+        <ColorModeContext.Provider value={{ toggleColorMode: vi.fn() }}>
+          <ThemeProvider theme={getTheme("light")}>
+            <CssBaseline />
+            <Layout
+              session={{
+                user: {
+                  email: "alex.member@example.com",
+                },
+              }}
+              households={[
+                {
+                  id: "household-1",
+                  slug: "home",
+                  displayName: "Home",
+                  role: "owner",
+                },
+              ]}
+              isOwner={true}
+              householdSlug="home"
+              householdName="Home"
+              householdRole="owner"
+              onSelectHousehold={vi.fn()}
+              onCreateHousehold={vi.fn()}
+              onLogout={vi.fn()}
+            >
+              <div>Inbox content</div>
+            </Layout>
+          </ThemeProvider>
+        </ColorModeContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(html).toContain("Inbox");
+    expect(html).toContain("Quarantine");
+    expect(html).toContain("Members");
+    expect(html).toContain("Providers &amp; rules");
+    expect(html).not.toContain(">Settings<");
+    expect(html).toContain("AM");
+  });
+});
+
+describe("UserAccountMenuContent", () => {
+  it("renders settings, theme toggle, and sign out actions", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter initialEntries={["/home/inbox"]}>
+        <ThemeProvider theme={getTheme("dark")}>
+          <MenuList>
+            <UserAccountMenuContent
+              session={{
+                user: {
+                  name: "Alex Member",
+                  email: "alex.member@example.com",
+                },
+              }}
+              householdSlug="home"
+              mode="dark"
+              onSettingsClick={vi.fn()}
+              onToggleColorMode={vi.fn()}
+              onLogout={vi.fn()}
+            />
+          </MenuList>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(html).toContain("Alex Member");
+    expect(html).toContain("alex.member@example.com");
+    expect(html).toContain("Settings");
+    expect(html).toContain("Light mode");
+    expect(html).toContain("Sign out");
+  });
+});
+
+describe("getUserInitials", () => {
+  it("uses name initials when a profile name exists", () => {
+    expect(
+      getUserInitials({
+        user: {
+          name: "Alex Member",
+          email: "alex.member@example.com",
+        },
+      }),
+    ).toBe("AM");
+  });
+
+  it("falls back to email-derived initials when there is no name", () => {
+    expect(
+      getUserInitials({
+        user: {
+          email: "alex.member@example.com",
+        },
+      }),
+    ).toBe("AM");
+  });
+});


### PR DESCRIPTION
## Summary
- move settings access from the sidebar into a top-right avatar menu and keep the household switcher in the sidebar
- add account menu actions for settings, theme toggle, and sign out with avatar image or initials fallback
- add focused layout tests for the new menu content and initials helper, and ignore generated `.wrangler` output in Biome checks

## Verification
- npm run check
- npm run typecheck
- npm run test
- npm run build