### PR TITLE
feat: add owner household settings

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -16,6 +16,7 @@ import {
   useParams,
 } from "react-router-dom";
 import { CreateHouseholdPage } from "./components/CreateHouseholdPage";
+import { HouseholdSettingsView } from "./components/HouseholdSettingsView";
 import { InboxView } from "./components/InboxView";
 import { InvitePage } from "./components/InvitePage";
 import { Layout } from "./components/Layout";
@@ -30,6 +31,9 @@ import type {
   AccountSession,
   AccountSettingsFormState,
   AccountSettingsResponse,
+  HouseholdSettings,
+  HouseholdSettingsFormState,
+  HouseholdSettingsResponse,
   HouseholdSummary,
   InboxMessage,
   InvitationFormState,
@@ -66,6 +70,10 @@ const INITIAL_SETTINGS_FORM_STATE: AccountSettingsFormState = {
   twoFactorCode: "",
   twoFactorBackupCode: "",
   passkeyName: "",
+};
+
+const INITIAL_HOUSEHOLD_SETTINGS_FORM_STATE: HouseholdSettingsFormState = {
+  displayName: "",
 };
 
 const INITIAL_MEMBER_FORM_STATE: MemberFormState = {
@@ -114,7 +122,7 @@ export function App() {
       : null;
 
   const activeView: ViewType =
-    location.pathname === "/settings"
+    location.pathname === "/settings" || location.pathname.endsWith("/settings")
       ? "settings"
       : location.pathname.includes("/quarantine")
         ? "quarantine"
@@ -139,6 +147,14 @@ export function App() {
     useState<AccountSettingsFormState>(INITIAL_SETTINGS_FORM_STATE);
   const [isLoadingSettings, setIsLoadingSettings] = useState(false);
   const [isSavingSettings, setIsSavingSettings] = useState(false);
+  const [householdSettings, setHouseholdSettings] =
+    useState<HouseholdSettings | null>(null);
+  const [householdSettingsFormState, setHouseholdSettingsFormState] =
+    useState<HouseholdSettingsFormState>(INITIAL_HOUSEHOLD_SETTINGS_FORM_STATE);
+  const [isLoadingHouseholdSettings, setIsLoadingHouseholdSettings] =
+    useState(false);
+  const [isSavingHouseholdSettings, setIsSavingHouseholdSettings] =
+    useState(false);
 
   const [selectedMessageId, setSelectedMessageId] = useState<string | null>(
     null,
@@ -332,7 +348,7 @@ export function App() {
   ]);
 
   useEffect(() => {
-    if (!isAuthenticated || activeView !== "settings") {
+    if (!isAuthenticated || location.pathname !== "/settings") {
       return;
     }
 
@@ -373,7 +389,71 @@ export function App() {
     return () => {
       cancelled = true;
     };
-  }, [isAuthenticated, activeView]);
+  }, [isAuthenticated, location.pathname]);
+
+  useEffect(() => {
+    const isHouseholdSettingsRoute = Boolean(
+      currentHousehold &&
+        location.pathname ===
+          buildHouseholdPath(currentHousehold.slug, "/settings"),
+    );
+
+    if (
+      !isAuthenticated ||
+      !currentHousehold ||
+      !isOwner ||
+      !isHouseholdSettingsRoute
+    ) {
+      setHouseholdSettings(null);
+      setHouseholdSettingsFormState(INITIAL_HOUSEHOLD_SETTINGS_FORM_STATE);
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadHouseholdSettings = async () => {
+      setIsLoadingHouseholdSettings(true);
+
+      try {
+        const response = await fetchJson<HouseholdSettingsResponse>(
+          householdApiPath("/admin/settings"),
+        );
+
+        if (cancelled) {
+          return;
+        }
+
+        setHouseholdSettings(response.household);
+        setHouseholdSettingsFormState({
+          displayName: response.household.displayName,
+        });
+      } catch (error) {
+        if (!cancelled) {
+          setViewError(
+            error instanceof Error
+              ? error.message
+              : "Unable to load household settings",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingHouseholdSettings(false);
+        }
+      }
+    };
+
+    void loadHouseholdSettings();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    currentHousehold,
+    householdApiPath,
+    isAuthenticated,
+    isOwner,
+    location.pathname,
+  ]);
 
   async function refreshSettings() {
     if (!isAuthenticated) return;
@@ -594,6 +674,59 @@ export function App() {
       return false;
     } finally {
       setIsSavingSettings(false);
+    }
+  }
+
+  async function refreshHouseholdSettings() {
+    if (!isAuthenticated || !currentHousehold || !isOwner) {
+      return;
+    }
+
+    const response = await fetchJson<HouseholdSettingsResponse>(
+      householdApiPath("/admin/settings"),
+    );
+
+    setHouseholdSettings(response.household);
+    setHouseholdSettingsFormState({
+      displayName: response.household.displayName,
+    });
+    setHouseholds((current) =>
+      current.map((household) =>
+        household.id === currentHousehold.id
+          ? { ...household, displayName: response.household.displayName }
+          : household,
+      ),
+    );
+  }
+
+  async function handleUpdateHouseholdSettings(
+    event: FormEvent<HTMLFormElement>,
+  ) {
+    event.preventDefault();
+    setIsSavingHouseholdSettings(true);
+    setStatusMessage(null);
+    setViewError(null);
+
+    try {
+      await fetchJson<HouseholdSettingsResponse>(
+        householdApiPath("/admin/settings"),
+        {
+          method: "PATCH",
+          body: JSON.stringify({
+            displayName: householdSettingsFormState.displayName,
+          }),
+        },
+      );
+      setStatusMessage("Household name updated.");
+      await refreshHouseholdSettings();
+    } catch (error) {
+      setViewError(
+        error instanceof Error
+          ? error.message
+          : "Unable to update household settings",
+      );
+    } finally {
+      setIsSavingHouseholdSettings(false);
     }
   }
 
@@ -1721,6 +1854,32 @@ export function App() {
               onRevokeOtherSessions={handleRevokeOtherSessions}
               isSaving={isSavingSettings}
             />
+          }
+        />
+        <Route
+          path="/:slug/settings"
+          element={
+            isOwner ? (
+              <HouseholdSettingsView
+                household={householdSettings}
+                isLoading={isLoadingHouseholdSettings}
+                error={viewError}
+                formState={householdSettingsFormState}
+                onFormChange={(update) =>
+                  setHouseholdSettingsFormState((current) => ({
+                    ...current,
+                    ...update,
+                  }))
+                }
+                onSave={handleUpdateHouseholdSettings}
+                isSaving={isSavingHouseholdSettings}
+              />
+            ) : (
+              <Navigate
+                to={buildHouseholdPath(layoutHousehold.slug, "/inbox")}
+                replace
+              />
+            )
           }
         />
         <Route

--- a/src/client/components/HouseholdSettingsView.tsx
+++ b/src/client/components/HouseholdSettingsView.tsx
@@ -1,0 +1,119 @@
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CircularProgress,
+  Container,
+  Divider,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import type { FormEvent } from "react";
+import type { HouseholdSettings, HouseholdSettingsFormState } from "../types";
+
+interface HouseholdSettingsViewProps {
+  household: HouseholdSettings | null;
+  isLoading: boolean;
+  error: string | null;
+  formState: HouseholdSettingsFormState;
+  onFormChange: (update: Partial<HouseholdSettingsFormState>) => void;
+  onSave: (event: FormEvent<HTMLFormElement>) => void;
+  isSaving: boolean;
+}
+
+export function HouseholdSettingsView({
+  household,
+  isLoading,
+  error,
+  formState,
+  onFormChange,
+  onSave,
+  isSaving,
+}: HouseholdSettingsViewProps) {
+  if (isLoading && !household) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (!household) {
+    return (
+      <Alert severity="error">
+        {error || "Unable to load household settings"}
+      </Alert>
+    );
+  }
+
+  return (
+    <Container maxWidth="md" disableGutters>
+      <Box sx={{ mb: 4 }}>
+        <Typography variant="h4" gutterBottom sx={{ fontWeight: "bold" }}>
+          Household Settings
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          Review your household details, rename the household, and see its
+          current plan.
+        </Typography>
+      </Box>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 4 }}>
+          {error}
+        </Alert>
+      )}
+
+      <Card sx={{ borderRadius: 2 }}>
+        <CardHeader title="Household details" />
+        <Divider />
+        <CardContent>
+          <Box component="form" onSubmit={onSave}>
+            <Stack spacing={2}>
+              <TextField
+                fullWidth
+                label="Household slug"
+                value={household.slug}
+                disabled
+              />
+              <TextField
+                fullWidth
+                label="Household email address"
+                value={household.emailAddress}
+                disabled
+              />
+              <TextField
+                fullWidth
+                label="Household name"
+                value={formState.displayName}
+                onChange={(event) =>
+                  onFormChange({ displayName: event.target.value })
+                }
+                required
+              />
+              <TextField
+                fullWidth
+                label="Subscription plan"
+                value={household.subscriptionPlan}
+                disabled
+              />
+              <Box>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  disabled={isSaving || !formState.displayName.trim()}
+                >
+                  Save Household Name
+                </Button>
+              </Box>
+            </Stack>
+          </Box>
+        </CardContent>
+      </Card>
+    </Container>
+  );
+}

--- a/src/client/components/Layout.tsx
+++ b/src/client/components/Layout.tsx
@@ -290,6 +290,34 @@ export function Layout({
           <>
             <ListItem disablePadding sx={{ mb: 1 }}>
               <ListItemButton
+                selected={activeView === "settings"}
+                component={Link}
+                to={buildHouseholdPath(householdSlug, "/settings")}
+                onClick={handleNavClick}
+                sx={{ borderRadius: 2 }}
+              >
+                <ListItemIcon>
+                  <ManageAccountsIcon
+                    color={activeView === "settings" ? "primary" : "inherit"}
+                  />
+                </ListItemIcon>
+                <ListItemText
+                  primary={
+                    <Typography
+                      sx={{
+                        fontWeight:
+                          activeView === "settings" ? "bold" : "normal",
+                      }}
+                    >
+                      Household settings
+                    </Typography>
+                  }
+                />
+              </ListItemButton>
+            </ListItem>
+
+            <ListItem disablePadding sx={{ mb: 1 }}>
+              <ListItemButton
                 selected={activeView === "quarantine"}
                 component={Link}
                 to={buildHouseholdPath(householdSlug, "/quarantine")}
@@ -316,7 +344,7 @@ export function Layout({
               </ListItemButton>
             </ListItem>
 
-            <ListItem disablePadding>
+            <ListItem disablePadding sx={{ mb: 1 }}>
               <ListItemButton
                 selected={activeView === "members"}
                 component={Link}
@@ -344,7 +372,7 @@ export function Layout({
               </ListItemButton>
             </ListItem>
 
-            <ListItem disablePadding sx={{ mt: 1 }}>
+            <ListItem disablePadding>
               <ListItemButton
                 selected={activeView === "providers"}
                 component={Link}

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -170,6 +170,21 @@ export type AccountSettingsFormState = {
   passkeyName: string;
 };
 
+export type HouseholdSettings = {
+  slug: string;
+  emailAddress: string;
+  displayName: string;
+  subscriptionPlan: string;
+};
+
+export type HouseholdSettingsResponse = {
+  household: HouseholdSettings;
+};
+
+export type HouseholdSettingsFormState = {
+  displayName: string;
+};
+
 export type InvitationAcceptanceState = {
   name: string;
   password: string;

--- a/src/server/db/repositories/households.ts
+++ b/src/server/db/repositories/households.ts
@@ -17,6 +17,14 @@ export type HouseholdSummary = {
   role: HouseholdMembershipRole;
 };
 
+export type HouseholdSettings = {
+  id: string;
+  slug: string;
+  displayName: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
 export async function listHouseholdsForUser(
   db: D1Database,
   userId: string,
@@ -92,6 +100,25 @@ export async function getHouseholdById(db: D1Database, id: string) {
   return rows[0] ?? null;
 }
 
+export async function getHouseholdSettings(
+  db: D1Database,
+  householdId: string,
+): Promise<HouseholdSettings | null> {
+  const rows = await dbForDatabase(db)
+    .select({
+      id: households.id,
+      slug: households.slug,
+      displayName: households.displayName,
+      createdAt: households.createdAt,
+      updatedAt: households.updatedAt,
+    })
+    .from(households)
+    .where(eq(households.id, householdId))
+    .limit(1);
+
+  return rows[0] ?? null;
+}
+
 export async function createHousehold(
   db: D1Database,
   input: {
@@ -122,6 +149,22 @@ export async function createHousehold(
   });
 
   return getHouseholdBySlug(db, input.slug);
+}
+
+export async function updateHouseholdDisplayName(
+  db: D1Database,
+  householdId: string,
+  displayName: string,
+) {
+  await dbForDatabase(db)
+    .update(households)
+    .set({
+      displayName,
+      updatedAt: sql`CURRENT_TIMESTAMP`,
+    })
+    .where(eq(households.id, householdId));
+
+  return getHouseholdSettings(db, householdId);
 }
 
 export async function addUserToHousehold(

--- a/src/server/routes/admin.ts
+++ b/src/server/routes/admin.ts
@@ -8,6 +8,8 @@ import {
 import {
   assertProvidersBelongToHousehold,
   getHouseholdMembership,
+  getHouseholdSettings,
+  updateHouseholdDisplayName,
   updateHouseholdMembershipRole,
 } from "../db/repositories/households";
 import {
@@ -69,6 +71,10 @@ type InvitationPayload = {
   providerIds?: string[];
 };
 
+type HouseholdSettingsPayload = {
+  displayName?: string;
+};
+
 export const adminRoutes = new Hono<{
   Bindings: Env;
   Variables: AppVariables;
@@ -104,6 +110,70 @@ function isValidMatchType(
 
 adminRoutes.use("/:slug/*", requireHouseholdContext);
 adminRoutes.use("/:slug/*", requireOwner);
+
+adminRoutes.get("/:slug/settings", async (c) => {
+  const household = c.get("household");
+
+  if (!household) {
+    return c.json({ error: "Forbidden" }, 403);
+  }
+
+  const settings = await getHouseholdSettings(c.env.DB, household.id);
+
+  if (!settings) {
+    return c.json({ error: "Household not found" }, 404);
+  }
+
+  return c.json({
+    household: {
+      slug: settings.slug,
+      emailAddress: `${settings.slug}@DOMAIN`,
+      displayName: settings.displayName,
+      subscriptionPlan: "Free Plan",
+    },
+  });
+});
+
+adminRoutes.patch("/:slug/settings", async (c) => {
+  const household = c.get("household");
+
+  if (!household) {
+    return c.json({ error: "Forbidden" }, 403);
+  }
+
+  let payload: HouseholdSettingsPayload;
+
+  try {
+    payload = await c.req.json<HouseholdSettingsPayload>();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+
+  const displayName = normalizeDisplayName(payload.displayName);
+
+  if (!displayName) {
+    return c.json({ error: "displayName is required" }, 400);
+  }
+
+  const settings = await updateHouseholdDisplayName(
+    c.env.DB,
+    household.id,
+    displayName,
+  );
+
+  if (!settings) {
+    return c.json({ error: "Household not found" }, 404);
+  }
+
+  return c.json({
+    household: {
+      slug: settings.slug,
+      emailAddress: `${settings.slug}@DOMAIN`,
+      displayName: settings.displayName,
+      subscriptionPlan: "Free Plan",
+    },
+  });
+});
 
 adminRoutes.get("/:slug/providers", async (c) => {
   const household = c.get("household");

--- a/test/household-settings-view.test.tsx
+++ b/test/household-settings-view.test.tsx
@@ -1,0 +1,38 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { HouseholdSettingsView } from "../src/client/components/HouseholdSettingsView";
+
+describe("HouseholdSettingsView", () => {
+  it("renders readonly slug, email, plan, and editable household name", () => {
+    const html = renderToStaticMarkup(
+      <HouseholdSettingsView
+        household={{
+          slug: "home",
+          emailAddress: "home@DOMAIN",
+          displayName: "Home",
+          subscriptionPlan: "Free Plan",
+        }}
+        isLoading={false}
+        error={null}
+        formState={{
+          displayName: "Home",
+        }}
+        onFormChange={vi.fn()}
+        onSave={vi.fn()}
+        isSaving={false}
+      />,
+    );
+
+    expect(html).toContain("Household Settings");
+    expect(html).toContain("Household details");
+    expect(html).toContain("Household slug");
+    expect(html).toContain("home");
+    expect(html).toContain("Household email address");
+    expect(html).toContain("home@DOMAIN");
+    expect(html).toContain("Household name");
+    expect(html).toContain("Subscription plan");
+    expect(html).toContain("Free Plan");
+    expect(html).toContain("Save Household Name");
+  });
+});

--- a/test/inbox-routes.test.ts
+++ b/test/inbox-routes.test.ts
@@ -315,6 +315,42 @@ vi.mock("../src/server/db/repositories/households", async () => {
     },
     getHouseholdById: async (_db: D1Database, id: string) =>
       getHouseholdByIdValue(id),
+    getHouseholdSettings: async (_db: D1Database, householdId: string) => {
+      const household = getHouseholdByIdValue(householdId);
+
+      if (!household) {
+        return null;
+      }
+
+      return {
+        id: household.id,
+        slug: household.slug,
+        displayName: household.displayName,
+        createdAt: "2026-05-10T12:00:00.000Z",
+        updatedAt: "2026-05-10T12:00:00.000Z",
+      };
+    },
+    updateHouseholdDisplayName: async (
+      _db: D1Database,
+      householdId: string,
+      displayName: string,
+    ) => {
+      const household = getHouseholdByIdValue(householdId);
+
+      if (!household) {
+        return null;
+      }
+
+      household.displayName = displayName;
+
+      return {
+        id: household.id,
+        slug: household.slug,
+        displayName: household.displayName,
+        createdAt: "2026-05-10T12:00:00.000Z",
+        updatedAt: "2026-05-10T12:00:00.000Z",
+      };
+    },
     assertProvidersBelongToHousehold: async (
       _db: D1Database,
       householdId: string,
@@ -1108,6 +1144,52 @@ describe("worker routes", () => {
     });
   });
 
+  it("allows an owner to read household settings for their household", async () => {
+    sessionState.current = {
+      user: { id: "owner-home", email: "owner@example.com", role: "user" },
+      session: { id: "session-1", userId: "owner-home" },
+    };
+
+    const response = await invokeWorker("/api/admin/home/settings");
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      household: {
+        slug: "home",
+        emailAddress: "home@DOMAIN",
+        displayName: "Home",
+        subscriptionPlan: "Free Plan",
+      },
+    });
+  });
+
+  it("allows an owner to update their household display name", async () => {
+    sessionState.current = {
+      user: { id: "owner-home", email: "owner@example.com", role: "user" },
+      session: { id: "session-1", userId: "owner-home" },
+    };
+
+    const response = await invokeWorker("/api/admin/home/settings", {
+      method: "PATCH",
+      body: JSON.stringify({ displayName: "Renamed Home" }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      household: {
+        slug: "home",
+        emailAddress: "home@DOMAIN",
+        displayName: "Renamed Home",
+        subscriptionPlan: "Free Plan",
+      },
+    });
+    expect(
+      repoState.households.find(
+        (household) => household.id === "household-home",
+      ),
+    ).toMatchObject({ displayName: "Renamed Home" });
+  });
+
   it("denies admin routes to members in the same household", async () => {
     sessionState.current = {
       user: { id: "member-home", email: "member@example.com", role: "user" },
@@ -1118,6 +1200,35 @@ describe("worker routes", () => {
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({ error: "Forbidden" });
+  });
+
+  it("denies household settings routes to members in the same household", async () => {
+    sessionState.current = {
+      user: { id: "member-home", email: "member@example.com", role: "user" },
+      session: { id: "session-1", userId: "member-home" },
+    };
+
+    const response = await invokeWorker("/api/admin/home/settings");
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "Forbidden" });
+  });
+
+  it("rejects blank household display names", async () => {
+    sessionState.current = {
+      user: { id: "owner-home", email: "owner@example.com", role: "user" },
+      session: { id: "session-1", userId: "owner-home" },
+    };
+
+    const response = await invokeWorker("/api/admin/home/settings", {
+      method: "PATCH",
+      body: JSON.stringify({ displayName: "   " }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "displayName is required",
+    });
   });
 
   it("denies admin routes across household boundaries even for another owner", async () => {

--- a/test/layout.test.tsx
+++ b/test/layout.test.tsx
@@ -11,7 +11,7 @@ import { ColorModeContext, getTheme } from "../src/client/theme";
 import { getUserInitials } from "../src/client/utils";
 
 describe("Layout", () => {
-  it("keeps settings out of the sidebar and shows avatar initials fallback", () => {
+  it("shows owner household settings in the sidebar and keeps account settings in the menu", () => {
     const html = renderToStaticMarkup(
       <MemoryRouter initialEntries={["/home/inbox"]}>
         <ColorModeContext.Provider value={{ toggleColorMode: vi.fn() }}>
@@ -47,11 +47,50 @@ describe("Layout", () => {
     );
 
     expect(html).toContain("Inbox");
+    expect(html).toContain("Household settings");
     expect(html).toContain("Quarantine");
     expect(html).toContain("Members");
     expect(html).toContain("Providers &amp; rules");
-    expect(html).not.toContain(">Settings<");
+    expect(html).not.toContain('href="/settings"');
     expect(html).toContain("AM");
+  });
+
+  it("hides household settings from members", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter initialEntries={["/home/inbox"]}>
+        <ColorModeContext.Provider value={{ toggleColorMode: vi.fn() }}>
+          <ThemeProvider theme={getTheme("light")}>
+            <CssBaseline />
+            <Layout
+              session={{
+                user: {
+                  email: "alex.member@example.com",
+                },
+              }}
+              households={[
+                {
+                  id: "household-1",
+                  slug: "home",
+                  displayName: "Home",
+                  role: "member",
+                },
+              ]}
+              isOwner={false}
+              householdSlug="home"
+              householdName="Home"
+              householdRole="member"
+              onSelectHousehold={vi.fn()}
+              onCreateHousehold={vi.fn()}
+              onLogout={vi.fn()}
+            >
+              <div>Inbox content</div>
+            </Layout>
+          </ThemeProvider>
+        </ColorModeContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(html).not.toContain("Household settings");
   });
 });
 


### PR DESCRIPTION
## Summary
- add owner-only household settings at `/:slug/settings` with readonly slug, derived email, hardcoded plan, and editable household name
- add server support for reading and updating household settings under `/api/admin/:slug/settings`
- add route, layout, and component tests for owner access, member denial, and household settings rendering

## Verification
- `npm run check`
- `npm run typecheck`
- `npm run test`
- `npm run build`