### PR TITLE
feat: refine public entry and household flows

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -60,6 +60,26 @@ import {
 
 type ViewType = "inbox" | "quarantine" | "members" | "providers" | "settings";
 
+function getActiveView(pathname: string): ViewType {
+  if (pathname === "/settings" || pathname.endsWith("/settings")) {
+    return "settings";
+  }
+
+  if (pathname.includes("/quarantine")) {
+    return "quarantine";
+  }
+
+  if (pathname.includes("/members")) {
+    return "members";
+  }
+
+  if (pathname.includes("/providers")) {
+    return "providers";
+  }
+
+  return "inbox";
+}
+
 const INITIAL_SETTINGS_FORM_STATE: AccountSettingsFormState = {
   name: "",
   image: "",
@@ -121,16 +141,7 @@ export function App() {
       ? routeSegments[0]
       : null;
 
-  const activeView: ViewType =
-    location.pathname === "/settings" || location.pathname.endsWith("/settings")
-      ? "settings"
-      : location.pathname.includes("/quarantine")
-        ? "quarantine"
-        : location.pathname.includes("/members")
-          ? "members"
-          : location.pathname.includes("/providers")
-            ? "providers"
-            : "inbox";
+  const activeView = getActiveView(location.pathname);
   const [households, setHouseholds] = useState<HouseholdSummary[]>([]);
   const [isLoadingHouseholds, setIsLoadingHouseholds] = useState(false);
   const [providers, setProviders] = useState<ProviderSummary[]>([]);
@@ -217,7 +228,7 @@ export function App() {
     (household: HouseholdSummary) => {
       switch (activeView) {
         case "settings":
-          return buildHouseholdPath(household.slug, "/inbox");
+          return buildHouseholdPath(household.slug, "/settings");
         case "quarantine":
           return buildHouseholdPath(
             household.slug,
@@ -348,7 +359,7 @@ export function App() {
   ]);
 
   useEffect(() => {
-    if (!isAuthenticated || location.pathname !== "/settings") {
+    if (!isAuthenticated || activeView !== "settings") {
       return;
     }
 
@@ -389,7 +400,7 @@ export function App() {
     return () => {
       cancelled = true;
     };
-  }, [isAuthenticated, location.pathname]);
+  }, [activeView, isAuthenticated]);
 
   useEffect(() => {
     const isHouseholdSettingsRoute = Boolean(

--- a/src/client/components/CreateHouseholdPage.tsx
+++ b/src/client/components/CreateHouseholdPage.tsx
@@ -1,16 +1,8 @@
-import {
-  Alert,
-  Box,
-  Button,
-  Card,
-  CardContent,
-  Container,
-  TextField,
-  Typography,
-} from "@mui/material";
+import { Alert, Box, Button, TextField } from "@mui/material";
 import { type FormEvent, useState } from "react";
 import type { CreateHouseholdFormState, HouseholdSummary } from "../types";
 import { fetchJson } from "../utils";
+import { PublicEntryShell } from "./PublicEntryShell";
 
 interface CreateHouseholdPageProps {
   onCreated: (household: HouseholdSummary) => void;
@@ -51,92 +43,62 @@ export function CreateHouseholdPage({ onCreated }: CreateHouseholdPageProps) {
   }
 
   return (
-    <Container component="main" maxWidth="sm">
-      <Box
-        sx={{
-          minHeight: "100vh",
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "center",
-          py: 4,
-        }}
-      >
-        <Card elevation={3} sx={{ borderRadius: 3 }}>
-          <CardContent sx={{ p: 4 }}>
-            <Typography
-              variant="overline"
-              color="text.secondary"
-              sx={{ fontWeight: "bold", letterSpacing: 1 }}
-            >
-              Create your household
-            </Typography>
-            <Typography
-              variant="h4"
-              component="h1"
-              gutterBottom
-              sx={{ mt: 1, fontWeight: "bold" }}
-            >
-              You need a household to continue.
-            </Typography>
-            <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
-              Pick the household name your members will see and the immutable
-              slug used in URLs and inbound email addresses.
-            </Typography>
+    <PublicEntryShell
+      eyebrow="Create your household"
+      title="You need a household to continue."
+      description="Pick the household name your members will see and the immutable slug used in URLs and inbound email addresses."
+    >
+      <Box component="form" onSubmit={handleSubmit} noValidate>
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          label="Household name"
+          value={formState.displayName}
+          onChange={(e) =>
+            setFormState((current) => ({
+              ...current,
+              displayName: e.target.value,
+            }))
+          }
+        />
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          label="Household slug"
+          helperText="Lowercase letters, numbers, and hyphens only. This cannot be changed later."
+          value={formState.slug}
+          onChange={(e) =>
+            setFormState((current) => ({
+              ...current,
+              slug: e.target.value.toLowerCase(),
+            }))
+          }
+          sx={{ mb: 3 }}
+        />
 
-            <Box component="form" onSubmit={handleSubmit} noValidate>
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                label="Household name"
-                value={formState.displayName}
-                onChange={(e) =>
-                  setFormState((current) => ({
-                    ...current,
-                    displayName: e.target.value,
-                  }))
-                }
-              />
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                label="Household slug"
-                helperText="Lowercase letters, numbers, and hyphens only. This cannot be changed later."
-                value={formState.slug}
-                onChange={(e) =>
-                  setFormState((current) => ({
-                    ...current,
-                    slug: e.target.value.toLowerCase(),
-                  }))
-                }
-                sx={{ mb: 3 }}
-              />
+        {error && (
+          <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
+            {error}
+          </Alert>
+        )}
 
-              {error && (
-                <Alert severity="error" sx={{ mb: 3 }}>
-                  {error}
-                </Alert>
-              )}
-
-              <Button
-                type="submit"
-                fullWidth
-                variant="contained"
-                size="large"
-                disabled={
-                  isCreating ||
-                  !formState.displayName.trim() ||
-                  !formState.slug.trim()
-                }
-                sx={{ py: 1.5 }}
-              >
-                {isCreating ? "Creating household…" : "Create household"}
-              </Button>
-            </Box>
-          </CardContent>
-        </Card>
+        <Button
+          type="submit"
+          fullWidth
+          variant="contained"
+          size="large"
+          disabled={
+            isCreating ||
+            !formState.displayName.trim() ||
+            !formState.slug.trim()
+          }
+          sx={{ py: 1.5 }}
+        >
+          {isCreating ? "Creating household…" : "Create household"}
+        </Button>
       </Box>
-    </Container>
+    </PublicEntryShell>
   );
 }

--- a/src/client/components/InboxView.tsx
+++ b/src/client/components/InboxView.tsx
@@ -122,13 +122,13 @@ export function InboxView({
     <Box
       sx={{
         display: "flex",
-        flexDirection: { xs: "column", md: "row" },
+        flexDirection: { xs: "column", lg: "row" },
         gap: 3,
         height: "100%",
       }}
     >
       {/* Providers Column */}
-      <Box sx={{ width: { xs: "100%", md: 320 }, flexShrink: 0 }}>
+      <Box sx={{ width: { xs: "100%", lg: 320 }, flexShrink: 0, minWidth: 0 }}>
         <Typography
           variant="overline"
           color="text.secondary"
@@ -171,6 +171,7 @@ export function InboxView({
                               alignItems: "center",
                               gap: 2,
                               mb: 0.5,
+                              minWidth: 0,
                             }}
                           >
                             <Badge
@@ -200,6 +201,10 @@ export function InboxView({
                                 color: isSelected
                                   ? "primary.main"
                                   : "text.primary",
+                                minWidth: 0,
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                                whiteSpace: "nowrap",
                               }}
                             >
                               {provider.display_name}
@@ -211,6 +216,8 @@ export function InboxView({
                             sx={{
                               display: "flex",
                               justifyContent: "space-between",
+                              gap: 1,
+                              flexWrap: "wrap",
                               color: "text.secondary",
                             }}
                           >
@@ -252,7 +259,7 @@ export function InboxView({
       </Box>
 
       {/* Messages Column */}
-      <Box sx={{ width: { xs: "100%", md: 360 }, flexShrink: 0 }}>
+      <Box sx={{ width: { xs: "100%", lg: 360 }, flexShrink: 0, minWidth: 0 }}>
         <Typography
           variant="overline"
           color="text.secondary"
@@ -272,7 +279,11 @@ export function InboxView({
             {selectedProvider?.display_name ?? "Choose a provider"}
           </Typography>
           {selectedProvider && (
-            <Typography variant="body2" color="text.secondary">
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ flexShrink: 0 }}
+            >
               {messages.length} messages
             </Typography>
           )}
@@ -298,17 +309,21 @@ export function InboxView({
                             sx={{
                               display: "flex",
                               justifyContent: "space-between",
+                              alignItems: "flex-start",
+                              gap: 1,
                               mb: 0.5,
                             }}
                           >
                             <Typography
                               variant="subtitle2"
                               sx={{
+                                flex: 1,
+                                minWidth: 0,
                                 fontWeight: isSelected ? "bold" : "medium",
                                 overflow: "hidden",
                                 textOverflow: "ellipsis",
                                 whiteSpace: "nowrap",
-                                pr: 1,
+                                pr: 0.5,
                               }}
                             >
                               {message.subject ?? "Untitled message"}
@@ -403,9 +418,11 @@ export function InboxView({
                 display: "flex",
                 justifyContent: "space-between",
                 alignItems: "flex-start",
+                flexDirection: { xs: "column", sm: "row" },
+                gap: 1.5,
               }}
             >
-              <Box>
+              <Box sx={{ minWidth: 0 }}>
                 <Typography variant="h5" sx={{ fontWeight: "bold", mb: 0.5 }}>
                   {selectedMessage.subject ?? "Untitled message"}
                 </Typography>
@@ -416,6 +433,7 @@ export function InboxView({
               <Chip
                 label={selectedMessage.status}
                 color={getStatusColor(selectedMessage.status)}
+                size="small"
                 sx={{ textTransform: "capitalize", fontWeight: "bold" }}
               />
             </Box>
@@ -447,6 +465,7 @@ export function InboxView({
                 <Box
                   sx={{
                     display: "flex",
+                    flexDirection: { xs: "column", sm: "row" },
                     alignItems: "center",
                     justifyContent: "center",
                     gap: 2,
@@ -454,7 +473,12 @@ export function InboxView({
                 >
                   <Typography
                     variant="h3"
-                    sx={{ fontWeight: "bold", letterSpacing: 2 }}
+                    sx={{
+                      fontWeight: "bold",
+                      letterSpacing: { xs: 1, sm: 2 },
+                      fontSize: { xs: "2rem", sm: undefined },
+                      wordBreak: "break-word",
+                    }}
                   >
                     {selectedMessage.extracted_code ?? "No code detected"}
                   </Typography>

--- a/src/client/components/InvitePage.tsx
+++ b/src/client/components/InvitePage.tsx
@@ -2,10 +2,7 @@ import {
   Alert,
   Box,
   Button,
-  Card,
-  CardContent,
   CircularProgress,
-  Container,
   TextField,
   Typography,
 } from "@mui/material";
@@ -13,6 +10,7 @@ import { type FormEvent, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type { InvitationAcceptanceState, InvitationSummary } from "../types";
 import { fetchJson } from "../utils";
+import { PublicEntryShell } from "./PublicEntryShell";
 
 interface InvitePageProps {
   token: string;
@@ -121,34 +119,24 @@ export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
 
   if (error && !invitation) {
     return (
-      <Container component="main" maxWidth="sm">
-        <Box
-          sx={{
-            minHeight: "100vh",
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "center",
-            py: 4,
+      <PublicEntryShell
+        eyebrow="Mi Casa Su Casa"
+        title="This invitation is not available."
+        description="The invite may have expired, already been accepted, or the link may be invalid."
+      >
+        <Alert severity="error" sx={{ mb: 2, borderRadius: 2 }}>
+          {error}
+        </Alert>
+        <Button
+          variant="outlined"
+          fullWidth
+          onClick={() => {
+            navigate("/login", { replace: true });
           }}
         >
-          <Card elevation={3} sx={{ borderRadius: 3 }}>
-            <CardContent sx={{ p: 4 }}>
-              <Alert severity="error" sx={{ mb: 2 }}>
-                {error}
-              </Alert>
-              <Button
-                variant="outlined"
-                fullWidth
-                onClick={() => {
-                  navigate("/login", { replace: true });
-                }}
-              >
-                Return to Login
-              </Button>
-            </CardContent>
-          </Card>
-        </Box>
-      </Container>
+          Return to Login
+        </Button>
+      </PublicEntryShell>
     );
   }
 
@@ -157,109 +145,81 @@ export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
   }
 
   return (
-    <Container component="main" maxWidth="sm">
-      <Box
-        sx={{
-          minHeight: "100vh",
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "center",
-          py: 4,
-        }}
-      >
-        <Card elevation={3} sx={{ borderRadius: 3 }}>
-          <CardContent sx={{ p: 4 }}>
-            <Typography
-              variant="overline"
-              color="text.secondary"
-              sx={{ fontWeight: "bold", letterSpacing: 1 }}
-            >
-              Mi Casa Su Casa
-            </Typography>
-            <Typography
-              variant="h4"
-              component="h1"
-              gutterBottom
-              sx={{ mt: 1, fontWeight: "bold" }}
-            >
-              Accept Invitation
-            </Typography>
-            <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
-              You have been invited to join as a{" "}
-              <strong>{invitation.role}</strong>. Please set up your account
-              details to continue.
-            </Typography>
+    <PublicEntryShell
+      eyebrow="Mi Casa Su Casa"
+      title="Accept invitation"
+      description={
+        <>
+          You have been invited to join as a <strong>{invitation.role}</strong>.
+          Set up your account details to continue.
+        </>
+      }
+    >
+      <Box component="form" onSubmit={handleAccept} noValidate>
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          label="Email Address"
+          value={invitation.email}
+          disabled
+        />
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          id="name"
+          label="Your Name"
+          name="name"
+          autoComplete="name"
+          autoFocus
+          value={formState.name}
+          onChange={(e) =>
+            setFormState((current) => ({
+              ...current,
+              name: e.target.value,
+            }))
+          }
+        />
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          name="password"
+          label="Password"
+          type="password"
+          id="password"
+          autoComplete="new-password"
+          helperText="Must be at least 12 characters."
+          value={formState.password}
+          onChange={(e) =>
+            setFormState((current) => ({
+              ...current,
+              password: e.target.value,
+            }))
+          }
+          sx={{ mb: 3 }}
+        />
 
-            <Box component="form" onSubmit={handleAccept} noValidate>
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                label="Email Address"
-                value={invitation.email}
-                disabled
-              />
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                id="name"
-                label="Your Name"
-                name="name"
-                autoComplete="name"
-                autoFocus
-                value={formState.name}
-                onChange={(e) =>
-                  setFormState((current) => ({
-                    ...current,
-                    name: e.target.value,
-                  }))
-                }
-              />
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                name="password"
-                label="Password"
-                type="password"
-                id="password"
-                autoComplete="new-password"
-                helperText="Must be at least 12 characters."
-                value={formState.password}
-                onChange={(e) =>
-                  setFormState((current) => ({
-                    ...current,
-                    password: e.target.value,
-                  }))
-                }
-                sx={{ mb: 3 }}
-              />
+        {error && (
+          <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
+            {error}
+          </Alert>
+        )}
 
-              {error && (
-                <Alert severity="error" sx={{ mb: 3 }}>
-                  {error}
-                </Alert>
-              )}
-
-              <Button
-                type="submit"
-                fullWidth
-                variant="contained"
-                size="large"
-                disabled={
-                  isAccepting ||
-                  !formState.name ||
-                  formState.password.length < 12
-                }
-                sx={{ py: 1.5 }}
-              >
-                {isAccepting ? "Accepting..." : "Accept Invitation"}
-              </Button>
-            </Box>
-          </CardContent>
-        </Card>
+        <Button
+          type="submit"
+          fullWidth
+          variant="contained"
+          size="large"
+          disabled={
+            isAccepting || !formState.name || formState.password.length < 12
+          }
+          sx={{ py: 1.5 }}
+        >
+          {isAccepting ? "Accepting…" : "Accept Invitation"}
+        </Button>
       </Box>
-    </Container>
+    </PublicEntryShell>
   );
 }

--- a/src/client/components/Layout.tsx
+++ b/src/client/components/Layout.tsx
@@ -16,6 +16,7 @@ import {
   Avatar,
   Box,
   ButtonBase,
+  Chip,
   Divider,
   Drawer,
   IconButton,
@@ -53,9 +54,34 @@ interface LayoutProps {
   onLogout: () => void;
 }
 
+function getActiveView(pathname: string) {
+  if (pathname === "/settings" || pathname.endsWith("/settings")) {
+    return "settings";
+  }
+
+  if (pathname.includes("/quarantine")) {
+    return "quarantine";
+  }
+
+  if (pathname.includes("/members")) {
+    return "members";
+  }
+
+  if (pathname.includes("/providers")) {
+    return "providers";
+  }
+
+  return "inbox";
+}
+
+export function isSettingsPath(pathname: string) {
+  return getActiveView(pathname) === "settings";
+}
+
 interface UserAccountMenuProps {
   session: SessionData | null | undefined;
   mode: "light" | "dark";
+  settingsPath: string;
   onSettingsClick: () => void;
   onToggleColorMode: () => void;
   onLogout: () => void;
@@ -64,6 +90,7 @@ interface UserAccountMenuProps {
 export function UserAccountMenuContent({
   session,
   mode,
+  settingsPath,
   onSettingsClick,
   onToggleColorMode,
   onLogout,
@@ -81,7 +108,7 @@ export function UserAccountMenuContent({
       <Divider />
       <MenuItem
         component={Link}
-        to="/settings"
+        to={settingsPath}
         onClick={onSettingsClick}
         sx={{ py: 1.25 }}
       >
@@ -171,16 +198,7 @@ export function Layout({
   onLogout,
 }: LayoutProps) {
   const location = useLocation();
-  const activeView =
-    location.pathname === "/settings"
-      ? "settings"
-      : location.pathname.includes("/quarantine")
-        ? "quarantine"
-        : location.pathname.includes("/members")
-          ? "members"
-          : location.pathname.includes("/providers")
-            ? "providers"
-            : "inbox";
+  const activeView = getActiveView(location.pathname);
   const theme = useTheme();
   const colorMode = useContext(ColorModeContext);
   const isDesktop = useMediaQuery(theme.breakpoints.up("lg"));
@@ -194,6 +212,7 @@ export function Layout({
   const activeHousehold =
     households.find((household) => household.slug === householdSlug) ?? null;
   const roleLabel = householdRole === "owner" ? "Owner" : "Member";
+  const settingsPath = buildHouseholdPath(householdSlug, "/settings");
   const isHouseholdMenuOpen = Boolean(householdMenuAnchor);
   const isUserMenuOpen = Boolean(userMenuAnchor);
 
@@ -431,14 +450,13 @@ export function Layout({
         >
           <Box sx={{ minWidth: 0, pr: 2 }}>
             <Typography variant="body2" sx={{ fontWeight: 700 }} noWrap>
-              {getDisplayName(session)}
-            </Typography>
-            <Typography variant="body2" color="text.secondary" noWrap>
               {householdName}
             </Typography>
-            <Typography variant="caption" color="text.secondary" noWrap>
-              {roleLabel}
-            </Typography>
+            <Chip
+              label={roleLabel}
+              size="small"
+              sx={{ mt: 0.75, fontWeight: 600, maxWidth: "100%" }}
+            />
           </Box>
           <ExpandMore color="action" />
         </ButtonBase>
@@ -556,6 +574,7 @@ export function Layout({
             anchorEl={userMenuAnchor}
             open={isUserMenuOpen}
             mode={theme.palette.mode}
+            settingsPath={settingsPath}
             onClose={handleCloseUserMenu}
             onToggleColorMode={handleToggleColorMode}
             onLogout={handleLogoutClick}

--- a/src/client/components/LoginPage.tsx
+++ b/src/client/components/LoginPage.tsx
@@ -1,16 +1,8 @@
-import {
-  Alert,
-  Box,
-  Button,
-  Card,
-  CardContent,
-  Container,
-  TextField,
-  Typography,
-} from "@mui/material";
+import { Alert, Box, Button, TextField } from "@mui/material";
 import { authClient } from "@server/auth/client";
 import { type FormEvent, useState } from "react";
 import type { LoginState, SetupStatus } from "../types";
+import { PublicEntryShell } from "./PublicEntryShell";
 
 interface LoginPageProps {
   setupStatus: SetupStatus | null;
@@ -53,102 +45,71 @@ export function LoginPage({
   };
 
   return (
-    <Container component="main" maxWidth="sm">
-      <Box
-        sx={{
-          minHeight: "100vh",
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "center",
-          py: 4,
-        }}
-      >
-        <Card elevation={3} sx={{ borderRadius: 3 }}>
-          <CardContent sx={{ p: 4 }}>
-            <Typography
-              variant="overline"
-              color="text.secondary"
-              sx={{ fontWeight: "bold", letterSpacing: 1 }}
-            >
-              Mi Casa Su Casa
-            </Typography>
-            <Typography
-              variant="h4"
-              component="h1"
-              gutterBottom
-              sx={{ mt: 1, fontWeight: "bold" }}
-            >
-              Shared verification inbox, without the chaos.
-            </Typography>
-            <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
-              Sign in with your invited household account to see the provider
-              groups you have access to and quickly find the latest verification
-              code.
-            </Typography>
+    <PublicEntryShell
+      eyebrow="Mi Casa Su Casa"
+      title="Shared verification inbox, without the chaos."
+      description="Sign in with your invited household account to see the provider groups you have access to and quickly find the latest verification code."
+    >
+      <Box component="form" onSubmit={handleLogin} noValidate>
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          id="email"
+          label="Email Address"
+          name="email"
+          autoComplete="email"
+          autoFocus
+          value={loginState.email}
+          onChange={(e) =>
+            setLoginState((current) => ({
+              ...current,
+              email: e.target.value,
+            }))
+          }
+        />
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          name="password"
+          label="Password"
+          type="password"
+          id="password"
+          autoComplete="current-password"
+          value={loginState.password}
+          onChange={(e) =>
+            setLoginState((current) => ({
+              ...current,
+              password: e.target.value,
+            }))
+          }
+          sx={{ mb: 3 }}
+        />
 
-            <Box component="form" onSubmit={handleLogin} noValidate>
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                id="email"
-                label="Email Address"
-                name="email"
-                autoComplete="email"
-                autoFocus
-                value={loginState.email}
-                onChange={(e) =>
-                  setLoginState((current) => ({
-                    ...current,
-                    email: e.target.value,
-                  }))
-                }
-              />
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                name="password"
-                label="Password"
-                type="password"
-                id="password"
-                autoComplete="current-password"
-                value={loginState.password}
-                onChange={(e) =>
-                  setLoginState((current) => ({
-                    ...current,
-                    password: e.target.value,
-                  }))
-                }
-                sx={{ mb: 3 }}
-              />
+        {loginError && (
+          <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
+            {loginError}
+          </Alert>
+        )}
 
-              {loginError && (
-                <Alert severity="error" sx={{ mb: 3 }}>
-                  {loginError}
-                </Alert>
-              )}
+        {setupError && !setupStatus?.isConfigured && (
+          <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
+            {setupError}
+          </Alert>
+        )}
 
-              {setupError && !setupStatus?.isConfigured && (
-                <Alert severity="error" sx={{ mb: 3 }}>
-                  {setupError}
-                </Alert>
-              )}
-
-              <Button
-                type="submit"
-                fullWidth
-                variant="contained"
-                size="large"
-                disabled={isLoggingIn}
-                sx={{ py: 1.5 }}
-              >
-                {isLoggingIn ? "Signing in…" : "Sign in"}
-              </Button>
-            </Box>
-          </CardContent>
-        </Card>
+        <Button
+          type="submit"
+          fullWidth
+          variant="contained"
+          size="large"
+          disabled={isLoggingIn}
+          sx={{ py: 1.5 }}
+        >
+          {isLoggingIn ? "Signing in…" : "Sign in"}
+        </Button>
       </Box>
-    </Container>
+    </PublicEntryShell>
   );
 }

--- a/src/client/components/MembersView.tsx
+++ b/src/client/components/MembersView.tsx
@@ -207,7 +207,9 @@ export function MembersView({
           }
           title="Household member actions"
           subheader="Open a focused flow when you need to add or invite someone"
-          titleTypographyProps={{ variant: "h6", fontWeight: "bold" }}
+          slotProps={{
+            title: { variant: "h6", fontWeight: "bold" },
+          }}
         />
         <Divider />
         <CardContent>
@@ -461,7 +463,9 @@ export function MembersView({
           }
           title="Pending and recent invitations"
           subheader="Track invitation status and resend or cancel pending links"
-          titleTypographyProps={{ variant: "h6", fontWeight: "bold" }}
+          slotProps={{
+            title: { variant: "h6", fontWeight: "bold" },
+          }}
         />
         <Divider />
         <CardContent>
@@ -571,26 +575,166 @@ export function MembersView({
       <Box
         sx={{
           display: "flex",
-          flexDirection: { xs: "column", md: "row" },
+          flexDirection: { xs: "column", lg: "row" },
           gap: 3,
           flexGrow: 1,
           minHeight: 0,
           alignItems: "flex-start",
         }}
       >
+        <Stack
+          spacing={2}
+          sx={{ display: { xs: "flex", md: "none" }, width: "100%" }}
+        >
+          {members.map((member) => {
+            const isSelected = member.id === selectedMemberId;
+
+            return (
+              <Card
+                key={member.id}
+                variant="outlined"
+                onClick={() => onSelectMember(member.id)}
+                sx={{
+                  width: "100%",
+                  borderRadius: 2,
+                  cursor: "pointer",
+                  borderColor: isSelected ? "primary.main" : "divider",
+                  boxShadow: isSelected ? 3 : undefined,
+                }}
+              >
+                <CardContent sx={{ p: 2.5 }}>
+                  <Stack spacing={2}>
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "flex-start",
+                        justifyContent: "space-between",
+                        gap: 2,
+                      }}
+                    >
+                      <Box
+                        sx={{ display: "flex", alignItems: "center", gap: 2 }}
+                      >
+                        <Badge
+                          overlap="circular"
+                          anchorOrigin={{
+                            vertical: "bottom",
+                            horizontal: "right",
+                          }}
+                          badgeContent={
+                            member.role === "admin" ? (
+                              <Tooltip title="Household Owner" placement="top">
+                                <AdminPanelSettingsOutlined
+                                  sx={{
+                                    fontSize: 16,
+                                    color: "primary.main",
+                                    bgcolor: "background.paper",
+                                    borderRadius: "50%",
+                                  }}
+                                />
+                              </Tooltip>
+                            ) : null
+                          }
+                        >
+                          <Avatar {...stringAvatar(member.name)} />
+                        </Badge>
+                        <Box sx={{ minWidth: 0 }}>
+                          <Typography
+                            variant="subtitle1"
+                            sx={{ fontWeight: "bold" }}
+                          >
+                            {member.name}
+                          </Typography>
+                          <Typography
+                            variant="body2"
+                            color="text.secondary"
+                            sx={{ wordBreak: "break-word" }}
+                          >
+                            {member.email}
+                          </Typography>
+                        </Box>
+                      </Box>
+                      <ChevronRightOutlined
+                        color={isSelected ? "primary" : "inherit"}
+                      />
+                    </Box>
+
+                    <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+                      <Chip
+                        label={member.role === "admin" ? "Owner" : "Member"}
+                        color={member.role === "admin" ? "primary" : "default"}
+                        size="small"
+                        sx={{ fontWeight: "bold" }}
+                      />
+                      {member.providerAccess.length === 0 ? (
+                        <Chip
+                          label="No provider access"
+                          size="small"
+                          variant="outlined"
+                        />
+                      ) : (
+                        member.providerAccess.slice(0, 2).map((access) => {
+                          return (
+                            <Chip
+                              key={access.providerKey}
+                              label={access.displayName}
+                              size="small"
+                              variant="outlined"
+                            />
+                          );
+                        })
+                      )}
+                      {member.providerAccess.length > 2 && (
+                        <Chip
+                          label={`+${member.providerAccess.length - 2} more`}
+                          size="small"
+                          variant="outlined"
+                        />
+                      )}
+                    </Box>
+                  </Stack>
+                </CardContent>
+              </Card>
+            );
+          })}
+
+          {!members.length && !isLoadingMembers && (
+            <Card variant="outlined" sx={{ borderRadius: 2 }}>
+              <CardContent sx={{ py: 6, textAlign: "center" }}>
+                <GroupOutlined
+                  sx={{ fontSize: 48, color: "text.disabled", mb: 2 }}
+                />
+                <Typography
+                  variant="subtitle1"
+                  sx={{ fontWeight: "bold" }}
+                  gutterBottom
+                >
+                  No members yet
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Create the first invited household member to get started.
+                </Typography>
+              </CardContent>
+            </Card>
+          )}
+        </Stack>
+
         <TableContainer
           component={Card}
           variant="outlined"
           sx={{
+            display: { xs: "none", md: "flex" },
             flexGrow: 1,
             borderRadius: 2,
             minWidth: 0,
             overflowX: "auto",
-            display: "flex",
             flexDirection: "column",
           }}
         >
-          <Table sx={{ minWidth: 500 }} aria-label="members table">
+          <Table
+            sx={{ width: "100%", tableLayout: "fixed" }}
+            aria-label="members table"
+          >
             <TableHead sx={{ bgcolor: "background.default" }}>
               <TableRow>
                 <TableCell sx={{ fontWeight: "bold", color: "text.secondary" }}>
@@ -769,7 +913,8 @@ export function MembersView({
           <Card
             variant="outlined"
             sx={{
-              width: { xs: "100%", md: 400 },
+              width: { xs: "100%", lg: 400 },
+              maxWidth: { xs: "100%", lg: 400 },
               flexShrink: 0,
               borderRadius: 2,
               display: "flex",
@@ -802,10 +947,12 @@ export function MembersView({
                   {selectedMember.email}
                 </Box>
               }
-              titleTypographyProps={{ variant: "h6", fontWeight: "bold" }}
-              subheaderTypographyProps={{
-                variant: "body2",
-                color: "text.secondary",
+              slotProps={{
+                title: { variant: "h6", fontWeight: "bold" },
+                subheader: {
+                  variant: "body2",
+                  color: "text.secondary",
+                },
               }}
               action={
                 <Tooltip title="Send email">

--- a/src/client/components/ProvidersRulesView.tsx
+++ b/src/client/components/ProvidersRulesView.tsx
@@ -276,7 +276,9 @@ export function ProvidersRulesView({
           }
           title="Provider and rule setup"
           subheader="Configure senders so codes route cleanly without owner intervention."
-          titleTypographyProps={{ variant: "h6", fontWeight: "bold" }}
+          slotProps={{
+            title: { variant: "h6", fontWeight: "bold" },
+          }}
         />
         <Divider />
         <CardContent>
@@ -346,7 +348,70 @@ export function ProvidersRulesView({
             >
               Connected providers
             </Typography>
-            <Box sx={{ height: 360, width: "100%" }}>
+            <Stack spacing={1.5} sx={{ display: { xs: "flex", md: "none" } }}>
+              {providers.map((provider) => {
+                const isSelected = provider.id === selectedProviderId;
+
+                return (
+                  <Card
+                    key={provider.id}
+                    variant="outlined"
+                    onClick={() => onSelectProvider(provider.id)}
+                    sx={{
+                      cursor: "pointer",
+                      borderRadius: 2,
+                      borderColor: isSelected ? "primary.main" : "divider",
+                    }}
+                  >
+                    <CardContent sx={{ p: 2 }}>
+                      <Stack spacing={1.5}>
+                        <Box
+                          sx={{
+                            display: "flex",
+                            justifyContent: "space-between",
+                            gap: 2,
+                            alignItems: "flex-start",
+                          }}
+                        >
+                          <Box sx={{ minWidth: 0 }}>
+                            <Typography
+                              variant="subtitle1"
+                              sx={{ fontWeight: "bold" }}
+                            >
+                              {provider.display_name}
+                            </Typography>
+                            <Typography
+                              variant="body2"
+                              color="text.secondary"
+                              sx={{ wordBreak: "break-word" }}
+                            >
+                              {provider.provider_key}
+                            </Typography>
+                          </Box>
+                          <Chip
+                            label={`${provider.rule_count} rules`}
+                            size="small"
+                          />
+                        </Box>
+                        <Typography variant="caption" color="text.secondary">
+                          Created {formatTimestamp(provider.created_at)}
+                        </Typography>
+                      </Stack>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+              {!providers.length && (
+                <Alert severity="info">No providers configured yet.</Alert>
+              )}
+            </Stack>
+            <Box
+              sx={{
+                height: 360,
+                width: "100%",
+                display: { xs: "none", md: "block" },
+              }}
+            >
               <DataGrid
                 rows={providers}
                 columns={providerColumns}
@@ -392,7 +457,81 @@ export function ProvidersRulesView({
                 {providerRules.length} configured
               </Typography>
             </Box>
-            <Box sx={{ height: 320, width: "100%" }}>
+            <Stack spacing={1.5} sx={{ display: { xs: "flex", md: "none" } }}>
+              {providerRules.map((rule) => {
+                const isSelected = rule.id === selectedRuleId;
+
+                return (
+                  <Card
+                    key={rule.id}
+                    variant="outlined"
+                    onClick={() => onSelectRule(rule.id)}
+                    sx={{
+                      cursor: "pointer",
+                      borderRadius: 2,
+                      borderColor: isSelected ? "primary.main" : "divider",
+                    }}
+                  >
+                    <CardContent sx={{ p: 2 }}>
+                      <Stack spacing={1.5}>
+                        <Box
+                          sx={{
+                            display: "flex",
+                            justifyContent: "space-between",
+                            gap: 2,
+                            alignItems: "flex-start",
+                          }}
+                        >
+                          <Box sx={{ minWidth: 0 }}>
+                            <Typography
+                              variant="subtitle1"
+                              sx={{
+                                fontWeight: "bold",
+                                wordBreak: "break-word",
+                              }}
+                            >
+                              {rule.match_value}
+                            </Typography>
+                            <Typography
+                              variant="caption"
+                              color="text.secondary"
+                            >
+                              Created {formatTimestamp(rule.created_at)}
+                            </Typography>
+                          </Box>
+                          <Chip
+                            size="small"
+                            label={
+                              rule.match_type === "domain" ? "Domain" : "Exact"
+                            }
+                            color={
+                              rule.match_type === "domain"
+                                ? "secondary"
+                                : "primary"
+                            }
+                            variant="outlined"
+                          />
+                        </Box>
+                      </Stack>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+              {!providerRules.length && (
+                <Alert severity="info">
+                  {selectedProvider
+                    ? "No sender rules configured yet for this provider."
+                    : "Choose a provider to view its rules."}
+                </Alert>
+              )}
+            </Stack>
+            <Box
+              sx={{
+                height: 320,
+                width: "100%",
+                display: { xs: "none", md: "block" },
+              }}
+            >
               <DataGrid
                 rows={providerRules}
                 columns={ruleColumns}
@@ -425,7 +564,9 @@ export function ProvidersRulesView({
               }
               title="Provider actions"
               subheader="Open a dialog to create, update, or delete a selected provider"
-              titleTypographyProps={{ variant: "h6", fontWeight: "bold" }}
+              slotProps={{
+                title: { variant: "h6", fontWeight: "bold" },
+              }}
             />
             <Divider />
             <CardContent>
@@ -478,7 +619,9 @@ export function ProvidersRulesView({
               }
               title="Rule actions"
               subheader="Create or refine sender mapping rules without losing grid context"
-              titleTypographyProps={{ variant: "h6", fontWeight: "bold" }}
+              slotProps={{
+                title: { variant: "h6", fontWeight: "bold" },
+              }}
             />
             <Divider />
             <CardContent>

--- a/src/client/components/PublicEntryShell.tsx
+++ b/src/client/components/PublicEntryShell.tsx
@@ -1,0 +1,77 @@
+import { Box, Card, CardContent, Container, Typography } from "@mui/material";
+import type { ReactNode } from "react";
+
+interface PublicEntryShellProps {
+  eyebrow: string;
+  title: string;
+  description?: ReactNode;
+  children: ReactNode;
+}
+
+export function PublicEntryShell({
+  eyebrow,
+  title,
+  description,
+  children,
+}: PublicEntryShellProps) {
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        py: { xs: 3, sm: 5, md: 7 },
+        px: { xs: 1.5, sm: 2.5, md: 3 },
+      }}
+    >
+      <Container maxWidth="md" disableGutters>
+        <Box
+          sx={{
+            width: "100%",
+            maxWidth: 760,
+            mx: "auto",
+          }}
+        >
+          <Card
+            elevation={3}
+            sx={{ borderRadius: { xs: 3, sm: 4 }, overflow: "hidden" }}
+          >
+            <CardContent sx={{ p: { xs: 3, sm: 4, md: 5 } }}>
+              <Typography
+                variant="overline"
+                color="text.secondary"
+                sx={{ fontWeight: "bold", letterSpacing: 1 }}
+              >
+                {eyebrow}
+              </Typography>
+              <Typography
+                variant="h4"
+                component="h1"
+                gutterBottom
+                sx={{
+                  mt: 1,
+                  fontWeight: "bold",
+                  fontSize: { xs: "1.9rem", sm: "2.25rem", md: "2.5rem" },
+                  lineHeight: 1.15,
+                  textWrap: "balance",
+                }}
+              >
+                {title}
+              </Typography>
+              {description ? (
+                <Typography
+                  variant="body1"
+                  color="text.secondary"
+                  sx={{ mb: 4, maxWidth: 56 * 8, textWrap: "pretty" }}
+                >
+                  {description}
+                </Typography>
+              ) : null}
+              {children}
+            </CardContent>
+          </Card>
+        </Box>
+      </Container>
+    </Box>
+  );
+}

--- a/src/client/components/QuarantineView.tsx
+++ b/src/client/components/QuarantineView.tsx
@@ -127,12 +127,12 @@ export function QuarantineView({
     <Box
       sx={{
         display: "flex",
-        flexDirection: { xs: "column", md: "row" },
+        flexDirection: { xs: "column", lg: "row" },
         gap: 3,
         height: "100%",
       }}
     >
-      <Box sx={{ width: { xs: "100%", md: 360 }, flexShrink: 0 }}>
+      <Box sx={{ width: { xs: "100%", lg: 360 }, flexShrink: 0, minWidth: 0 }}>
         <Typography
           variant="overline"
           color="text.secondary"
@@ -178,17 +178,21 @@ export function QuarantineView({
                             sx={{
                               display: "flex",
                               justifyContent: "space-between",
+                              alignItems: "flex-start",
+                              gap: 1,
                               mb: 0.5,
                             }}
                           >
                             <Typography
                               variant="subtitle2"
                               sx={{
+                                flex: 1,
+                                minWidth: 0,
                                 fontWeight: isSelected ? "bold" : "medium",
                                 overflow: "hidden",
                                 textOverflow: "ellipsis",
                                 whiteSpace: "nowrap",
-                                pr: 1,
+                                pr: 0.5,
                               }}
                             >
                               {message.subject ?? "Untitled message"}
@@ -276,9 +280,11 @@ export function QuarantineView({
                 display: "flex",
                 justifyContent: "space-between",
                 alignItems: "flex-start",
+                flexDirection: { xs: "column", sm: "row" },
+                gap: 1.5,
               }}
             >
-              <Box>
+              <Box sx={{ minWidth: 0 }}>
                 <Typography variant="h5" sx={{ fontWeight: "bold", mb: 0.5 }}>
                   {selectedQuarantineMessage.subject ?? "Untitled message"}
                 </Typography>
@@ -315,6 +321,7 @@ export function QuarantineView({
                 <Box
                   sx={{
                     display: "inline-flex",
+                    flexDirection: { xs: "column", sm: "row" },
                     alignItems: "center",
                     gap: 2,
                     justifyContent: "center",
@@ -322,7 +329,12 @@ export function QuarantineView({
                 >
                   <Typography
                     variant="h3"
-                    sx={{ fontWeight: "bold", letterSpacing: 2 }}
+                    sx={{
+                      fontWeight: "bold",
+                      letterSpacing: { xs: 1, sm: 2 },
+                      fontSize: { xs: "2rem", sm: undefined },
+                      wordBreak: "break-word",
+                    }}
                   >
                     {selectedQuarantineMessage.extracted_code ??
                       "No code detected"}
@@ -388,7 +400,7 @@ export function QuarantineView({
                 alignItems: { xs: "stretch", sm: "flex-end" },
               }}
             >
-              <FormControl sx={{ minWidth: 200, flexGrow: 1 }}>
+              <FormControl sx={{ minWidth: { xs: 0, sm: 200 }, flexGrow: 1 }}>
                 <InputLabel id="release-provider-label">
                   Release to provider
                 </InputLabel>
@@ -409,14 +421,18 @@ export function QuarantineView({
                 </Select>
               </FormControl>
 
-              <Stack direction="row" spacing={2}>
+              <Stack
+                direction={{ xs: "column", sm: "row" }}
+                spacing={2}
+                sx={{ width: { xs: "100%", sm: "auto" } }}
+              >
                 <Button
                   variant="contained"
                   color="primary"
                   startIcon={<MoveToInboxOutlined />}
                   disabled={isReviewingQuarantine || !releaseProviderKey}
                   onClick={() => setReviewAction("release")}
-                  sx={{ px: 4, py: 1.5 }}
+                  sx={{ px: 4, py: 1.5, width: { xs: "100%", sm: "auto" } }}
                 >
                   Release to inbox
                 </Button>
@@ -425,7 +441,7 @@ export function QuarantineView({
                   startIcon={<DeleteOutlined />}
                   disabled={isReviewingQuarantine}
                   onClick={() => setReviewAction("dismiss")}
-                  sx={{ px: 4, py: 1.5 }}
+                  sx={{ px: 4, py: 1.5, width: { xs: "100%", sm: "auto" } }}
                 >
                   Dismiss
                 </Button>

--- a/src/client/components/SettingsView.tsx
+++ b/src/client/components/SettingsView.tsx
@@ -106,7 +106,7 @@ export function SettingsView({
 
   return (
     <Container maxWidth="md" disableGutters>
-      <Box sx={{ mb: 4 }}>
+      <Box sx={{ mb: 4, px: { xs: 0.5, sm: 0 } }}>
         <Typography variant="h4" gutterBottom sx={{ fontWeight: "bold" }}>
           Account Settings
         </Typography>
@@ -117,13 +117,13 @@ export function SettingsView({
       </Box>
 
       {error && (
-        <Alert severity="error" sx={{ mb: 4 }}>
+        <Alert severity="error" sx={{ mb: 4, borderRadius: 2 }}>
           {error}
         </Alert>
       )}
 
       {/* Profile Card */}
-      <Card sx={{ mb: 4, borderRadius: 2 }}>
+      <Card sx={{ mb: 4, borderRadius: 2, overflow: "hidden" }}>
         <CardHeader title="Profile" />
         <Divider />
         <CardContent>
@@ -169,7 +169,7 @@ export function SettingsView({
       </Card>
 
       {/* Password Card */}
-      <Card sx={{ mb: 4, borderRadius: 2 }}>
+      <Card sx={{ mb: 4, borderRadius: 2, overflow: "hidden" }}>
         <CardHeader title="Change Password" />
         <Divider />
         <CardContent>
@@ -217,7 +217,7 @@ export function SettingsView({
         </CardContent>
       </Card>
 
-      <Card sx={{ mb: 4, borderRadius: 2 }}>
+      <Card sx={{ mb: 4, borderRadius: 2, overflow: "hidden" }}>
         <CardHeader title="Password Reset Email" />
         <Divider />
         <CardContent>
@@ -254,7 +254,7 @@ export function SettingsView({
       </Card>
 
       {/* Two-Factor Authentication */}
-      <Card sx={{ mb: 4, borderRadius: 2 }}>
+      <Card sx={{ mb: 4, borderRadius: 2, overflow: "hidden" }}>
         <CardHeader title="Two-Factor Authentication" />
         <Divider />
         <CardContent>
@@ -330,7 +330,7 @@ export function SettingsView({
       </Card>
 
       {/* Passkeys */}
-      <Card sx={{ mb: 4, borderRadius: 2 }}>
+      <Card sx={{ mb: 4, borderRadius: 2, overflow: "hidden" }}>
         <CardHeader title="Passkeys" />
         <Divider />
         <CardContent>
@@ -367,18 +367,29 @@ export function SettingsView({
       </Card>
 
       {/* Sessions Card */}
-      <Card sx={{ mb: 4, borderRadius: 2 }}>
+      <Card sx={{ mb: 4, borderRadius: 2, overflow: "hidden" }}>
         <CardHeader
           title="Active Sessions"
+          slotProps={{ title: { sx: { pr: { xs: 0, sm: 2 } } } }}
           action={
             <Button
               color="error"
               disabled={isSaving || sessions.length <= 1}
               onClick={() => setIsRevokeOthersOpen(true)}
+              sx={{ alignSelf: { xs: "flex-start", sm: "center" } }}
             >
               Revoke Others
             </Button>
           }
+          sx={{
+            alignItems: { xs: "flex-start", sm: "center" },
+            flexDirection: { xs: "column", sm: "row" },
+            gap: { xs: 1.5, sm: 0 },
+            "& .MuiCardHeader-action": {
+              alignSelf: { xs: "flex-start", sm: "center" },
+              m: 0,
+            },
+          }}
         />
         <Divider />
         <List disablePadding>
@@ -386,12 +397,17 @@ export function SettingsView({
             <Fragment key={session.id}>
               {index > 0 && <Divider />}
               <ListItem
+                sx={{
+                  alignItems: { xs: "flex-start", sm: "center" },
+                  pr: { xs: 2, sm: 11 },
+                }}
                 secondaryAction={
                   <Button
                     color="error"
                     size="small"
                     onClick={() => setSessionToRevoke(session)}
                     disabled={isSaving}
+                    sx={{ top: { xs: 20, sm: "50%" } }}
                   >
                     Revoke
                   </Button>

--- a/src/client/components/SetupPage.tsx
+++ b/src/client/components/SetupPage.tsx
@@ -1,16 +1,8 @@
-import {
-  Alert,
-  Box,
-  Button,
-  Card,
-  CardContent,
-  Container,
-  TextField,
-  Typography,
-} from "@mui/material";
+import { Alert, Box, Button, TextField, Typography } from "@mui/material";
 import { type FormEvent, useState } from "react";
 import type { SetupFormState } from "../types";
 import { fetchJson } from "../utils";
+import { PublicEntryShell } from "./PublicEntryShell";
 
 interface SetupPageProps {
   onSetupComplete: () => void;
@@ -63,186 +55,152 @@ export function SetupPage({
   };
 
   return (
-    <Container component="main" maxWidth="sm">
-      <Box
-        sx={{
-          minHeight: "100vh",
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "center",
-          py: 4,
-        }}
-      >
-        <Card elevation={3} sx={{ borderRadius: 3 }}>
-          <CardContent sx={{ p: 4 }}>
-            <Typography
-              variant="overline"
-              color="text.secondary"
-              sx={{ fontWeight: "bold", letterSpacing: 1 }}
-            >
-              First-run setup
+    <PublicEntryShell
+      eyebrow="First-run setup"
+      title="Finish setting up your household inbox."
+      description="Create the initial owner account after your Cloudflare deployment completes. This screen closes automatically after the first successful setup."
+    >
+      <Alert severity="info" sx={{ mb: 4, borderRadius: 2 }}>
+        <Typography variant="subtitle2" sx={{ fontWeight: "bold", mb: 0.5 }}>
+          What you need
+        </Typography>
+        <Box component="ul" sx={{ m: 0, pl: 2 }}>
+          <li>
+            <Typography variant="body2">
+              The owner email configured as <code>OWNER_EMAIL</code>
             </Typography>
-            <Typography
-              variant="h4"
-              component="h1"
-              gutterBottom
-              sx={{ mt: 1, fontWeight: "bold" }}
-            >
-              Finish setting up your household inbox.
+          </li>
+          <li>
+            <Typography variant="body2">
+              Your one-time <code>SETUP_SECRET</code>
             </Typography>
-            <Typography variant="body1" color="text.secondary" sx={{ mb: 2 }}>
-              Create the initial owner account after your Cloudflare deployment
-              completes. This screen closes automatically after the first
-              successful setup.
+          </li>
+          <li>
+            <Typography variant="body2">
+              A strong password for the initial owner account
             </Typography>
+          </li>
+        </Box>
+      </Alert>
 
-            <Alert severity="info" sx={{ mb: 4, borderRadius: 2 }}>
-              <Typography
-                variant="subtitle2"
-                sx={{ fontWeight: "bold", mb: 0.5 }}
-              >
-                What you need
-              </Typography>
-              <Box component="ul" sx={{ m: 0, pl: 2 }}>
-                <li>
-                  <Typography variant="body2">
-                    The owner email configured as <code>OWNER_EMAIL</code>
-                  </Typography>
-                </li>
-                <li>
-                  <Typography variant="body2">
-                    Your one-time <code>SETUP_SECRET</code>
-                  </Typography>
-                </li>
-                <li>
-                  <Typography variant="body2">
-                    A strong password for the initial owner account
-                  </Typography>
-                </li>
-              </Box>
-            </Alert>
+      <Box component="form" onSubmit={handleSetupComplete} noValidate>
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          id="setup-household-name"
+          label="Household name"
+          name="setup-household-name"
+          value={setupFormState.householdName}
+          onChange={(e) =>
+            setSetupFormState((current) => ({
+              ...current,
+              householdName: e.target.value,
+            }))
+          }
+        />
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          id="setup-household-slug"
+          label="Household slug"
+          name="setup-household-slug"
+          helperText="Lowercase letters, numbers, and hyphens only."
+          value={setupFormState.householdSlug}
+          onChange={(e) =>
+            setSetupFormState((current) => ({
+              ...current,
+              householdSlug: e.target.value.toLowerCase(),
+            }))
+          }
+        />
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          id="setup-email"
+          label="Owner email"
+          name="setup-email"
+          autoComplete="email"
+          value={setupFormState.email}
+          onChange={(e) =>
+            setSetupFormState((current) => ({
+              ...current,
+              email: e.target.value,
+            }))
+          }
+        />
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          id="setup-name"
+          label="Owner display name"
+          name="setup-name"
+          autoComplete="name"
+          value={setupFormState.name}
+          onChange={(e) =>
+            setSetupFormState((current) => ({
+              ...current,
+              name: e.target.value,
+            }))
+          }
+        />
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          name="setup-password"
+          label="Password"
+          type="password"
+          id="setup-password"
+          autoComplete="new-password"
+          value={setupFormState.password}
+          onChange={(e) =>
+            setSetupFormState((current) => ({
+              ...current,
+              password: e.target.value,
+            }))
+          }
+          slotProps={{ htmlInput: { minLength: 12 } }}
+        />
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          name="setup-secret"
+          label="Setup secret"
+          type="password"
+          id="setup-secret"
+          autoComplete="off"
+          value={setupFormState.setupSecret}
+          onChange={(e) =>
+            setSetupFormState((current) => ({
+              ...current,
+              setupSecret: e.target.value,
+            }))
+          }
+          sx={{ mb: 3 }}
+        />
 
-            <Box component="form" onSubmit={handleSetupComplete} noValidate>
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                id="setup-household-name"
-                label="Household name"
-                name="setup-household-name"
-                value={setupFormState.householdName}
-                onChange={(e) =>
-                  setSetupFormState((current) => ({
-                    ...current,
-                    householdName: e.target.value,
-                  }))
-                }
-              />
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                id="setup-household-slug"
-                label="Household slug"
-                name="setup-household-slug"
-                helperText="Lowercase letters, numbers, and hyphens only."
-                value={setupFormState.householdSlug}
-                onChange={(e) =>
-                  setSetupFormState((current) => ({
-                    ...current,
-                    householdSlug: e.target.value.toLowerCase(),
-                  }))
-                }
-              />
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                id="setup-email"
-                label="Owner email"
-                name="setup-email"
-                autoComplete="email"
-                value={setupFormState.email}
-                onChange={(e) =>
-                  setSetupFormState((current) => ({
-                    ...current,
-                    email: e.target.value,
-                  }))
-                }
-              />
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                id="setup-name"
-                label="Owner display name"
-                name="setup-name"
-                autoComplete="name"
-                value={setupFormState.name}
-                onChange={(e) =>
-                  setSetupFormState((current) => ({
-                    ...current,
-                    name: e.target.value,
-                  }))
-                }
-              />
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                name="setup-password"
-                label="Password"
-                type="password"
-                id="setup-password"
-                autoComplete="new-password"
-                value={setupFormState.password}
-                onChange={(e) =>
-                  setSetupFormState((current) => ({
-                    ...current,
-                    password: e.target.value,
-                  }))
-                }
-                slotProps={{ htmlInput: { minLength: 12 } }}
-              />
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                name="setup-secret"
-                label="Setup secret"
-                type="password"
-                id="setup-secret"
-                autoComplete="off"
-                value={setupFormState.setupSecret}
-                onChange={(e) =>
-                  setSetupFormState((current) => ({
-                    ...current,
-                    setupSecret: e.target.value,
-                  }))
-                }
-                sx={{ mb: 3 }}
-              />
+        {setupError && (
+          <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
+            {setupError}
+          </Alert>
+        )}
 
-              {setupError && (
-                <Alert severity="error" sx={{ mb: 3 }}>
-                  {setupError}
-                </Alert>
-              )}
-
-              <Button
-                type="submit"
-                fullWidth
-                variant="contained"
-                size="large"
-                disabled={isCompletingSetup}
-                sx={{ py: 1.5 }}
-              >
-                {isCompletingSetup ? "Creating owner…" : "Complete setup"}
-              </Button>
-            </Box>
-          </CardContent>
-        </Card>
+        <Button
+          type="submit"
+          fullWidth
+          variant="contained"
+          size="large"
+          disabled={isCompletingSetup}
+          sx={{ py: 1.5 }}
+        >
+          {isCompletingSetup ? "Creating owner…" : "Complete setup"}
+        </Button>
       </Box>
-    </Container>
+    </PublicEntryShell>
   );
 }

--- a/test/layout.test.tsx
+++ b/test/layout.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  isSettingsPath,
   Layout,
   UserAccountMenuContent,
 } from "../src/client/components/Layout";
@@ -58,13 +59,55 @@ describe("Layout", () => {
     expect(html).toContain("Quarantine");
     expect(html).toContain("Members");
     expect(html).toContain("Providers &amp; rules");
-    expect(html).not.toContain('href="/settings"');
+    expect(html).toContain("Home");
+    expect(html).toContain("Owner");
     expect(html).toContain("AM");
     expect(settingsIndex).toBeGreaterThan(-1);
     expect(membersIndex).toBeGreaterThan(settingsIndex);
     expect(quarantineIndex).toBeGreaterThan(membersIndex);
     expect(providersIndex).toBeGreaterThan(quarantineIndex);
     expect(householdSettingsIndex).toBeGreaterThan(providersIndex);
+  });
+
+  it("treats household settings paths as settings views", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter initialEntries={["/home/settings"]}>
+        <ColorModeContext.Provider value={{ toggleColorMode: vi.fn() }}>
+          <ThemeProvider theme={getTheme("light")}>
+            <CssBaseline />
+            <Layout
+              session={{
+                user: {
+                  email: "alex.member@example.com",
+                },
+              }}
+              households={[
+                {
+                  id: "household-1",
+                  slug: "home",
+                  displayName: "Home",
+                  role: "owner",
+                },
+              ]}
+              isOwner={true}
+              householdSlug="home"
+              householdName="Home"
+              householdRole="owner"
+              onSelectHousehold={vi.fn()}
+              onCreateHousehold={vi.fn()}
+              onLogout={vi.fn()}
+            >
+              <div>Settings content</div>
+            </Layout>
+          </ThemeProvider>
+        </ColorModeContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(html).toContain('href="/home/inbox"');
+    expect(isSettingsPath("/home/settings")).toBe(true);
+    expect(isSettingsPath("/settings")).toBe(true);
+    expect(isSettingsPath("/home/inbox")).toBe(false);
   });
 
   it("hides household settings from members", () => {
@@ -120,6 +163,7 @@ describe("UserAccountMenuContent", () => {
                 },
               }}
               mode="dark"
+              settingsPath="/home/settings"
               onSettingsClick={vi.fn()}
               onToggleColorMode={vi.fn()}
               onLogout={vi.fn()}
@@ -132,7 +176,7 @@ describe("UserAccountMenuContent", () => {
     expect(html).toContain("Alex Member");
     expect(html).toContain("alex.member@example.com");
     expect(html).toContain("Settings");
-    expect(html).toContain('href="/settings"');
+    expect(html).toContain('href="/home/settings"');
     expect(html).toContain("Light mode");
     expect(html).toContain("Sign out");
   });


### PR DESCRIPTION
## Summary
- refresh the public auth/setup/create-household flows with a shared entry shell and improved responsive layout
- tighten household-aware navigation so settings and household switching keep the correct active state and destination
- improve responsive inbox, members, providers, quarantine, and settings screens while preserving existing behavior

## Verification
- `rtk npm run check`
- `rtk npm run typecheck`
- `npm test`