### PR TITLE
fix household settings sidebar state

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -56,6 +56,26 @@ import {
 
 type ViewType = "inbox" | "quarantine" | "members" | "providers" | "settings";
 
+function getActiveView(pathname: string): ViewType {
+  if (pathname === "/settings" || pathname.endsWith("/settings")) {
+    return "settings";
+  }
+
+  if (pathname.includes("/quarantine")) {
+    return "quarantine";
+  }
+
+  if (pathname.includes("/members")) {
+    return "members";
+  }
+
+  if (pathname.includes("/providers")) {
+    return "providers";
+  }
+
+  return "inbox";
+}
+
 const INITIAL_SETTINGS_FORM_STATE: AccountSettingsFormState = {
   name: "",
   image: "",
@@ -108,19 +128,12 @@ export function App() {
   const location = useLocation();
   const routeSegments = location.pathname.split("/").filter(Boolean);
   const routeSlug =
-    routeSegments[0] && !["login", "setup", "invite"].includes(routeSegments[0])
+    routeSegments[0] &&
+    !["login", "setup", "invite", "settings"].includes(routeSegments[0])
       ? routeSegments[0]
       : null;
 
-  const activeView: ViewType = location.pathname.includes("/settings")
-    ? "settings"
-    : location.pathname.includes("/quarantine")
-      ? "quarantine"
-      : location.pathname.includes("/members")
-        ? "members"
-        : location.pathname.includes("/providers")
-          ? "providers"
-          : "inbox";
+  const activeView = getActiveView(location.pathname);
   const [households, setHouseholds] = useState<HouseholdSummary[]>([]);
   const [isLoadingHouseholds, setIsLoadingHouseholds] = useState(false);
   const [providers, setProviders] = useState<ProviderSummary[]>([]);
@@ -301,6 +314,10 @@ export function App() {
       return;
     }
 
+    if (activeView === "settings") {
+      return;
+    }
+
     if (!routeSlug || !currentHousehold) {
       navigate(
         buildHouseholdPath(
@@ -320,6 +337,7 @@ export function App() {
     isLoadingHouseholds,
     navigate,
     routeSlug,
+    activeView,
   ]);
 
   useEffect(() => {

--- a/src/client/components/Layout.tsx
+++ b/src/client/components/Layout.tsx
@@ -16,6 +16,7 @@ import {
   Avatar,
   Box,
   ButtonBase,
+  Chip,
   Divider,
   Drawer,
   IconButton,
@@ -53,10 +54,34 @@ interface LayoutProps {
   onLogout: () => void;
 }
 
+function getActiveView(pathname: string) {
+  if (pathname === "/settings" || pathname.endsWith("/settings")) {
+    return "settings";
+  }
+
+  if (pathname.includes("/quarantine")) {
+    return "quarantine";
+  }
+
+  if (pathname.includes("/members")) {
+    return "members";
+  }
+
+  if (pathname.includes("/providers")) {
+    return "providers";
+  }
+
+  return "inbox";
+}
+
+export function isSettingsPath(pathname: string) {
+  return getActiveView(pathname) === "settings";
+}
+
 interface UserAccountMenuProps {
   session: SessionData | null | undefined;
-  householdSlug: string;
   mode: "light" | "dark";
+  settingsPath: string;
   onSettingsClick: () => void;
   onToggleColorMode: () => void;
   onLogout: () => void;
@@ -64,8 +89,8 @@ interface UserAccountMenuProps {
 
 export function UserAccountMenuContent({
   session,
-  householdSlug,
   mode,
+  settingsPath,
   onSettingsClick,
   onToggleColorMode,
   onLogout,
@@ -83,7 +108,7 @@ export function UserAccountMenuContent({
       <Divider />
       <MenuItem
         component={Link}
-        to={buildHouseholdPath(householdSlug, "/settings")}
+        to={settingsPath}
         onClick={onSettingsClick}
         sx={{ py: 1.25 }}
       >
@@ -173,15 +198,7 @@ export function Layout({
   onLogout,
 }: LayoutProps) {
   const location = useLocation();
-  const activeView = location.pathname.includes("/settings")
-    ? "settings"
-    : location.pathname.includes("/quarantine")
-      ? "quarantine"
-      : location.pathname.includes("/members")
-        ? "members"
-        : location.pathname.includes("/providers")
-          ? "providers"
-          : "inbox";
+  const activeView = getActiveView(location.pathname);
   const theme = useTheme();
   const colorMode = useContext(ColorModeContext);
   const isDesktop = useMediaQuery(theme.breakpoints.up("lg"));
@@ -195,6 +212,7 @@ export function Layout({
   const activeHousehold =
     households.find((household) => household.slug === householdSlug) ?? null;
   const roleLabel = householdRole === "owner" ? "Owner" : "Member";
+  const settingsPath = buildHouseholdPath(householdSlug, "/settings");
   const isHouseholdMenuOpen = Boolean(householdMenuAnchor);
   const isUserMenuOpen = Boolean(userMenuAnchor);
 
@@ -394,14 +412,13 @@ export function Layout({
         >
           <Box sx={{ minWidth: 0, pr: 2 }}>
             <Typography variant="body2" sx={{ fontWeight: 700 }} noWrap>
-              {getDisplayName(session)}
-            </Typography>
-            <Typography variant="body2" color="text.secondary" noWrap>
               {householdName}
             </Typography>
-            <Typography variant="caption" color="text.secondary" noWrap>
-              {roleLabel}
-            </Typography>
+            <Chip
+              label={roleLabel}
+              size="small"
+              sx={{ mt: 0.75, fontWeight: 600, maxWidth: "100%" }}
+            />
           </Box>
           <ExpandMore color="action" />
         </ButtonBase>
@@ -516,10 +533,10 @@ export function Layout({
           </IconButton>
           <UserAccountMenu
             session={session}
-            householdSlug={householdSlug}
             anchorEl={userMenuAnchor}
             open={isUserMenuOpen}
             mode={theme.palette.mode}
+            settingsPath={settingsPath}
             onClose={handleCloseUserMenu}
             onToggleColorMode={handleToggleColorMode}
             onLogout={handleLogoutClick}

--- a/test/layout.test.tsx
+++ b/test/layout.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  isSettingsPath,
   Layout,
   UserAccountMenuContent,
 } from "../src/client/components/Layout";
@@ -51,7 +52,50 @@ describe("Layout", () => {
     expect(html).toContain("Members");
     expect(html).toContain("Providers &amp; rules");
     expect(html).not.toContain(">Settings<");
+    expect(html).toContain("Home");
+    expect(html).toContain("Owner");
     expect(html).toContain("AM");
+  });
+
+  it("treats household settings paths as settings views", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter initialEntries={["/home/settings"]}>
+        <ColorModeContext.Provider value={{ toggleColorMode: vi.fn() }}>
+          <ThemeProvider theme={getTheme("light")}>
+            <CssBaseline />
+            <Layout
+              session={{
+                user: {
+                  email: "alex.member@example.com",
+                },
+              }}
+              households={[
+                {
+                  id: "household-1",
+                  slug: "home",
+                  displayName: "Home",
+                  role: "owner",
+                },
+              ]}
+              isOwner={true}
+              householdSlug="home"
+              householdName="Home"
+              householdRole="owner"
+              onSelectHousehold={vi.fn()}
+              onCreateHousehold={vi.fn()}
+              onLogout={vi.fn()}
+            >
+              <div>Settings content</div>
+            </Layout>
+          </ThemeProvider>
+        </ColorModeContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(html).toContain('href="/home/inbox"');
+    expect(isSettingsPath("/home/settings")).toBe(true);
+    expect(isSettingsPath("/settings")).toBe(true);
+    expect(isSettingsPath("/home/inbox")).toBe(false);
   });
 });
 
@@ -68,8 +112,8 @@ describe("UserAccountMenuContent", () => {
                   email: "alex.member@example.com",
                 },
               }}
-              householdSlug="home"
               mode="dark"
+              settingsPath="/home/settings"
               onSettingsClick={vi.fn()}
               onToggleColorMode={vi.fn()}
               onLogout={vi.fn()}
@@ -82,6 +126,7 @@ describe("UserAccountMenuContent", () => {
     expect(html).toContain("Alex Member");
     expect(html).toContain("alex.member@example.com");
     expect(html).toContain("Settings");
+    expect(html).toContain('href="/home/settings"');
     expect(html).toContain("Light mode");
     expect(html).toContain("Sign out");
   });


### PR DESCRIPTION
## Summary
- fix household-scoped settings route detection so `/household/settings` no longer highlights inbox in the sidebar
- keep settings navigation household-scoped and avoid redirecting settings views back to inbox
- change the household switcher summary to two lines with household name and a role label

## Verification
- `npm test -- layout.test.tsx`
- `rtk npm run check`
- `rtk npm run typecheck`