### PR TITLE
fix: make settings a global route

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -108,19 +108,21 @@ export function App() {
   const location = useLocation();
   const routeSegments = location.pathname.split("/").filter(Boolean);
   const routeSlug =
-    routeSegments[0] && !["login", "setup", "invite"].includes(routeSegments[0])
+    routeSegments[0] &&
+    !["login", "setup", "invite", "settings"].includes(routeSegments[0])
       ? routeSegments[0]
       : null;
 
-  const activeView: ViewType = location.pathname.includes("/settings")
-    ? "settings"
-    : location.pathname.includes("/quarantine")
-      ? "quarantine"
-      : location.pathname.includes("/members")
-        ? "members"
-        : location.pathname.includes("/providers")
-          ? "providers"
-          : "inbox";
+  const activeView: ViewType =
+    location.pathname === "/settings"
+      ? "settings"
+      : location.pathname.includes("/quarantine")
+        ? "quarantine"
+        : location.pathname.includes("/members")
+          ? "members"
+          : location.pathname.includes("/providers")
+            ? "providers"
+            : "inbox";
   const [households, setHouseholds] = useState<HouseholdSummary[]>([]);
   const [isLoadingHouseholds, setIsLoadingHouseholds] = useState(false);
   const [providers, setProviders] = useState<ProviderSummary[]>([]);
@@ -193,11 +195,13 @@ export function App() {
     : null;
   const defaultHousehold = households[0] ?? null;
   const isOwner = currentHousehold?.role === "owner";
+  const layoutHousehold = currentHousehold ?? defaultHousehold;
+  const layoutIsOwner = layoutHousehold?.role === "owner";
   const getHouseholdDestination = useCallback(
     (household: HouseholdSummary) => {
       switch (activeView) {
         case "settings":
-          return buildHouseholdPath(household.slug, "/settings");
+          return buildHouseholdPath(household.slug, "/inbox");
         case "quarantine":
           return buildHouseholdPath(
             household.slug,
@@ -301,6 +305,10 @@ export function App() {
       return;
     }
 
+    if (activeView === "settings") {
+      return;
+    }
+
     if (!routeSlug || !currentHousehold) {
       navigate(
         buildHouseholdPath(
@@ -320,6 +328,7 @@ export function App() {
     isLoadingHouseholds,
     navigate,
     routeSlug,
+    activeView,
   ]);
 
   useEffect(() => {
@@ -1562,6 +1571,7 @@ export function App() {
     setViewError(null);
     setStatusMessage("Household creation walkthrough coming soon.");
   }
+
   if (
     isSessionPending ||
     isCheckingSetup ||
@@ -1647,18 +1657,18 @@ export function App() {
     );
   }
 
-  if (!currentHousehold) {
+  if (!layoutHousehold) {
     return null;
   }
 
   return (
     <Layout
       session={session}
+      isOwner={layoutIsOwner}
+      householdSlug={layoutHousehold.slug}
+      householdName={layoutHousehold.displayName}
+      householdRole={layoutHousehold.role}
       households={households}
-      isOwner={isOwner}
-      householdSlug={currentHousehold.slug}
-      householdName={currentHousehold.displayName}
-      householdRole={currentHousehold.role}
       onSelectHousehold={handleSelectHousehold}
       onCreateHousehold={handleCreateHousehold}
       onLogout={handleLogout}
@@ -1668,7 +1678,7 @@ export function App() {
           path="/"
           element={
             <Navigate
-              to={buildHouseholdPath(currentHousehold.slug, "/inbox")}
+              to={buildHouseholdPath(layoutHousehold.slug, "/inbox")}
               replace
             />
           }
@@ -1690,7 +1700,7 @@ export function App() {
           }
         />
         <Route
-          path="/:slug/settings"
+          path="/settings"
           element={
             <SettingsView
               profile={profile}
@@ -1730,7 +1740,7 @@ export function App() {
               />
             ) : (
               <Navigate
-                to={buildHouseholdPath(currentHousehold.slug, "/inbox")}
+                to={buildHouseholdPath(layoutHousehold.slug, "/inbox")}
                 replace
               />
             )
@@ -1769,7 +1779,7 @@ export function App() {
               />
             ) : (
               <Navigate
-                to={buildHouseholdPath(currentHousehold.slug, "/inbox")}
+                to={buildHouseholdPath(layoutHousehold.slug, "/inbox")}
                 replace
               />
             )
@@ -1849,7 +1859,7 @@ export function App() {
               />
             ) : (
               <Navigate
-                to={buildHouseholdPath(currentHousehold.slug, "/inbox")}
+                to={buildHouseholdPath(layoutHousehold.slug, "/inbox")}
                 replace
               />
             )
@@ -1859,7 +1869,7 @@ export function App() {
           path="*"
           element={
             <Navigate
-              to={buildHouseholdPath(currentHousehold.slug, "/inbox")}
+              to={buildHouseholdPath(layoutHousehold.slug, "/inbox")}
               replace
             />
           }

--- a/src/client/components/Layout.tsx
+++ b/src/client/components/Layout.tsx
@@ -55,7 +55,6 @@ interface LayoutProps {
 
 interface UserAccountMenuProps {
   session: SessionData | null | undefined;
-  householdSlug: string;
   mode: "light" | "dark";
   onSettingsClick: () => void;
   onToggleColorMode: () => void;
@@ -64,7 +63,6 @@ interface UserAccountMenuProps {
 
 export function UserAccountMenuContent({
   session,
-  householdSlug,
   mode,
   onSettingsClick,
   onToggleColorMode,
@@ -83,7 +81,7 @@ export function UserAccountMenuContent({
       <Divider />
       <MenuItem
         component={Link}
-        to={buildHouseholdPath(householdSlug, "/settings")}
+        to="/settings"
         onClick={onSettingsClick}
         sx={{ py: 1.25 }}
       >
@@ -173,15 +171,16 @@ export function Layout({
   onLogout,
 }: LayoutProps) {
   const location = useLocation();
-  const activeView = location.pathname.includes("/settings")
-    ? "settings"
-    : location.pathname.includes("/quarantine")
-      ? "quarantine"
-      : location.pathname.includes("/members")
-        ? "members"
-        : location.pathname.includes("/providers")
-          ? "providers"
-          : "inbox";
+  const activeView =
+    location.pathname === "/settings"
+      ? "settings"
+      : location.pathname.includes("/quarantine")
+        ? "quarantine"
+        : location.pathname.includes("/members")
+          ? "members"
+          : location.pathname.includes("/providers")
+            ? "providers"
+            : "inbox";
   const theme = useTheme();
   const colorMode = useContext(ColorModeContext);
   const isDesktop = useMediaQuery(theme.breakpoints.up("lg"));
@@ -516,7 +515,6 @@ export function Layout({
           </IconButton>
           <UserAccountMenu
             session={session}
-            householdSlug={householdSlug}
             anchorEl={userMenuAnchor}
             open={isUserMenuOpen}
             mode={theme.palette.mode}

--- a/test/layout.test.tsx
+++ b/test/layout.test.tsx
@@ -68,7 +68,6 @@ describe("UserAccountMenuContent", () => {
                   email: "alex.member@example.com",
                 },
               }}
-              householdSlug="home"
               mode="dark"
               onSettingsClick={vi.fn()}
               onToggleColorMode={vi.fn()}
@@ -82,6 +81,7 @@ describe("UserAccountMenuContent", () => {
     expect(html).toContain("Alex Member");
     expect(html).toContain("alex.member@example.com");
     expect(html).toContain("Settings");
+    expect(html).toContain('href="/settings"');
     expect(html).toContain("Light mode");
     expect(html).toContain("Sign out");
   });


### PR DESCRIPTION
## Summary
- change settings from a household-scoped route to a global `/settings` route
- update the account avatar menu to point to `/settings` and stop treating that path as a household slug
- keep household navigation working by using the default household context for layout chrome while on settings

## Verification
- npm run check
- npm run typecheck
- npm run test
- npm run build