### PR TITLE
feat: rename inbox groupings and tighten inbox UI

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -60,6 +60,26 @@ import {
 
 type ViewType = "inbox" | "quarantine" | "members" | "providers" | "settings";
 
+function getActiveView(pathname: string): ViewType {
+  if (pathname === "/settings" || pathname.endsWith("/settings")) {
+    return "settings";
+  }
+
+  if (pathname.includes("/quarantine")) {
+    return "quarantine";
+  }
+
+  if (pathname.includes("/members")) {
+    return "members";
+  }
+
+  if (pathname.includes("/providers")) {
+    return "providers";
+  }
+
+  return "inbox";
+}
+
 const INITIAL_SETTINGS_FORM_STATE: AccountSettingsFormState = {
   name: "",
   image: "",
@@ -121,16 +141,7 @@ export function App() {
       ? routeSegments[0]
       : null;
 
-  const activeView: ViewType =
-    location.pathname === "/settings" || location.pathname.endsWith("/settings")
-      ? "settings"
-      : location.pathname.includes("/quarantine")
-        ? "quarantine"
-        : location.pathname.includes("/members")
-          ? "members"
-          : location.pathname.includes("/providers")
-            ? "providers"
-            : "inbox";
+  const activeView = getActiveView(location.pathname);
   const [households, setHouseholds] = useState<HouseholdSummary[]>([]);
   const [isLoadingHouseholds, setIsLoadingHouseholds] = useState(false);
   const [providers, setProviders] = useState<ProviderSummary[]>([]);
@@ -217,7 +228,7 @@ export function App() {
     (household: HouseholdSummary) => {
       switch (activeView) {
         case "settings":
-          return buildHouseholdPath(household.slug, "/inbox");
+          return buildHouseholdPath(household.slug, "/settings");
         case "quarantine":
           return buildHouseholdPath(
             household.slug,
@@ -348,7 +359,7 @@ export function App() {
   ]);
 
   useEffect(() => {
-    if (!isAuthenticated || location.pathname !== "/settings") {
+    if (!isAuthenticated || activeView !== "settings") {
       return;
     }
 
@@ -389,7 +400,7 @@ export function App() {
     return () => {
       cancelled = true;
     };
-  }, [isAuthenticated, location.pathname]);
+  }, [activeView, isAuthenticated]);
 
   useEffect(() => {
     const isHouseholdSettingsRoute = Boolean(

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -58,7 +58,7 @@ import {
   getProviderAccessToggleRequest,
 } from "./utils";
 
-type ViewType = "inbox" | "quarantine" | "members" | "providers" | "settings";
+type ViewType = "inbox" | "quarantine" | "members" | "inboxes" | "settings";
 
 function getActiveView(pathname: string): ViewType {
   if (pathname === "/settings" || pathname.endsWith("/settings")) {
@@ -73,8 +73,8 @@ function getActiveView(pathname: string): ViewType {
     return "members";
   }
 
-  if (pathname.includes("/providers")) {
-    return "providers";
+  if (pathname.includes("/inboxes")) {
+    return "inboxes";
   }
 
   return "inbox";
@@ -239,10 +239,10 @@ export function App() {
             household.slug,
             household.role === "owner" ? "/members" : "/inbox",
           );
-        case "providers":
+        case "inboxes":
           return buildHouseholdPath(
             household.slug,
-            household.role === "owner" ? "/providers" : "/inbox",
+            household.role === "owner" ? "/inboxes" : "/inbox",
           );
         default:
           return buildHouseholdPath(household.slug, "/inbox");
@@ -834,7 +834,7 @@ export function App() {
 
       try {
         const response = await fetchJson<{ providers: ProviderSummary[] }>(
-          householdApiPath("/inbox/providers"),
+          householdApiPath("/inbox/inboxes"),
         );
 
         if (cancelled) return;
@@ -861,7 +861,7 @@ export function App() {
       } catch (error) {
         if (!cancelled) {
           setViewError(
-            error instanceof Error ? error.message : "Unable to load providers",
+            error instanceof Error ? error.message : "Unable to load inboxes",
           );
         }
       } finally {
@@ -893,7 +893,7 @@ export function App() {
 
       try {
         const response = await fetchJson<ProviderMessagesResponse>(
-          householdApiPath(`/inbox/providers/${selectedProviderKey}`),
+          householdApiPath(`/inbox/inboxes/${selectedProviderKey}`),
         );
 
         if (cancelled) return;
@@ -992,7 +992,7 @@ export function App() {
       !isAuthenticated ||
       !isOwner ||
       !currentHousehold ||
-      activeView !== "providers"
+      activeView !== "inboxes"
     ) {
       return;
     }
@@ -1004,7 +1004,7 @@ export function App() {
 
       try {
         const response = await fetchJson<ProviderConfigurationResponse>(
-          householdApiPath("/admin/providers"),
+          householdApiPath("/admin/inboxes"),
         );
 
         if (cancelled) return;
@@ -1066,7 +1066,7 @@ export function App() {
           setViewError(
             error instanceof Error
               ? error.message
-              : "Unable to load provider configuration",
+              : "Unable to load inbox configuration",
           );
         }
       }
@@ -1156,7 +1156,7 @@ export function App() {
   async function refreshProviders() {
     if (!isAuthenticated || !currentHousehold) return;
     const response = await fetchJson<{ providers: ProviderSummary[] }>(
-      householdApiPath("/inbox/providers"),
+      householdApiPath("/inbox/inboxes"),
     );
     setProviders(response.providers);
     setReleaseProviderKey((current) => {
@@ -1212,7 +1212,7 @@ export function App() {
     if (!isAuthenticated || !isOwner || !currentHousehold) return;
 
     const response = await fetchJson<ProviderConfigurationResponse>(
-      householdApiPath("/admin/providers"),
+      householdApiPath("/admin/inboxes"),
     );
 
     setProviderConfigurations(response.providers);
@@ -1303,7 +1303,7 @@ export function App() {
 
       setStatusMessage(
         action === "release"
-          ? "Quarantined message released to the selected provider."
+          ? "Quarantined message released to the selected inbox."
           : "Quarantined message dismissed.",
       );
 
@@ -1489,7 +1489,7 @@ export function App() {
       setViewError(
         error instanceof Error
           ? error.message
-          : "Unable to update provider access",
+          : "Unable to update inbox access",
       );
     }
   }
@@ -1504,7 +1504,7 @@ export function App() {
 
     try {
       await fetchJson<{ provider: ProviderConfiguration }>(
-        householdApiPath("/admin/providers"),
+        householdApiPath("/admin/inboxes"),
         {
           method: "POST",
           body: JSON.stringify(providerFormState),
@@ -1521,7 +1521,7 @@ export function App() {
       return true;
     } catch (error) {
       setViewError(
-        error instanceof Error ? error.message : "Unable to create provider",
+        error instanceof Error ? error.message : "Unable to create inbox",
       );
       return false;
     } finally {
@@ -1538,7 +1538,7 @@ export function App() {
 
     try {
       await fetchJson<{ provider: ProviderConfiguration }>(
-        householdApiPath(`/admin/providers/${selectedProviderId}`),
+        householdApiPath(`/admin/inboxes/${selectedProviderId}`),
         {
           method: "PATCH",
           body: JSON.stringify(providerFormState),
@@ -1554,7 +1554,7 @@ export function App() {
       return true;
     } catch (error) {
       setViewError(
-        error instanceof Error ? error.message : "Unable to update provider",
+        error instanceof Error ? error.message : "Unable to update inbox",
       );
       return false;
     } finally {
@@ -1571,7 +1571,7 @@ export function App() {
 
     try {
       await fetchJson<{ ok: boolean }>(
-        householdApiPath(`/admin/providers/${selectedProviderId}`),
+        householdApiPath(`/admin/inboxes/${selectedProviderId}`),
         {
           method: "DELETE",
         },
@@ -1588,7 +1588,7 @@ export function App() {
       return true;
     } catch (error) {
       setViewError(
-        error instanceof Error ? error.message : "Unable to delete provider",
+        error instanceof Error ? error.message : "Unable to delete inbox",
       );
       return false;
     } finally {
@@ -1956,7 +1956,7 @@ export function App() {
           }
         />
         <Route
-          path="/:slug/providers"
+          path="/:slug/inboxes"
           element={
             isOwner ? (
               <ProvidersRulesView

--- a/src/client/components/CreateHouseholdPage.tsx
+++ b/src/client/components/CreateHouseholdPage.tsx
@@ -1,16 +1,8 @@
-import {
-  Alert,
-  Box,
-  Button,
-  Card,
-  CardContent,
-  Container,
-  TextField,
-  Typography,
-} from "@mui/material";
+import { Alert, Box, Button, TextField } from "@mui/material";
 import { type FormEvent, useState } from "react";
 import type { CreateHouseholdFormState, HouseholdSummary } from "../types";
 import { fetchJson } from "../utils";
+import { PublicEntryShell } from "./PublicEntryShell";
 
 interface CreateHouseholdPageProps {
   onCreated: (household: HouseholdSummary) => void;
@@ -51,92 +43,62 @@ export function CreateHouseholdPage({ onCreated }: CreateHouseholdPageProps) {
   }
 
   return (
-    <Container component="main" maxWidth="sm">
-      <Box
-        sx={{
-          minHeight: "100vh",
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "center",
-          py: 4,
-        }}
-      >
-        <Card elevation={3} sx={{ borderRadius: 3 }}>
-          <CardContent sx={{ p: 4 }}>
-            <Typography
-              variant="overline"
-              color="text.secondary"
-              sx={{ fontWeight: "bold", letterSpacing: 1 }}
-            >
-              Create your household
-            </Typography>
-            <Typography
-              variant="h4"
-              component="h1"
-              gutterBottom
-              sx={{ mt: 1, fontWeight: "bold" }}
-            >
-              You need a household to continue.
-            </Typography>
-            <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
-              Pick the household name your members will see and the immutable
-              slug used in URLs and inbound email addresses.
-            </Typography>
+    <PublicEntryShell
+      eyebrow="Create your household"
+      title="You need a household to continue."
+      description="Pick the household name your members will see and the immutable slug used in URLs and inbound email addresses."
+    >
+      <Box component="form" onSubmit={handleSubmit} noValidate>
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          label="Household name"
+          value={formState.displayName}
+          onChange={(e) =>
+            setFormState((current) => ({
+              ...current,
+              displayName: e.target.value,
+            }))
+          }
+        />
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          label="Household slug"
+          helperText="Lowercase letters, numbers, and hyphens only. This cannot be changed later."
+          value={formState.slug}
+          onChange={(e) =>
+            setFormState((current) => ({
+              ...current,
+              slug: e.target.value.toLowerCase(),
+            }))
+          }
+          sx={{ mb: 3 }}
+        />
 
-            <Box component="form" onSubmit={handleSubmit} noValidate>
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                label="Household name"
-                value={formState.displayName}
-                onChange={(e) =>
-                  setFormState((current) => ({
-                    ...current,
-                    displayName: e.target.value,
-                  }))
-                }
-              />
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                label="Household slug"
-                helperText="Lowercase letters, numbers, and hyphens only. This cannot be changed later."
-                value={formState.slug}
-                onChange={(e) =>
-                  setFormState((current) => ({
-                    ...current,
-                    slug: e.target.value.toLowerCase(),
-                  }))
-                }
-                sx={{ mb: 3 }}
-              />
+        {error && (
+          <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
+            {error}
+          </Alert>
+        )}
 
-              {error && (
-                <Alert severity="error" sx={{ mb: 3 }}>
-                  {error}
-                </Alert>
-              )}
-
-              <Button
-                type="submit"
-                fullWidth
-                variant="contained"
-                size="large"
-                disabled={
-                  isCreating ||
-                  !formState.displayName.trim() ||
-                  !formState.slug.trim()
-                }
-                sx={{ py: 1.5 }}
-              >
-                {isCreating ? "Creating household…" : "Create household"}
-              </Button>
-            </Box>
-          </CardContent>
-        </Card>
+        <Button
+          type="submit"
+          fullWidth
+          variant="contained"
+          size="large"
+          disabled={
+            isCreating ||
+            !formState.displayName.trim() ||
+            !formState.slug.trim()
+          }
+          sx={{ py: 1.5 }}
+        >
+          {isCreating ? "Creating household…" : "Create household"}
+        </Button>
       </Box>
-    </Container>
+    </PublicEntryShell>
   );
 }

--- a/src/client/components/InboxView.tsx
+++ b/src/client/components/InboxView.tsx
@@ -122,13 +122,13 @@ export function InboxView({
     <Box
       sx={{
         display: "flex",
-        flexDirection: { xs: "column", md: "row" },
+        flexDirection: { xs: "column", lg: "row" },
         gap: 3,
         height: "100%",
       }}
     >
       {/* Providers Column */}
-      <Box sx={{ width: { xs: "100%", md: 320 }, flexShrink: 0 }}>
+      <Box sx={{ width: { xs: "100%", lg: 320 }, flexShrink: 0, minWidth: 0 }}>
         <Typography
           variant="overline"
           color="text.secondary"
@@ -171,6 +171,7 @@ export function InboxView({
                               alignItems: "center",
                               gap: 2,
                               mb: 0.5,
+                              minWidth: 0,
                             }}
                           >
                             <Badge
@@ -200,6 +201,10 @@ export function InboxView({
                                 color: isSelected
                                   ? "primary.main"
                                   : "text.primary",
+                                minWidth: 0,
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                                whiteSpace: "nowrap",
                               }}
                             >
                               {provider.display_name}
@@ -211,6 +216,8 @@ export function InboxView({
                             sx={{
                               display: "flex",
                               justifyContent: "space-between",
+                              gap: 1,
+                              flexWrap: "wrap",
                               color: "text.secondary",
                             }}
                           >
@@ -252,7 +259,7 @@ export function InboxView({
       </Box>
 
       {/* Messages Column */}
-      <Box sx={{ width: { xs: "100%", md: 360 }, flexShrink: 0 }}>
+      <Box sx={{ width: { xs: "100%", lg: 360 }, flexShrink: 0, minWidth: 0 }}>
         <Typography
           variant="overline"
           color="text.secondary"
@@ -272,7 +279,11 @@ export function InboxView({
             {selectedProvider?.display_name ?? "Choose a provider"}
           </Typography>
           {selectedProvider && (
-            <Typography variant="body2" color="text.secondary">
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ flexShrink: 0 }}
+            >
               {messages.length} messages
             </Typography>
           )}
@@ -298,17 +309,21 @@ export function InboxView({
                             sx={{
                               display: "flex",
                               justifyContent: "space-between",
+                              alignItems: "flex-start",
+                              gap: 1,
                               mb: 0.5,
                             }}
                           >
                             <Typography
                               variant="subtitle2"
                               sx={{
+                                flex: 1,
+                                minWidth: 0,
                                 fontWeight: isSelected ? "bold" : "medium",
                                 overflow: "hidden",
                                 textOverflow: "ellipsis",
                                 whiteSpace: "nowrap",
-                                pr: 1,
+                                pr: 0.5,
                               }}
                             >
                               {message.subject ?? "Untitled message"}
@@ -403,9 +418,11 @@ export function InboxView({
                 display: "flex",
                 justifyContent: "space-between",
                 alignItems: "flex-start",
+                flexDirection: { xs: "column", sm: "row" },
+                gap: 1.5,
               }}
             >
-              <Box>
+              <Box sx={{ minWidth: 0 }}>
                 <Typography variant="h5" sx={{ fontWeight: "bold", mb: 0.5 }}>
                   {selectedMessage.subject ?? "Untitled message"}
                 </Typography>
@@ -416,6 +433,7 @@ export function InboxView({
               <Chip
                 label={selectedMessage.status}
                 color={getStatusColor(selectedMessage.status)}
+                size="small"
                 sx={{ textTransform: "capitalize", fontWeight: "bold" }}
               />
             </Box>
@@ -447,6 +465,7 @@ export function InboxView({
                 <Box
                   sx={{
                     display: "flex",
+                    flexDirection: { xs: "column", sm: "row" },
                     alignItems: "center",
                     justifyContent: "center",
                     gap: 2,
@@ -454,7 +473,12 @@ export function InboxView({
                 >
                   <Typography
                     variant="h3"
-                    sx={{ fontWeight: "bold", letterSpacing: 2 }}
+                    sx={{
+                      fontWeight: "bold",
+                      letterSpacing: { xs: 1, sm: 2 },
+                      fontSize: { xs: "2rem", sm: undefined },
+                      wordBreak: "break-word",
+                    }}
                   >
                     {selectedMessage.extracted_code ?? "No code detected"}
                   </Typography>

--- a/src/client/components/InboxView.tsx
+++ b/src/client/components/InboxView.tsx
@@ -23,6 +23,7 @@ import {
   ListItemButton,
   ListItemText,
   Paper,
+  Skeleton,
   Tooltip,
   Typography,
 } from "@mui/material";
@@ -63,6 +64,64 @@ function stringAvatar(name: string) {
     },
     children: initials.toUpperCase(),
   };
+}
+
+function getCodePreview(message: InboxMessage) {
+  if (message.extracted_code) {
+    return `Code ${message.extracted_code}`;
+  }
+
+  return "No code detected";
+}
+
+function LoadingList({ rows = 4 }: { rows?: number }) {
+  const skeletonRows = Array.from({ length: rows }, (_, rowNumber) => rowNumber + 1);
+
+  return (
+    <List disablePadding>
+      {skeletonRows.map((rowNumber) => (
+        <React.Fragment key={`loading-row-${rows}-${rowNumber}`}>
+          {rowNumber > 1 && <Divider />}
+          <ListItem sx={{ px: 1.5, py: 1.25 }}>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1.25, width: "100%" }}>
+              <Skeleton variant="circular" width={28} height={28} />
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Skeleton variant="text" width="58%" height={22} />
+                <Skeleton variant="text" width="36%" height={16} />
+              </Box>
+            </Box>
+          </ListItem>
+        </React.Fragment>
+      ))}
+    </List>
+  );
+}
+
+function LoadingDetail() {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <Paper variant="outlined" sx={{ p: 2.5, borderRadius: 2 }}>
+        <Skeleton variant="text" width={72} height={16} />
+        <Skeleton variant="text" width="52%" height={32} />
+        <Skeleton variant="text" width="42%" height={22} />
+        <Box sx={{ display: "flex", gap: 0.75, flexWrap: "wrap", mt: 1.25 }}>
+          <Skeleton variant="rounded" width={76} height={24} />
+          <Skeleton variant="rounded" width={96} height={24} />
+          <Skeleton variant="rounded" width={150} height={24} />
+        </Box>
+      </Paper>
+      <Card elevation={0} sx={{ borderRadius: 2 }}>
+        <CardContent sx={{ p: 2.5 }}>
+          <Skeleton variant="text" width={112} height={16} />
+          <Skeleton variant="text" width="42%" height={40} />
+        </CardContent>
+      </Card>
+      <Paper variant="outlined" sx={{ p: 2.5, borderRadius: 2 }}>
+        <Skeleton variant="text" width={132} height={20} />
+        <Skeleton variant="rounded" width="100%" height={120} />
+      </Paper>
+    </Box>
+  );
 }
 
 interface InboxViewProps {
@@ -123,35 +182,94 @@ export function InboxView({
       sx={{
         display: "flex",
         flexDirection: { xs: "column", lg: "row" },
-        gap: 3,
+        gap: 2,
         height: "100%",
       }}
     >
-      {/* Providers Column */}
-      <Box sx={{ width: { xs: "100%", lg: 320 }, flexShrink: 0, minWidth: 0 }}>
-        <Typography
-          variant="overline"
-          color="text.secondary"
-          sx={{ fontWeight: "bold" }}
-        >
-          Providers
-        </Typography>
+      {/* Inboxes Column */}
+      <Box
+        sx={{
+          width: { xs: "100%", lg: 280 },
+          flexShrink: 0,
+          minWidth: 0,
+          order: { xs: selectedMessage ? 3 : 1, lg: 1 },
+        }}
+      >
         <Box
           sx={{
             display: "flex",
             justifyContent: "space-between",
-            alignItems: "baseline",
-            mb: 2,
+            alignItems: "center",
+            mb: 1.5,
+            gap: 1,
           }}
         >
-          <Typography variant="h5" component="h2" sx={{ fontWeight: "bold" }}>
-            Your accessible groups
-          </Typography>
+          <Box sx={{ minWidth: 0 }}>
+            <Typography
+              variant="overline"
+              color="text.secondary"
+              sx={{ fontWeight: "bold", lineHeight: 1.2 }}
+            >
+              Inboxes
+            </Typography>
+            <Typography variant="h6" component="h2" sx={{ fontWeight: "bold" }}>
+              Your accessible inboxes
+            </Typography>
+          </Box>
+          <Chip
+            size="small"
+            label={`${providers.length} total`}
+            variant="outlined"
+            sx={{ flexShrink: 0 }}
+          />
         </Box>
 
-        <Paper variant="outlined" sx={{ borderRadius: 2, overflow: "hidden" }}>
-          <List disablePadding>
-            {providers.map((provider, index) => {
+        <Box
+          sx={{
+            display: { xs: "flex", lg: "none" },
+            gap: 1,
+            overflowX: "auto",
+            pb: 0.5,
+            scrollbarWidth: "none",
+            "&::-webkit-scrollbar": { display: "none" },
+          }}
+        >
+          {providers.map((provider) => {
+            const isSelected = provider.provider_key === selectedProviderKey;
+
+            return (
+              <Chip
+                key={provider.provider_key}
+                clickable
+                onClick={() => onSelectProvider(provider.provider_key)}
+                color={isSelected ? "primary" : "default"}
+                variant={isSelected ? "filled" : "outlined"}
+                label={`${provider.display_name}${provider.new_count > 0 ? ` (${provider.new_count})` : ""}`}
+                sx={{ flexShrink: 0, maxWidth: 220 }}
+              />
+            );
+          })}
+
+          {!providers.length && !isLoadingInbox && (
+            <Typography variant="body2" color="text.secondary">
+              No inboxes yet.
+            </Typography>
+          )}
+        </Box>
+
+        <Paper
+          variant="outlined"
+          sx={{
+            borderRadius: 2,
+            overflow: "hidden",
+            display: { xs: "none", lg: "block" },
+          }}
+        >
+          {isLoadingInbox ? (
+            <LoadingList rows={5} />
+          ) : (
+            <List disablePadding>
+              {providers.map((provider, index) => {
               const isSelected = provider.provider_key === selectedProviderKey;
 
               return (
@@ -161,7 +279,15 @@ export function InboxView({
                     <ListItemButton
                       selected={isSelected}
                       onClick={() => onSelectProvider(provider.provider_key)}
-                      sx={{ py: 2 }}
+                      sx={{
+                        px: 1.5,
+                        py: 1.25,
+                        alignItems: "stretch",
+                        borderLeft: 3,
+                        borderColor: isSelected ? "primary.main" : "transparent",
+                        bgcolor: isSelected ? "action.selected" : "transparent",
+                        transition: "background-color 0.2s ease, border-color 0.2s ease",
+                      }}
                     >
                       <ListItemText
                         primary={
@@ -169,8 +295,7 @@ export function InboxView({
                             sx={{
                               display: "flex",
                               alignItems: "center",
-                              gap: 2,
-                              mb: 0.5,
+                              gap: 1.25,
                               minWidth: 0,
                             }}
                           >
@@ -181,6 +306,8 @@ export function InboxView({
                               sx={{
                                 "& .MuiBadge-badge": {
                                   fontWeight: "bold",
+                                  minWidth: 18,
+                                  height: 18,
                                 },
                               }}
                             >
@@ -188,110 +315,143 @@ export function InboxView({
                                 {...stringAvatar(provider.display_name)}
                                 sx={{
                                   ...stringAvatar(provider.display_name).sx,
-                                  width: 32,
-                                  height: 32,
-                                  fontSize: "0.875rem",
+                                  width: 28,
+                                  height: 28,
+                                  fontSize: "0.75rem",
                                 }}
                               />
                             </Badge>
-                            <Typography
-                              variant="subtitle1"
-                              sx={{
-                                fontWeight: isSelected ? "bold" : "medium",
-                                color: isSelected
-                                  ? "primary.main"
-                                  : "text.primary",
-                                minWidth: 0,
-                                overflow: "hidden",
-                                textOverflow: "ellipsis",
-                                whiteSpace: "nowrap",
-                              }}
-                            >
-                              {provider.display_name}
-                            </Typography>
+                            <Box sx={{ minWidth: 0, flex: 1 }}>
+                              <Typography
+                                variant="subtitle2"
+                                sx={{
+                                  fontWeight: isSelected ? "bold" : 600,
+                                  color: isSelected
+                                    ? "primary.main"
+                                    : "text.primary",
+                                  minWidth: 0,
+                                  overflow: "hidden",
+                                  textOverflow: "ellipsis",
+                                  whiteSpace: "nowrap",
+                                }}
+                              >
+                                {provider.display_name}
+                              </Typography>
+                              <Box
+                                sx={{
+                                  display: "flex",
+                                  alignItems: "center",
+                                  gap: 1,
+                                  mt: 0.25,
+                                  flexWrap: "wrap",
+                                }}
+                              >
+                                <Typography variant="caption" color="text.secondary">
+                                  {provider.message_count} messages
+                                </Typography>
+                                {provider.new_count > 0 && (
+                                  <Chip
+                                    label={`${provider.new_count} new`}
+                                    size="small"
+                                    color="primary"
+                                    variant="outlined"
+                                    sx={{ height: 18 }}
+                                  />
+                                )}
+                              </Box>
+                            </Box>
                           </Box>
                         }
                         secondary={
-                          <Box
-                            sx={{
-                              display: "flex",
-                              justifyContent: "space-between",
-                              gap: 1,
-                              flexWrap: "wrap",
-                              color: "text.secondary",
-                            }}
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{ display: "block", mt: 0.75 }}
                           >
-                            <Typography variant="body2">
-                              {formatTimestamp(provider.latest_received_at)}
-                            </Typography>
-                            <Typography variant="body2">
-                              {provider.message_count} total
-                            </Typography>
-                          </Box>
+                            Latest {formatTimestamp(provider.latest_received_at)}
+                          </Typography>
                         }
                       />
                     </ListItemButton>
                   </ListItem>
                 </React.Fragment>
               );
-            })}
+              })}
 
-            {!providers.length && !isLoadingInbox && (
-              <Box sx={{ p: 4, textAlign: "center" }}>
-                <InboxOutlined
-                  sx={{ fontSize: 48, color: "text.disabled", mb: 2 }}
-                />
-                <Typography
-                  variant="subtitle1"
-                  sx={{ fontWeight: "bold" }}
-                  gutterBottom
-                >
-                  No providers yet
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  Once messages arrive for your household services, they’ll
-                  appear here.
-                </Typography>
-              </Box>
-            )}
-          </List>
+              {!providers.length && (
+                <Box sx={{ p: 3, textAlign: "center" }}>
+                  <InboxOutlined
+                    sx={{ fontSize: 40, color: "text.disabled", mb: 1.5 }}
+                  />
+                  <Typography
+                    variant="subtitle1"
+                    sx={{ fontWeight: "bold" }}
+                    gutterBottom
+                  >
+                    No inboxes yet
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Once messages arrive for your household services, they&apos;ll
+                    appear here.
+                  </Typography>
+                </Box>
+              )}
+            </List>
+          )}
         </Paper>
       </Box>
 
       {/* Messages Column */}
-      <Box sx={{ width: { xs: "100%", lg: 360 }, flexShrink: 0, minWidth: 0 }}>
-        <Typography
-          variant="overline"
-          color="text.secondary"
-          sx={{ fontWeight: "bold" }}
-        >
-          Inbox
-        </Typography>
+      <Box
+        sx={{
+          width: { xs: "100%", lg: 320 },
+          flexShrink: 0,
+          minWidth: 0,
+          order: { xs: 2, lg: 2 },
+        }}
+      >
         <Box
           sx={{
             display: "flex",
             justifyContent: "space-between",
-            alignItems: "baseline",
-            mb: 2,
+            alignItems: "center",
+            mb: 1.5,
+            gap: 1,
           }}
         >
-          <Typography variant="h5" component="h2" sx={{ fontWeight: "bold" }}>
-            {selectedProvider?.display_name ?? "Choose a provider"}
-          </Typography>
-          {selectedProvider && (
+          <Box sx={{ minWidth: 0 }}>
             <Typography
-              variant="body2"
+              variant="overline"
               color="text.secondary"
-              sx={{ flexShrink: 0 }}
+              sx={{ fontWeight: "bold", lineHeight: 1.2 }}
             >
-              {messages.length} messages
+              Messages
             </Typography>
+            <Typography
+              variant="h6"
+              component="h2"
+              sx={{ fontWeight: "bold" }}
+              noWrap
+            >
+              {selectedProvider?.display_name ?? "Choose an inbox"}
+            </Typography>
+          </Box>
+          {selectedProvider && (
+            <Chip
+              label={`${messages.length} total`}
+              size="small"
+              variant="outlined"
+              sx={{ flexShrink: 0 }}
+            />
           )}
         </Box>
 
         <Paper variant="outlined" sx={{ borderRadius: 2, overflow: "hidden" }}>
-          <List disablePadding>
-            {messages.map((message, index) => {
+          {isLoadingInbox ? (
+            <LoadingList rows={6} />
+          ) : (
+            <List disablePadding>
+              {messages.map((message, index) => {
               const isSelected = message.id === selectedMessageId;
 
               return (
@@ -301,15 +461,23 @@ export function InboxView({
                     <ListItemButton
                       selected={isSelected}
                       onClick={() => onSelectMessage(message.id)}
-                      sx={{ py: 2 }}
+                      sx={{
+                        px: 1.5,
+                        py: 1.25,
+                        alignItems: "stretch",
+                        borderLeft: 3,
+                        borderColor: isSelected ? "primary.main" : "transparent",
+                        bgcolor: isSelected ? "action.selected" : "transparent",
+                        transition: "background-color 0.2s ease, border-color 0.2s ease",
+                      }}
                     >
                       <ListItemText
                         primary={
                           <Box
                             sx={{
                               display: "flex",
-                              justifyContent: "space-between",
                               alignItems: "flex-start",
+                              justifyContent: "space-between",
                               gap: 1,
                               mb: 0.5,
                             }}
@@ -319,26 +487,26 @@ export function InboxView({
                               sx={{
                                 flex: 1,
                                 minWidth: 0,
-                                fontWeight: isSelected ? "bold" : "medium",
+                                fontWeight: isSelected ? "bold" : 600,
+                                color: isSelected ? "primary.main" : "text.primary",
                                 overflow: "hidden",
                                 textOverflow: "ellipsis",
                                 whiteSpace: "nowrap",
-                                pr: 0.5,
                               }}
                             >
                               {message.subject ?? "Untitled message"}
                             </Typography>
-                            <Chip
-                              label={message.status}
-                              size="small"
-                              color={getStatusColor(message.status)}
-                              variant="outlined"
-                              sx={{ textTransform: "capitalize", height: 20 }}
-                            />
+                            <Typography
+                              variant="caption"
+                              color="text.secondary"
+                              sx={{ flexShrink: 0, pl: 1 }}
+                            >
+                              {formatTimestamp(message.received_at)}
+                            </Typography>
                           </Box>
                         }
                         secondary={
-                          <>
+                          <Box>
                             <Typography
                               variant="body2"
                               color="text.secondary"
@@ -350,93 +518,125 @@ export function InboxView({
                             >
                               {message.from_header ?? "Unknown sender"}
                             </Typography>
-                            <Typography
-                              variant="caption"
-                              color="text.disabled"
+                            <Box
                               sx={{
-                                mt: 0.5,
                                 display: "flex",
                                 alignItems: "center",
-                                gap: 0.5,
+                                gap: 0.75,
+                                mt: 0.75,
+                                flexWrap: "wrap",
                               }}
                             >
-                              <ScheduleOutlined sx={{ fontSize: 14 }} />
-                              {formatTimestamp(message.received_at)}
-                            </Typography>
-                          </>
+                              <Chip
+                                label={message.status}
+                                size="small"
+                                color={getStatusColor(message.status)}
+                                variant="outlined"
+                                sx={{ textTransform: "capitalize", height: 20 }}
+                              />
+                              <Typography variant="caption" color="text.secondary">
+                                {getCodePreview(message)}
+                              </Typography>
+                            </Box>
+                          </Box>
                         }
                       />
                     </ListItemButton>
                   </ListItem>
                 </React.Fragment>
               );
-            })}
+              })}
 
-            {!messages.length && !isLoadingInbox && (
-              <Box sx={{ p: 4, textAlign: "center" }}>
-                <MailOutlined
-                  sx={{ fontSize: 48, color: "text.disabled", mb: 2 }}
-                />
-                <Typography
-                  variant="subtitle1"
-                  sx={{ fontWeight: "bold" }}
-                  gutterBottom
-                >
-                  No messages here yet
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  Select another provider or wait for the next verification
-                  email.
-                </Typography>
-              </Box>
-            )}
-          </List>
+              {!messages.length && (
+                <Box sx={{ p: 3, textAlign: "center" }}>
+                  <MailOutlined
+                    sx={{ fontSize: 40, color: "text.disabled", mb: 1.5 }}
+                  />
+                  <Typography
+                    variant="subtitle1"
+                    sx={{ fontWeight: "bold" }}
+                    gutterBottom
+                  >
+                    {selectedProvider ? "No messages here yet" : "Choose an inbox"}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {selectedProvider
+                      ? "This inbox is ready for the next verification email."
+                      : "Pick an inbox to browse recent verification messages."}
+                  </Typography>
+                </Box>
+              )}
+            </List>
+          )}
         </Paper>
       </Box>
 
       {/* Message Detail Column */}
-      <Box sx={{ flexGrow: 1, minWidth: 0 }}>
-        <Typography
-          variant="overline"
-          color="text.secondary"
-          sx={{ fontWeight: "bold" }}
-        >
-          Message Detail
-        </Typography>
-        <Typography
-          variant="h5"
-          component="h2"
-          sx={{ fontWeight: "bold", mb: 2, visibility: "hidden" }}
-        >
-          Detail
-        </Typography>
-
-        {selectedMessage ? (
-          <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-            <Box
-              sx={{
-                display: "flex",
-                justifyContent: "space-between",
-                alignItems: "flex-start",
-                flexDirection: { xs: "column", sm: "row" },
-                gap: 1.5,
-              }}
-            >
-              <Box sx={{ minWidth: 0 }}>
-                <Typography variant="h5" sx={{ fontWeight: "bold", mb: 0.5 }}>
-                  {selectedMessage.subject ?? "Untitled message"}
-                </Typography>
-                <Typography variant="body1" color="text.secondary">
-                  {selectedMessage.from_header ?? "Unknown sender"}
-                </Typography>
+      <Box
+        sx={{
+          flexGrow: 1,
+          minWidth: 0,
+          order: { xs: selectedMessage ? 1 : 3, lg: 3 },
+        }}
+      >
+        {isLoadingInbox ? (
+          <LoadingDetail />
+        ) : selectedMessage ? (
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <Paper variant="outlined" sx={{ p: 2.5, borderRadius: 2 }}>
+              <Box
+                sx={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "flex-start",
+                  flexDirection: { xs: "column", sm: "row" },
+                  gap: 1.5,
+                }}
+              >
+                <Box sx={{ minWidth: 0 }}>
+                  <Typography
+                    variant="overline"
+                    color="text.secondary"
+                    sx={{ fontWeight: "bold", lineHeight: 1.2 }}
+                  >
+                    Details
+                  </Typography>
+                  <Typography variant="h6" sx={{ fontWeight: "bold", mb: 0.5 }}>
+                    {selectedMessage.subject ?? "Untitled message"}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {selectedMessage.from_header ?? "Unknown sender"}
+                  </Typography>
+                  <Box
+                    sx={{
+                      display: "flex",
+                      flexWrap: "wrap",
+                      gap: 0.75,
+                      mt: 1.25,
+                    }}
+                  >
+                    <Chip
+                      label={selectedMessage.status}
+                      size="small"
+                      color={getStatusColor(selectedMessage.status)}
+                      variant="outlined"
+                      sx={{ textTransform: "capitalize" }}
+                    />
+                    <Chip
+                      label={selectedProvider?.display_name ?? "Inbox"}
+                      size="small"
+                      variant="outlined"
+                    />
+                    <Chip
+                      label={formatTimestamp(selectedMessage.received_at)}
+                      size="small"
+                      variant="outlined"
+                      icon={<ScheduleOutlined sx={{ fontSize: 14 }} />}
+                    />
+                  </Box>
+                </Box>
               </Box>
-              <Chip
-                label={selectedMessage.status}
-                color={getStatusColor(selectedMessage.status)}
-                size="small"
-                sx={{ textTransform: "capitalize", fontWeight: "bold" }}
-              />
-            </Box>
+            </Paper>
 
             <Card
               elevation={0}
@@ -448,14 +648,12 @@ export function InboxView({
                 color: "primary.contrastText",
               }}
             >
-              <CardContent
-                sx={{ p: 4, textAlign: "center", position: "relative" }}
-              >
+              <CardContent sx={{ p: 2.5 }}>
                 <Typography
                   variant="overline"
                   sx={{
                     display: "block",
-                    mb: 1,
+                    mb: 0.75,
                     fontWeight: "bold",
                     opacity: 0.9,
                   }}
@@ -466,17 +664,16 @@ export function InboxView({
                   sx={{
                     display: "flex",
                     flexDirection: { xs: "column", sm: "row" },
-                    alignItems: "center",
-                    justifyContent: "center",
-                    gap: 2,
+                    alignItems: { xs: "flex-start", sm: "center" },
+                    justifyContent: "space-between",
+                    gap: 1.5,
                   }}
                 >
                   <Typography
-                    variant="h3"
+                    variant="h4"
                     sx={{
                       fontWeight: "bold",
                       letterSpacing: { xs: 1, sm: 2 },
-                      fontSize: { xs: "2rem", sm: undefined },
                       wordBreak: "break-word",
                     }}
                   >
@@ -518,37 +715,43 @@ export function InboxView({
               </CardContent>
             </Card>
 
-            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
               <Button
                 variant="outlined"
+                size="small"
                 disabled={isSavingMessage}
                 onClick={() => onStatusChange("new")}
                 startIcon={<EmailOutlined />}
+                sx={{ width: { xs: "100%", sm: "auto" } }}
               >
                 Mark new
               </Button>
               <Button
                 variant="outlined"
+                size="small"
                 disabled={isSavingMessage}
                 onClick={() => onStatusChange("used")}
                 startIcon={<MarkEmailReadOutlined />}
+                sx={{ width: { xs: "100%", sm: "auto" } }}
               >
                 Mark used
               </Button>
               <Button
                 variant="outlined"
+                size="small"
                 disabled={isSavingMessage}
                 onClick={() => onStatusChange("expired")}
                 startIcon={<HistoryOutlined />}
+                sx={{ width: { xs: "100%", sm: "auto" } }}
               >
                 Mark expired
               </Button>
             </Box>
 
-            <Paper variant="outlined" sx={{ p: 3, borderRadius: 2 }}>
+            <Paper variant="outlined" sx={{ p: 2.5, borderRadius: 2 }}>
               <Typography
                 variant="subtitle2"
-                sx={{ mb: 2, fontWeight: "bold" }}
+                sx={{ mb: 1.5, fontWeight: "bold" }}
               >
                 Plain-text message
               </Typography>
@@ -560,6 +763,7 @@ export function InboxView({
                   wordBreak: "break-word",
                   fontFamily: "monospace",
                   fontSize: "0.875rem",
+                  lineHeight: 1.55,
                 }}
               >
                 {selectedMessage.text_body}
@@ -570,21 +774,22 @@ export function InboxView({
           <Paper
             variant="outlined"
             sx={{
-              p: 6,
+              p: 5,
               textAlign: "center",
               borderRadius: 2,
               borderStyle: "dashed",
             }}
           >
             <EmailOutlined
-              sx={{ fontSize: 64, color: "text.disabled", mb: 2 }}
+              sx={{ fontSize: 56, color: "text.disabled", mb: 2 }}
             />
             <Typography variant="h6" sx={{ fontWeight: "bold", mb: 1 }}>
-              Select a message
+              {selectedProvider ? "Select a message" : "No message selected"}
             </Typography>
             <Typography variant="body1" color="text.secondary">
-              Pick the most recent message in a provider group to see the full
-              code and body.
+              {selectedProvider
+                ? "Pick a message to see the code, metadata, and full plain-text body."
+                : "Choose an inbox first, then select a message to review its verification details."}
             </Typography>
           </Paper>
         )}

--- a/src/client/components/InvitePage.tsx
+++ b/src/client/components/InvitePage.tsx
@@ -2,10 +2,7 @@ import {
   Alert,
   Box,
   Button,
-  Card,
-  CardContent,
   CircularProgress,
-  Container,
   TextField,
   Typography,
 } from "@mui/material";
@@ -13,6 +10,7 @@ import { type FormEvent, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type { InvitationAcceptanceState, InvitationSummary } from "../types";
 import { fetchJson } from "../utils";
+import { PublicEntryShell } from "./PublicEntryShell";
 
 interface InvitePageProps {
   token: string;
@@ -121,34 +119,24 @@ export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
 
   if (error && !invitation) {
     return (
-      <Container component="main" maxWidth="sm">
-        <Box
-          sx={{
-            minHeight: "100vh",
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "center",
-            py: 4,
+      <PublicEntryShell
+        eyebrow="Mi Casa Su Casa"
+        title="This invitation is not available."
+        description="The invite may have expired, already been accepted, or the link may be invalid."
+      >
+        <Alert severity="error" sx={{ mb: 2, borderRadius: 2 }}>
+          {error}
+        </Alert>
+        <Button
+          variant="outlined"
+          fullWidth
+          onClick={() => {
+            navigate("/login", { replace: true });
           }}
         >
-          <Card elevation={3} sx={{ borderRadius: 3 }}>
-            <CardContent sx={{ p: 4 }}>
-              <Alert severity="error" sx={{ mb: 2 }}>
-                {error}
-              </Alert>
-              <Button
-                variant="outlined"
-                fullWidth
-                onClick={() => {
-                  navigate("/login", { replace: true });
-                }}
-              >
-                Return to Login
-              </Button>
-            </CardContent>
-          </Card>
-        </Box>
-      </Container>
+          Return to Login
+        </Button>
+      </PublicEntryShell>
     );
   }
 
@@ -157,109 +145,81 @@ export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
   }
 
   return (
-    <Container component="main" maxWidth="sm">
-      <Box
-        sx={{
-          minHeight: "100vh",
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "center",
-          py: 4,
-        }}
-      >
-        <Card elevation={3} sx={{ borderRadius: 3 }}>
-          <CardContent sx={{ p: 4 }}>
-            <Typography
-              variant="overline"
-              color="text.secondary"
-              sx={{ fontWeight: "bold", letterSpacing: 1 }}
-            >
-              Mi Casa Su Casa
-            </Typography>
-            <Typography
-              variant="h4"
-              component="h1"
-              gutterBottom
-              sx={{ mt: 1, fontWeight: "bold" }}
-            >
-              Accept Invitation
-            </Typography>
-            <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
-              You have been invited to join as a{" "}
-              <strong>{invitation.role}</strong>. Please set up your account
-              details to continue.
-            </Typography>
+    <PublicEntryShell
+      eyebrow="Mi Casa Su Casa"
+      title="Accept invitation"
+      description={
+        <>
+          You have been invited to join as a <strong>{invitation.role}</strong>.
+          Set up your account details to continue.
+        </>
+      }
+    >
+      <Box component="form" onSubmit={handleAccept} noValidate>
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          label="Email Address"
+          value={invitation.email}
+          disabled
+        />
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          id="name"
+          label="Your Name"
+          name="name"
+          autoComplete="name"
+          autoFocus
+          value={formState.name}
+          onChange={(e) =>
+            setFormState((current) => ({
+              ...current,
+              name: e.target.value,
+            }))
+          }
+        />
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          name="password"
+          label="Password"
+          type="password"
+          id="password"
+          autoComplete="new-password"
+          helperText="Must be at least 12 characters."
+          value={formState.password}
+          onChange={(e) =>
+            setFormState((current) => ({
+              ...current,
+              password: e.target.value,
+            }))
+          }
+          sx={{ mb: 3 }}
+        />
 
-            <Box component="form" onSubmit={handleAccept} noValidate>
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                label="Email Address"
-                value={invitation.email}
-                disabled
-              />
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                id="name"
-                label="Your Name"
-                name="name"
-                autoComplete="name"
-                autoFocus
-                value={formState.name}
-                onChange={(e) =>
-                  setFormState((current) => ({
-                    ...current,
-                    name: e.target.value,
-                  }))
-                }
-              />
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                name="password"
-                label="Password"
-                type="password"
-                id="password"
-                autoComplete="new-password"
-                helperText="Must be at least 12 characters."
-                value={formState.password}
-                onChange={(e) =>
-                  setFormState((current) => ({
-                    ...current,
-                    password: e.target.value,
-                  }))
-                }
-                sx={{ mb: 3 }}
-              />
+        {error && (
+          <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
+            {error}
+          </Alert>
+        )}
 
-              {error && (
-                <Alert severity="error" sx={{ mb: 3 }}>
-                  {error}
-                </Alert>
-              )}
-
-              <Button
-                type="submit"
-                fullWidth
-                variant="contained"
-                size="large"
-                disabled={
-                  isAccepting ||
-                  !formState.name ||
-                  formState.password.length < 12
-                }
-                sx={{ py: 1.5 }}
-              >
-                {isAccepting ? "Accepting..." : "Accept Invitation"}
-              </Button>
-            </Box>
-          </CardContent>
-        </Card>
+        <Button
+          type="submit"
+          fullWidth
+          variant="contained"
+          size="large"
+          disabled={
+            isAccepting || !formState.name || formState.password.length < 12
+          }
+          sx={{ py: 1.5 }}
+        >
+          {isAccepting ? "Accepting…" : "Accept Invitation"}
+        </Button>
       </Box>
-    </Container>
+    </PublicEntryShell>
   );
 }

--- a/src/client/components/Layout.tsx
+++ b/src/client/components/Layout.tsx
@@ -67,8 +67,8 @@ function getActiveView(pathname: string) {
     return "members";
   }
 
-  if (pathname.includes("/providers")) {
-    return "providers";
+  if (pathname.includes("/inboxes")) {
+    return "inboxes";
   }
 
   return "inbox";
@@ -375,15 +375,15 @@ export function Layout({
 
             <ListItem disablePadding sx={{ mb: 1 }}>
               <ListItemButton
-                selected={activeView === "providers"}
+                selected={activeView === "inboxes"}
                 component={Link}
-                to={buildHouseholdPath(householdSlug, "/providers")}
+                to={buildHouseholdPath(householdSlug, "/inboxes")}
                 onClick={handleNavClick}
                 sx={{ borderRadius: 2 }}
               >
                 <ListItemIcon>
                   <HubOutlined
-                    color={activeView === "providers" ? "primary" : "inherit"}
+                    color={activeView === "inboxes" ? "primary" : "inherit"}
                   />
                 </ListItemIcon>
                 <ListItemText
@@ -391,10 +391,10 @@ export function Layout({
                     <Typography
                       sx={{
                         fontWeight:
-                          activeView === "providers" ? "bold" : "normal",
+                          activeView === "inboxes" ? "bold" : "normal",
                       }}
                     >
-                      Providers &amp; rules
+                      Inboxes &amp; rules
                     </Typography>
                   }
                 />

--- a/src/client/components/Layout.tsx
+++ b/src/client/components/Layout.tsx
@@ -16,6 +16,7 @@ import {
   Avatar,
   Box,
   ButtonBase,
+  Chip,
   Divider,
   Drawer,
   IconButton,
@@ -53,9 +54,34 @@ interface LayoutProps {
   onLogout: () => void;
 }
 
+function getActiveView(pathname: string) {
+  if (pathname === "/settings" || pathname.endsWith("/settings")) {
+    return "settings";
+  }
+
+  if (pathname.includes("/quarantine")) {
+    return "quarantine";
+  }
+
+  if (pathname.includes("/members")) {
+    return "members";
+  }
+
+  if (pathname.includes("/providers")) {
+    return "providers";
+  }
+
+  return "inbox";
+}
+
+export function isSettingsPath(pathname: string) {
+  return getActiveView(pathname) === "settings";
+}
+
 interface UserAccountMenuProps {
   session: SessionData | null | undefined;
   mode: "light" | "dark";
+  settingsPath: string;
   onSettingsClick: () => void;
   onToggleColorMode: () => void;
   onLogout: () => void;
@@ -64,6 +90,7 @@ interface UserAccountMenuProps {
 export function UserAccountMenuContent({
   session,
   mode,
+  settingsPath,
   onSettingsClick,
   onToggleColorMode,
   onLogout,
@@ -81,7 +108,7 @@ export function UserAccountMenuContent({
       <Divider />
       <MenuItem
         component={Link}
-        to="/settings"
+        to={settingsPath}
         onClick={onSettingsClick}
         sx={{ py: 1.25 }}
       >
@@ -171,16 +198,7 @@ export function Layout({
   onLogout,
 }: LayoutProps) {
   const location = useLocation();
-  const activeView =
-    location.pathname === "/settings"
-      ? "settings"
-      : location.pathname.includes("/quarantine")
-        ? "quarantine"
-        : location.pathname.includes("/members")
-          ? "members"
-          : location.pathname.includes("/providers")
-            ? "providers"
-            : "inbox";
+  const activeView = getActiveView(location.pathname);
   const theme = useTheme();
   const colorMode = useContext(ColorModeContext);
   const isDesktop = useMediaQuery(theme.breakpoints.up("lg"));
@@ -194,6 +212,7 @@ export function Layout({
   const activeHousehold =
     households.find((household) => household.slug === householdSlug) ?? null;
   const roleLabel = householdRole === "owner" ? "Owner" : "Member";
+  const settingsPath = buildHouseholdPath(householdSlug, "/settings");
   const isHouseholdMenuOpen = Boolean(householdMenuAnchor);
   const isUserMenuOpen = Boolean(userMenuAnchor);
 
@@ -431,14 +450,13 @@ export function Layout({
         >
           <Box sx={{ minWidth: 0, pr: 2 }}>
             <Typography variant="body2" sx={{ fontWeight: 700 }} noWrap>
-              {getDisplayName(session)}
-            </Typography>
-            <Typography variant="body2" color="text.secondary" noWrap>
               {householdName}
             </Typography>
-            <Typography variant="caption" color="text.secondary" noWrap>
-              {roleLabel}
-            </Typography>
+            <Chip
+              label={roleLabel}
+              size="small"
+              sx={{ mt: 0.75, fontWeight: 600, maxWidth: "100%" }}
+            />
           </Box>
           <ExpandMore color="action" />
         </ButtonBase>
@@ -556,6 +574,7 @@ export function Layout({
             anchorEl={userMenuAnchor}
             open={isUserMenuOpen}
             mode={theme.palette.mode}
+            settingsPath={settingsPath}
             onClose={handleCloseUserMenu}
             onToggleColorMode={handleToggleColorMode}
             onLogout={handleLogoutClick}

--- a/src/client/components/LoginPage.tsx
+++ b/src/client/components/LoginPage.tsx
@@ -1,16 +1,8 @@
-import {
-  Alert,
-  Box,
-  Button,
-  Card,
-  CardContent,
-  Container,
-  TextField,
-  Typography,
-} from "@mui/material";
+import { Alert, Box, Button, TextField } from "@mui/material";
 import { authClient } from "@server/auth/client";
 import { type FormEvent, useState } from "react";
 import type { LoginState, SetupStatus } from "../types";
+import { PublicEntryShell } from "./PublicEntryShell";
 
 interface LoginPageProps {
   setupStatus: SetupStatus | null;
@@ -53,102 +45,71 @@ export function LoginPage({
   };
 
   return (
-    <Container component="main" maxWidth="sm">
-      <Box
-        sx={{
-          minHeight: "100vh",
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "center",
-          py: 4,
-        }}
-      >
-        <Card elevation={3} sx={{ borderRadius: 3 }}>
-          <CardContent sx={{ p: 4 }}>
-            <Typography
-              variant="overline"
-              color="text.secondary"
-              sx={{ fontWeight: "bold", letterSpacing: 1 }}
-            >
-              Mi Casa Su Casa
-            </Typography>
-            <Typography
-              variant="h4"
-              component="h1"
-              gutterBottom
-              sx={{ mt: 1, fontWeight: "bold" }}
-            >
-              Shared verification inbox, without the chaos.
-            </Typography>
-            <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
-              Sign in with your invited household account to see the provider
-              groups you have access to and quickly find the latest verification
-              code.
-            </Typography>
+    <PublicEntryShell
+      eyebrow="Mi Casa Su Casa"
+      title="Shared verification inbox, without the chaos."
+      description="Sign in with your invited household account to see the provider groups you have access to and quickly find the latest verification code."
+    >
+      <Box component="form" onSubmit={handleLogin} noValidate>
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          id="email"
+          label="Email Address"
+          name="email"
+          autoComplete="email"
+          autoFocus
+          value={loginState.email}
+          onChange={(e) =>
+            setLoginState((current) => ({
+              ...current,
+              email: e.target.value,
+            }))
+          }
+        />
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          name="password"
+          label="Password"
+          type="password"
+          id="password"
+          autoComplete="current-password"
+          value={loginState.password}
+          onChange={(e) =>
+            setLoginState((current) => ({
+              ...current,
+              password: e.target.value,
+            }))
+          }
+          sx={{ mb: 3 }}
+        />
 
-            <Box component="form" onSubmit={handleLogin} noValidate>
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                id="email"
-                label="Email Address"
-                name="email"
-                autoComplete="email"
-                autoFocus
-                value={loginState.email}
-                onChange={(e) =>
-                  setLoginState((current) => ({
-                    ...current,
-                    email: e.target.value,
-                  }))
-                }
-              />
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                name="password"
-                label="Password"
-                type="password"
-                id="password"
-                autoComplete="current-password"
-                value={loginState.password}
-                onChange={(e) =>
-                  setLoginState((current) => ({
-                    ...current,
-                    password: e.target.value,
-                  }))
-                }
-                sx={{ mb: 3 }}
-              />
+        {loginError && (
+          <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
+            {loginError}
+          </Alert>
+        )}
 
-              {loginError && (
-                <Alert severity="error" sx={{ mb: 3 }}>
-                  {loginError}
-                </Alert>
-              )}
+        {setupError && !setupStatus?.isConfigured && (
+          <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
+            {setupError}
+          </Alert>
+        )}
 
-              {setupError && !setupStatus?.isConfigured && (
-                <Alert severity="error" sx={{ mb: 3 }}>
-                  {setupError}
-                </Alert>
-              )}
-
-              <Button
-                type="submit"
-                fullWidth
-                variant="contained"
-                size="large"
-                disabled={isLoggingIn}
-                sx={{ py: 1.5 }}
-              >
-                {isLoggingIn ? "Signing in…" : "Sign in"}
-              </Button>
-            </Box>
-          </CardContent>
-        </Card>
+        <Button
+          type="submit"
+          fullWidth
+          variant="contained"
+          size="large"
+          disabled={isLoggingIn}
+          sx={{ py: 1.5 }}
+        >
+          {isLoggingIn ? "Signing in…" : "Sign in"}
+        </Button>
       </Box>
-    </Container>
+    </PublicEntryShell>
   );
 }

--- a/src/client/components/MembersView.tsx
+++ b/src/client/components/MembersView.tsx
@@ -207,7 +207,9 @@ export function MembersView({
           }
           title="Household member actions"
           subheader="Open a focused flow when you need to add or invite someone"
-          titleTypographyProps={{ variant: "h6", fontWeight: "bold" }}
+          slotProps={{
+            title: { variant: "h6", fontWeight: "bold" },
+          }}
         />
         <Divider />
         <CardContent>
@@ -461,7 +463,9 @@ export function MembersView({
           }
           title="Pending and recent invitations"
           subheader="Track invitation status and resend or cancel pending links"
-          titleTypographyProps={{ variant: "h6", fontWeight: "bold" }}
+          slotProps={{
+            title: { variant: "h6", fontWeight: "bold" },
+          }}
         />
         <Divider />
         <CardContent>
@@ -571,26 +575,166 @@ export function MembersView({
       <Box
         sx={{
           display: "flex",
-          flexDirection: { xs: "column", md: "row" },
+          flexDirection: { xs: "column", lg: "row" },
           gap: 3,
           flexGrow: 1,
           minHeight: 0,
           alignItems: "flex-start",
         }}
       >
+        <Stack
+          spacing={2}
+          sx={{ display: { xs: "flex", md: "none" }, width: "100%" }}
+        >
+          {members.map((member) => {
+            const isSelected = member.id === selectedMemberId;
+
+            return (
+              <Card
+                key={member.id}
+                variant="outlined"
+                onClick={() => onSelectMember(member.id)}
+                sx={{
+                  width: "100%",
+                  borderRadius: 2,
+                  cursor: "pointer",
+                  borderColor: isSelected ? "primary.main" : "divider",
+                  boxShadow: isSelected ? 3 : undefined,
+                }}
+              >
+                <CardContent sx={{ p: 2.5 }}>
+                  <Stack spacing={2}>
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "flex-start",
+                        justifyContent: "space-between",
+                        gap: 2,
+                      }}
+                    >
+                      <Box
+                        sx={{ display: "flex", alignItems: "center", gap: 2 }}
+                      >
+                        <Badge
+                          overlap="circular"
+                          anchorOrigin={{
+                            vertical: "bottom",
+                            horizontal: "right",
+                          }}
+                          badgeContent={
+                            member.role === "admin" ? (
+                              <Tooltip title="Household Owner" placement="top">
+                                <AdminPanelSettingsOutlined
+                                  sx={{
+                                    fontSize: 16,
+                                    color: "primary.main",
+                                    bgcolor: "background.paper",
+                                    borderRadius: "50%",
+                                  }}
+                                />
+                              </Tooltip>
+                            ) : null
+                          }
+                        >
+                          <Avatar {...stringAvatar(member.name)} />
+                        </Badge>
+                        <Box sx={{ minWidth: 0 }}>
+                          <Typography
+                            variant="subtitle1"
+                            sx={{ fontWeight: "bold" }}
+                          >
+                            {member.name}
+                          </Typography>
+                          <Typography
+                            variant="body2"
+                            color="text.secondary"
+                            sx={{ wordBreak: "break-word" }}
+                          >
+                            {member.email}
+                          </Typography>
+                        </Box>
+                      </Box>
+                      <ChevronRightOutlined
+                        color={isSelected ? "primary" : "inherit"}
+                      />
+                    </Box>
+
+                    <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+                      <Chip
+                        label={member.role === "admin" ? "Owner" : "Member"}
+                        color={member.role === "admin" ? "primary" : "default"}
+                        size="small"
+                        sx={{ fontWeight: "bold" }}
+                      />
+                      {member.providerAccess.length === 0 ? (
+                        <Chip
+                          label="No provider access"
+                          size="small"
+                          variant="outlined"
+                        />
+                      ) : (
+                        member.providerAccess.slice(0, 2).map((access) => {
+                          return (
+                            <Chip
+                              key={access.providerKey}
+                              label={access.displayName}
+                              size="small"
+                              variant="outlined"
+                            />
+                          );
+                        })
+                      )}
+                      {member.providerAccess.length > 2 && (
+                        <Chip
+                          label={`+${member.providerAccess.length - 2} more`}
+                          size="small"
+                          variant="outlined"
+                        />
+                      )}
+                    </Box>
+                  </Stack>
+                </CardContent>
+              </Card>
+            );
+          })}
+
+          {!members.length && !isLoadingMembers && (
+            <Card variant="outlined" sx={{ borderRadius: 2 }}>
+              <CardContent sx={{ py: 6, textAlign: "center" }}>
+                <GroupOutlined
+                  sx={{ fontSize: 48, color: "text.disabled", mb: 2 }}
+                />
+                <Typography
+                  variant="subtitle1"
+                  sx={{ fontWeight: "bold" }}
+                  gutterBottom
+                >
+                  No members yet
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Create the first invited household member to get started.
+                </Typography>
+              </CardContent>
+            </Card>
+          )}
+        </Stack>
+
         <TableContainer
           component={Card}
           variant="outlined"
           sx={{
+            display: { xs: "none", md: "flex" },
             flexGrow: 1,
             borderRadius: 2,
             minWidth: 0,
             overflowX: "auto",
-            display: "flex",
             flexDirection: "column",
           }}
         >
-          <Table sx={{ minWidth: 500 }} aria-label="members table">
+          <Table
+            sx={{ width: "100%", tableLayout: "fixed" }}
+            aria-label="members table"
+          >
             <TableHead sx={{ bgcolor: "background.default" }}>
               <TableRow>
                 <TableCell sx={{ fontWeight: "bold", color: "text.secondary" }}>
@@ -769,7 +913,8 @@ export function MembersView({
           <Card
             variant="outlined"
             sx={{
-              width: { xs: "100%", md: 400 },
+              width: { xs: "100%", lg: 400 },
+              maxWidth: { xs: "100%", lg: 400 },
               flexShrink: 0,
               borderRadius: 2,
               display: "flex",
@@ -802,10 +947,12 @@ export function MembersView({
                   {selectedMember.email}
                 </Box>
               }
-              titleTypographyProps={{ variant: "h6", fontWeight: "bold" }}
-              subheaderTypographyProps={{
-                variant: "body2",
-                color: "text.secondary",
+              slotProps={{
+                title: { variant: "h6", fontWeight: "bold" },
+                subheader: {
+                  variant: "body2",
+                  color: "text.secondary",
+                },
               }}
               action={
                 <Tooltip title="Send email">

--- a/src/client/components/MembersView.tsx
+++ b/src/client/components/MembersView.tsx
@@ -345,7 +345,7 @@ export function MembersView({
             <Stack spacing={3}>
               <Alert severity="info" icon={<PersonAddOutlined />}>
                 Invitations let members choose their own password and receive
-                provider access once accepted.
+                inbox access once accepted.
               </Alert>
               <Box
                 sx={{
@@ -397,13 +397,13 @@ export function MembersView({
                   sx={{ gridColumn: { md: "1 / -1" } }}
                 >
                   <InputLabel id="invite-providers-select-label">
-                    Provider Access
+                    Inbox Access
                   </InputLabel>
                   <Select
                     labelId="invite-providers-select-label"
                     multiple
                     value={invitationFormState.providerIds}
-                    label="Provider Access"
+                    label="Inbox Access"
                     onChange={(e) =>
                       onInvitationFormChange({
                         providerIds: e.target.value as string[],
@@ -413,7 +413,7 @@ export function MembersView({
                       const providerIds = selected as string[];
 
                       if (!providerIds.length) {
-                        return "No provider access yet";
+                        return "No inbox access yet";
                       }
 
                       return providerOptions
@@ -759,7 +759,7 @@ export function MembersView({
                     display: { xs: "none", md: "table-cell" },
                   }}
                 >
-                  Provider Access
+                  Inbox Access
                 </TableCell>
                 <TableCell
                   align="right"
@@ -996,7 +996,7 @@ export function MembersView({
                     color="text.secondary"
                     sx={{ mb: 2 }}
                   >
-                    Owners can invite members and configure provider access.
+                    Owners can invite members and configure inbox access.
                   </Typography>
                   <FormControl fullWidth size="small">
                     <InputLabel id="role-change-label">
@@ -1033,7 +1033,7 @@ export function MembersView({
                   }}
                 >
                   <VpnKeyOutlined fontSize="small" />
-                  Provider Access
+                  Inbox Access
                 </Typography>
                 <Card variant="outlined" sx={{ borderRadius: 2 }}>
                   <List disablePadding>

--- a/src/client/components/ProvidersRulesView.tsx
+++ b/src/client/components/ProvidersRulesView.tsx
@@ -195,7 +195,7 @@ export function ProvidersRulesView({
   const providerColumns: GridColDef<ProviderConfiguration>[] = [
     {
       field: "display_name",
-      headerName: "Provider",
+      headerName: "Inbox",
       flex: 1,
       minWidth: 180,
     },
@@ -274,8 +274,8 @@ export function ProvidersRulesView({
               <AutoAwesomeOutlined />
             </Avatar>
           }
-          title="Provider and rule setup"
-          subheader="Configure senders so codes route cleanly without owner intervention."
+          title="Inbox and rule setup"
+          subheader="Configure inboxes so codes route cleanly without owner intervention."
           slotProps={{
             title: { variant: "h6", fontWeight: "bold" },
           }}
@@ -283,14 +283,14 @@ export function ProvidersRulesView({
         <Divider />
         <CardContent>
           <Alert severity="info" sx={{ mb: 3 }} icon={<LinkOutlined />}>
-            Providers define the household service buckets. Sender rules attach
-            exact addresses or domains to those providers so inbound
+            Inboxes define the household service buckets. Sender rules attach
+            exact addresses or domains to those inboxes so inbound
             verification emails classify automatically.
           </Alert>
           <Stack spacing={2}>
             <Stack direction={{ xs: "column", md: "row" }} spacing={2}>
               <Chip
-                label={`${providers.length} providers`}
+                label={`${providers.length} inboxes`}
                 color="primary"
                 variant="outlined"
               />
@@ -306,7 +306,7 @@ export function ProvidersRulesView({
                 startIcon={<AddCircleOutlined />}
                 onClick={handleOpenCreateProvider}
               >
-                Create provider
+                Create inbox
               </Button>
               <Button
                 variant="outlined"
@@ -339,14 +339,14 @@ export function ProvidersRulesView({
               color="text.secondary"
               sx={{ fontWeight: "bold" }}
             >
-              Provider inventory
+              Inbox inventory
             </Typography>
             <Typography
               variant="h5"
               component="h2"
               sx={{ fontWeight: "bold", mb: 2 }}
             >
-              Connected providers
+              Connected inboxes
             </Typography>
             <Stack spacing={1.5} sx={{ display: { xs: "flex", md: "none" } }}>
               {providers.map((provider) => {
@@ -402,7 +402,7 @@ export function ProvidersRulesView({
                 );
               })}
               {!providers.length && (
-                <Alert severity="info">No providers configured yet.</Alert>
+                <Alert severity="info">No inboxes configured yet.</Alert>
               )}
             </Stack>
             <Box
@@ -451,7 +451,7 @@ export function ProvidersRulesView({
               >
                 {selectedProvider
                   ? `${selectedProvider.display_name} rules`
-                  : "Choose a provider"}
+                  : "Choose an inbox"}
               </Typography>
               <Typography variant="body2" color="text.secondary">
                 {providerRules.length} configured
@@ -520,8 +520,8 @@ export function ProvidersRulesView({
               {!providerRules.length && (
                 <Alert severity="info">
                   {selectedProvider
-                    ? "No sender rules configured yet for this provider."
-                    : "Choose a provider to view its rules."}
+                    ? "No sender rules configured yet for this inbox."
+                    : "Choose an inbox to view its rules."}
                 </Alert>
               )}
             </Stack>
@@ -562,8 +562,8 @@ export function ProvidersRulesView({
                   <AddCircleOutlined />
                 </Avatar>
               }
-              title="Provider actions"
-              subheader="Open a dialog to create, update, or delete a selected provider"
+              title="Inbox actions"
+              subheader="Open a dialog to create, update, or delete a selected inbox"
               slotProps={{
                 title: { variant: "h6", fontWeight: "bold" },
               }}
@@ -572,7 +572,7 @@ export function ProvidersRulesView({
             <CardContent>
               <Stack spacing={2}>
                 <Typography variant="body2" color="text.secondary">
-                  Select a provider from the inventory, then open the focused
+                  Select an inbox from the inventory, then open the focused
                   edit flow when you need to make changes.
                 </Typography>
                 <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
@@ -581,7 +581,7 @@ export function ProvidersRulesView({
                     startIcon={<AddCircleOutlined />}
                     onClick={handleOpenCreateProvider}
                   >
-                    Create provider
+                    Create inbox
                   </Button>
                   <Button
                     variant="outlined"
@@ -627,7 +627,7 @@ export function ProvidersRulesView({
             <CardContent>
               <Stack spacing={2}>
                 <Typography variant="body2" color="text.secondary">
-                  Rules stay tied to the selected provider, but the editor opens
+                  Rules stay tied to the selected inbox, but the editor opens
                   separately so the inventory remains easy to scan.
                 </Typography>
                 <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
@@ -678,11 +678,11 @@ export function ProvidersRulesView({
         <Box component="form" onSubmit={handleProviderSubmit}>
           <DialogTitle sx={{ pr: 7 }}>
             {providerDialogMode === "edit"
-              ? "Edit provider"
-              : "Create provider"}
+              ? "Edit inbox"
+              : "Create inbox"}
           </DialogTitle>
           <IconButton
-            aria-label="Close provider dialog"
+            aria-label="Close inbox dialog"
             onClick={() => setProviderDialogMode(null)}
             disabled={isSaving}
             sx={{ position: "absolute", top: 12, right: 12 }}
@@ -692,7 +692,7 @@ export function ProvidersRulesView({
           <DialogContent dividers>
             <Stack spacing={3}>
               <Alert severity="info" icon={<LinkOutlined />}>
-                Providers define the household service buckets used by inbox and
+                Inboxes define the household service buckets used by inbox and
                 access controls.
               </Alert>
               <Stack spacing={2}>
@@ -707,7 +707,7 @@ export function ProvidersRulesView({
                   fullWidth
                 />
                 <TextField
-                  label="Provider key"
+                  label="Inbox key"
                   size="small"
                   helperText="Lowercase identifier used in routing and access control"
                   value={providerFormState.providerKey}
@@ -731,8 +731,8 @@ export function ProvidersRulesView({
               {isSaving
                 ? "Saving…"
                 : providerDialogMode === "edit"
-                  ? "Save provider"
-                  : "Create provider"}
+                  ? "Save inbox"
+                  : "Create inbox"}
             </Button>
           </DialogActions>
         </Box>
@@ -759,17 +759,17 @@ export function ProvidersRulesView({
           <DialogContent dividers>
             <Stack spacing={3}>
               <Alert severity="info" icon={<RuleFolderOutlined />}>
-                Match exact senders or domains to the provider that should own
+                Match exact senders or domains to the inbox that should own
                 incoming verification messages.
               </Alert>
               <Stack spacing={2}>
                 <FormControl size="small" fullWidth>
                   <InputLabel id="provider-rule-provider-label">
-                    Provider
+                    Inbox
                   </InputLabel>
                   <Select
                     labelId="provider-rule-provider-label"
-                    label="Provider"
+                    label="Inbox"
                     value={ruleFormState.providerId}
                     onChange={(event) =>
                       onRuleFormChange({
@@ -848,7 +848,7 @@ export function ProvidersRulesView({
 
       <ConfirmDialog
         open={isDeleteProviderOpen}
-        title="Delete provider?"
+        title="Delete inbox?"
         description={
           selectedProvider ? (
             <Typography variant="body2" color="text.secondary">
@@ -859,7 +859,7 @@ export function ProvidersRulesView({
             ""
           )
         }
-        confirmLabel="Delete provider"
+        confirmLabel="Delete inbox"
         confirmColor="error"
         isLoading={isSaving}
         onClose={() => setIsDeleteProviderOpen(false)}
@@ -873,7 +873,7 @@ export function ProvidersRulesView({
           selectedRule ? (
             <Typography variant="body2" color="text.secondary">
               Rule <strong>{selectedRule.match_value}</strong> will stop routing
-              senders to this provider.
+              senders to this inbox.
             </Typography>
           ) : (
             ""

--- a/src/client/components/ProvidersRulesView.tsx
+++ b/src/client/components/ProvidersRulesView.tsx
@@ -276,7 +276,9 @@ export function ProvidersRulesView({
           }
           title="Provider and rule setup"
           subheader="Configure senders so codes route cleanly without owner intervention."
-          titleTypographyProps={{ variant: "h6", fontWeight: "bold" }}
+          slotProps={{
+            title: { variant: "h6", fontWeight: "bold" },
+          }}
         />
         <Divider />
         <CardContent>
@@ -346,7 +348,70 @@ export function ProvidersRulesView({
             >
               Connected providers
             </Typography>
-            <Box sx={{ height: 360, width: "100%" }}>
+            <Stack spacing={1.5} sx={{ display: { xs: "flex", md: "none" } }}>
+              {providers.map((provider) => {
+                const isSelected = provider.id === selectedProviderId;
+
+                return (
+                  <Card
+                    key={provider.id}
+                    variant="outlined"
+                    onClick={() => onSelectProvider(provider.id)}
+                    sx={{
+                      cursor: "pointer",
+                      borderRadius: 2,
+                      borderColor: isSelected ? "primary.main" : "divider",
+                    }}
+                  >
+                    <CardContent sx={{ p: 2 }}>
+                      <Stack spacing={1.5}>
+                        <Box
+                          sx={{
+                            display: "flex",
+                            justifyContent: "space-between",
+                            gap: 2,
+                            alignItems: "flex-start",
+                          }}
+                        >
+                          <Box sx={{ minWidth: 0 }}>
+                            <Typography
+                              variant="subtitle1"
+                              sx={{ fontWeight: "bold" }}
+                            >
+                              {provider.display_name}
+                            </Typography>
+                            <Typography
+                              variant="body2"
+                              color="text.secondary"
+                              sx={{ wordBreak: "break-word" }}
+                            >
+                              {provider.provider_key}
+                            </Typography>
+                          </Box>
+                          <Chip
+                            label={`${provider.rule_count} rules`}
+                            size="small"
+                          />
+                        </Box>
+                        <Typography variant="caption" color="text.secondary">
+                          Created {formatTimestamp(provider.created_at)}
+                        </Typography>
+                      </Stack>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+              {!providers.length && (
+                <Alert severity="info">No providers configured yet.</Alert>
+              )}
+            </Stack>
+            <Box
+              sx={{
+                height: 360,
+                width: "100%",
+                display: { xs: "none", md: "block" },
+              }}
+            >
               <DataGrid
                 rows={providers}
                 columns={providerColumns}
@@ -392,7 +457,81 @@ export function ProvidersRulesView({
                 {providerRules.length} configured
               </Typography>
             </Box>
-            <Box sx={{ height: 320, width: "100%" }}>
+            <Stack spacing={1.5} sx={{ display: { xs: "flex", md: "none" } }}>
+              {providerRules.map((rule) => {
+                const isSelected = rule.id === selectedRuleId;
+
+                return (
+                  <Card
+                    key={rule.id}
+                    variant="outlined"
+                    onClick={() => onSelectRule(rule.id)}
+                    sx={{
+                      cursor: "pointer",
+                      borderRadius: 2,
+                      borderColor: isSelected ? "primary.main" : "divider",
+                    }}
+                  >
+                    <CardContent sx={{ p: 2 }}>
+                      <Stack spacing={1.5}>
+                        <Box
+                          sx={{
+                            display: "flex",
+                            justifyContent: "space-between",
+                            gap: 2,
+                            alignItems: "flex-start",
+                          }}
+                        >
+                          <Box sx={{ minWidth: 0 }}>
+                            <Typography
+                              variant="subtitle1"
+                              sx={{
+                                fontWeight: "bold",
+                                wordBreak: "break-word",
+                              }}
+                            >
+                              {rule.match_value}
+                            </Typography>
+                            <Typography
+                              variant="caption"
+                              color="text.secondary"
+                            >
+                              Created {formatTimestamp(rule.created_at)}
+                            </Typography>
+                          </Box>
+                          <Chip
+                            size="small"
+                            label={
+                              rule.match_type === "domain" ? "Domain" : "Exact"
+                            }
+                            color={
+                              rule.match_type === "domain"
+                                ? "secondary"
+                                : "primary"
+                            }
+                            variant="outlined"
+                          />
+                        </Box>
+                      </Stack>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+              {!providerRules.length && (
+                <Alert severity="info">
+                  {selectedProvider
+                    ? "No sender rules configured yet for this provider."
+                    : "Choose a provider to view its rules."}
+                </Alert>
+              )}
+            </Stack>
+            <Box
+              sx={{
+                height: 320,
+                width: "100%",
+                display: { xs: "none", md: "block" },
+              }}
+            >
               <DataGrid
                 rows={providerRules}
                 columns={ruleColumns}
@@ -425,7 +564,9 @@ export function ProvidersRulesView({
               }
               title="Provider actions"
               subheader="Open a dialog to create, update, or delete a selected provider"
-              titleTypographyProps={{ variant: "h6", fontWeight: "bold" }}
+              slotProps={{
+                title: { variant: "h6", fontWeight: "bold" },
+              }}
             />
             <Divider />
             <CardContent>
@@ -478,7 +619,9 @@ export function ProvidersRulesView({
               }
               title="Rule actions"
               subheader="Create or refine sender mapping rules without losing grid context"
-              titleTypographyProps={{ variant: "h6", fontWeight: "bold" }}
+              slotProps={{
+                title: { variant: "h6", fontWeight: "bold" },
+              }}
             />
             <Divider />
             <CardContent>

--- a/src/client/components/PublicEntryShell.tsx
+++ b/src/client/components/PublicEntryShell.tsx
@@ -1,0 +1,77 @@
+import { Box, Card, CardContent, Container, Typography } from "@mui/material";
+import type { ReactNode } from "react";
+
+interface PublicEntryShellProps {
+  eyebrow: string;
+  title: string;
+  description?: ReactNode;
+  children: ReactNode;
+}
+
+export function PublicEntryShell({
+  eyebrow,
+  title,
+  description,
+  children,
+}: PublicEntryShellProps) {
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        py: { xs: 3, sm: 5, md: 7 },
+        px: { xs: 1.5, sm: 2.5, md: 3 },
+      }}
+    >
+      <Container maxWidth="md" disableGutters>
+        <Box
+          sx={{
+            width: "100%",
+            maxWidth: 760,
+            mx: "auto",
+          }}
+        >
+          <Card
+            elevation={3}
+            sx={{ borderRadius: { xs: 3, sm: 4 }, overflow: "hidden" }}
+          >
+            <CardContent sx={{ p: { xs: 3, sm: 4, md: 5 } }}>
+              <Typography
+                variant="overline"
+                color="text.secondary"
+                sx={{ fontWeight: "bold", letterSpacing: 1 }}
+              >
+                {eyebrow}
+              </Typography>
+              <Typography
+                variant="h4"
+                component="h1"
+                gutterBottom
+                sx={{
+                  mt: 1,
+                  fontWeight: "bold",
+                  fontSize: { xs: "1.9rem", sm: "2.25rem", md: "2.5rem" },
+                  lineHeight: 1.15,
+                  textWrap: "balance",
+                }}
+              >
+                {title}
+              </Typography>
+              {description ? (
+                <Typography
+                  variant="body1"
+                  color="text.secondary"
+                  sx={{ mb: 4, maxWidth: 56 * 8, textWrap: "pretty" }}
+                >
+                  {description}
+                </Typography>
+              ) : null}
+              {children}
+            </CardContent>
+          </Card>
+        </Box>
+      </Container>
+    </Box>
+  );
+}

--- a/src/client/components/QuarantineView.tsx
+++ b/src/client/components/QuarantineView.tsx
@@ -402,12 +402,12 @@ export function QuarantineView({
             >
               <FormControl sx={{ minWidth: { xs: 0, sm: 200 }, flexGrow: 1 }}>
                 <InputLabel id="release-provider-label">
-                  Release to provider
+                  Release to inbox
                 </InputLabel>
                 <Select
                   labelId="release-provider-label"
                   value={releaseProviderKey}
-                  label="Release to provider"
+                  label="Release to inbox"
                   onChange={(e) => onReleaseProviderKeyChange(e.target.value)}
                 >
                   {providers.map((provider) => (
@@ -487,7 +487,7 @@ export function QuarantineView({
             </Typography>
             <Typography variant="body1" color="text.secondary">
               Review the classification reason, then release it to the right
-              provider or dismiss it.
+              inbox or dismiss it.
             </Typography>
           </Paper>
         )}
@@ -511,7 +511,7 @@ export function QuarantineView({
               </Typography>
               <Typography variant="body2" color="text.secondary">
                 {reviewAction === "release"
-                  ? `This will move the message into ${providers.find((provider) => provider.provider_key === releaseProviderKey)?.display_name || "the selected provider"}.`
+                  ? `This will move the message into ${providers.find((provider) => provider.provider_key === releaseProviderKey)?.display_name || "the selected inbox"}.`
                   : "This will remove the message from quarantine review."}
               </Typography>
             </Stack>

--- a/src/client/components/QuarantineView.tsx
+++ b/src/client/components/QuarantineView.tsx
@@ -127,12 +127,12 @@ export function QuarantineView({
     <Box
       sx={{
         display: "flex",
-        flexDirection: { xs: "column", md: "row" },
+        flexDirection: { xs: "column", lg: "row" },
         gap: 3,
         height: "100%",
       }}
     >
-      <Box sx={{ width: { xs: "100%", md: 360 }, flexShrink: 0 }}>
+      <Box sx={{ width: { xs: "100%", lg: 360 }, flexShrink: 0, minWidth: 0 }}>
         <Typography
           variant="overline"
           color="text.secondary"
@@ -178,17 +178,21 @@ export function QuarantineView({
                             sx={{
                               display: "flex",
                               justifyContent: "space-between",
+                              alignItems: "flex-start",
+                              gap: 1,
                               mb: 0.5,
                             }}
                           >
                             <Typography
                               variant="subtitle2"
                               sx={{
+                                flex: 1,
+                                minWidth: 0,
                                 fontWeight: isSelected ? "bold" : "medium",
                                 overflow: "hidden",
                                 textOverflow: "ellipsis",
                                 whiteSpace: "nowrap",
-                                pr: 1,
+                                pr: 0.5,
                               }}
                             >
                               {message.subject ?? "Untitled message"}
@@ -276,9 +280,11 @@ export function QuarantineView({
                 display: "flex",
                 justifyContent: "space-between",
                 alignItems: "flex-start",
+                flexDirection: { xs: "column", sm: "row" },
+                gap: 1.5,
               }}
             >
-              <Box>
+              <Box sx={{ minWidth: 0 }}>
                 <Typography variant="h5" sx={{ fontWeight: "bold", mb: 0.5 }}>
                   {selectedQuarantineMessage.subject ?? "Untitled message"}
                 </Typography>
@@ -315,6 +321,7 @@ export function QuarantineView({
                 <Box
                   sx={{
                     display: "inline-flex",
+                    flexDirection: { xs: "column", sm: "row" },
                     alignItems: "center",
                     gap: 2,
                     justifyContent: "center",
@@ -322,7 +329,12 @@ export function QuarantineView({
                 >
                   <Typography
                     variant="h3"
-                    sx={{ fontWeight: "bold", letterSpacing: 2 }}
+                    sx={{
+                      fontWeight: "bold",
+                      letterSpacing: { xs: 1, sm: 2 },
+                      fontSize: { xs: "2rem", sm: undefined },
+                      wordBreak: "break-word",
+                    }}
                   >
                     {selectedQuarantineMessage.extracted_code ??
                       "No code detected"}
@@ -388,7 +400,7 @@ export function QuarantineView({
                 alignItems: { xs: "stretch", sm: "flex-end" },
               }}
             >
-              <FormControl sx={{ minWidth: 200, flexGrow: 1 }}>
+              <FormControl sx={{ minWidth: { xs: 0, sm: 200 }, flexGrow: 1 }}>
                 <InputLabel id="release-provider-label">
                   Release to provider
                 </InputLabel>
@@ -409,14 +421,18 @@ export function QuarantineView({
                 </Select>
               </FormControl>
 
-              <Stack direction="row" spacing={2}>
+              <Stack
+                direction={{ xs: "column", sm: "row" }}
+                spacing={2}
+                sx={{ width: { xs: "100%", sm: "auto" } }}
+              >
                 <Button
                   variant="contained"
                   color="primary"
                   startIcon={<MoveToInboxOutlined />}
                   disabled={isReviewingQuarantine || !releaseProviderKey}
                   onClick={() => setReviewAction("release")}
-                  sx={{ px: 4, py: 1.5 }}
+                  sx={{ px: 4, py: 1.5, width: { xs: "100%", sm: "auto" } }}
                 >
                   Release to inbox
                 </Button>
@@ -425,7 +441,7 @@ export function QuarantineView({
                   startIcon={<DeleteOutlined />}
                   disabled={isReviewingQuarantine}
                   onClick={() => setReviewAction("dismiss")}
-                  sx={{ px: 4, py: 1.5 }}
+                  sx={{ px: 4, py: 1.5, width: { xs: "100%", sm: "auto" } }}
                 >
                   Dismiss
                 </Button>

--- a/src/client/components/SettingsView.tsx
+++ b/src/client/components/SettingsView.tsx
@@ -106,7 +106,7 @@ export function SettingsView({
 
   return (
     <Container maxWidth="md" disableGutters>
-      <Box sx={{ mb: 4 }}>
+      <Box sx={{ mb: 4, px: { xs: 0.5, sm: 0 } }}>
         <Typography variant="h4" gutterBottom sx={{ fontWeight: "bold" }}>
           Account Settings
         </Typography>
@@ -117,13 +117,13 @@ export function SettingsView({
       </Box>
 
       {error && (
-        <Alert severity="error" sx={{ mb: 4 }}>
+        <Alert severity="error" sx={{ mb: 4, borderRadius: 2 }}>
           {error}
         </Alert>
       )}
 
       {/* Profile Card */}
-      <Card sx={{ mb: 4, borderRadius: 2 }}>
+      <Card sx={{ mb: 4, borderRadius: 2, overflow: "hidden" }}>
         <CardHeader title="Profile" />
         <Divider />
         <CardContent>
@@ -169,7 +169,7 @@ export function SettingsView({
       </Card>
 
       {/* Password Card */}
-      <Card sx={{ mb: 4, borderRadius: 2 }}>
+      <Card sx={{ mb: 4, borderRadius: 2, overflow: "hidden" }}>
         <CardHeader title="Change Password" />
         <Divider />
         <CardContent>
@@ -217,7 +217,7 @@ export function SettingsView({
         </CardContent>
       </Card>
 
-      <Card sx={{ mb: 4, borderRadius: 2 }}>
+      <Card sx={{ mb: 4, borderRadius: 2, overflow: "hidden" }}>
         <CardHeader title="Password Reset Email" />
         <Divider />
         <CardContent>
@@ -254,7 +254,7 @@ export function SettingsView({
       </Card>
 
       {/* Two-Factor Authentication */}
-      <Card sx={{ mb: 4, borderRadius: 2 }}>
+      <Card sx={{ mb: 4, borderRadius: 2, overflow: "hidden" }}>
         <CardHeader title="Two-Factor Authentication" />
         <Divider />
         <CardContent>
@@ -330,7 +330,7 @@ export function SettingsView({
       </Card>
 
       {/* Passkeys */}
-      <Card sx={{ mb: 4, borderRadius: 2 }}>
+      <Card sx={{ mb: 4, borderRadius: 2, overflow: "hidden" }}>
         <CardHeader title="Passkeys" />
         <Divider />
         <CardContent>
@@ -367,18 +367,29 @@ export function SettingsView({
       </Card>
 
       {/* Sessions Card */}
-      <Card sx={{ mb: 4, borderRadius: 2 }}>
+      <Card sx={{ mb: 4, borderRadius: 2, overflow: "hidden" }}>
         <CardHeader
           title="Active Sessions"
+          slotProps={{ title: { sx: { pr: { xs: 0, sm: 2 } } } }}
           action={
             <Button
               color="error"
               disabled={isSaving || sessions.length <= 1}
               onClick={() => setIsRevokeOthersOpen(true)}
+              sx={{ alignSelf: { xs: "flex-start", sm: "center" } }}
             >
               Revoke Others
             </Button>
           }
+          sx={{
+            alignItems: { xs: "flex-start", sm: "center" },
+            flexDirection: { xs: "column", sm: "row" },
+            gap: { xs: 1.5, sm: 0 },
+            "& .MuiCardHeader-action": {
+              alignSelf: { xs: "flex-start", sm: "center" },
+              m: 0,
+            },
+          }}
         />
         <Divider />
         <List disablePadding>
@@ -386,12 +397,17 @@ export function SettingsView({
             <Fragment key={session.id}>
               {index > 0 && <Divider />}
               <ListItem
+                sx={{
+                  alignItems: { xs: "flex-start", sm: "center" },
+                  pr: { xs: 2, sm: 11 },
+                }}
                 secondaryAction={
                   <Button
                     color="error"
                     size="small"
                     onClick={() => setSessionToRevoke(session)}
                     disabled={isSaving}
+                    sx={{ top: { xs: 20, sm: "50%" } }}
                   >
                     Revoke
                   </Button>

--- a/src/client/components/SetupPage.tsx
+++ b/src/client/components/SetupPage.tsx
@@ -1,16 +1,8 @@
-import {
-  Alert,
-  Box,
-  Button,
-  Card,
-  CardContent,
-  Container,
-  TextField,
-  Typography,
-} from "@mui/material";
+import { Alert, Box, Button, TextField, Typography } from "@mui/material";
 import { type FormEvent, useState } from "react";
 import type { SetupFormState } from "../types";
 import { fetchJson } from "../utils";
+import { PublicEntryShell } from "./PublicEntryShell";
 
 interface SetupPageProps {
   onSetupComplete: () => void;
@@ -63,186 +55,152 @@ export function SetupPage({
   };
 
   return (
-    <Container component="main" maxWidth="sm">
-      <Box
-        sx={{
-          minHeight: "100vh",
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "center",
-          py: 4,
-        }}
-      >
-        <Card elevation={3} sx={{ borderRadius: 3 }}>
-          <CardContent sx={{ p: 4 }}>
-            <Typography
-              variant="overline"
-              color="text.secondary"
-              sx={{ fontWeight: "bold", letterSpacing: 1 }}
-            >
-              First-run setup
+    <PublicEntryShell
+      eyebrow="First-run setup"
+      title="Finish setting up your household inbox."
+      description="Create the initial owner account after your Cloudflare deployment completes. This screen closes automatically after the first successful setup."
+    >
+      <Alert severity="info" sx={{ mb: 4, borderRadius: 2 }}>
+        <Typography variant="subtitle2" sx={{ fontWeight: "bold", mb: 0.5 }}>
+          What you need
+        </Typography>
+        <Box component="ul" sx={{ m: 0, pl: 2 }}>
+          <li>
+            <Typography variant="body2">
+              The owner email configured as <code>OWNER_EMAIL</code>
             </Typography>
-            <Typography
-              variant="h4"
-              component="h1"
-              gutterBottom
-              sx={{ mt: 1, fontWeight: "bold" }}
-            >
-              Finish setting up your household inbox.
+          </li>
+          <li>
+            <Typography variant="body2">
+              Your one-time <code>SETUP_SECRET</code>
             </Typography>
-            <Typography variant="body1" color="text.secondary" sx={{ mb: 2 }}>
-              Create the initial owner account after your Cloudflare deployment
-              completes. This screen closes automatically after the first
-              successful setup.
+          </li>
+          <li>
+            <Typography variant="body2">
+              A strong password for the initial owner account
             </Typography>
+          </li>
+        </Box>
+      </Alert>
 
-            <Alert severity="info" sx={{ mb: 4, borderRadius: 2 }}>
-              <Typography
-                variant="subtitle2"
-                sx={{ fontWeight: "bold", mb: 0.5 }}
-              >
-                What you need
-              </Typography>
-              <Box component="ul" sx={{ m: 0, pl: 2 }}>
-                <li>
-                  <Typography variant="body2">
-                    The owner email configured as <code>OWNER_EMAIL</code>
-                  </Typography>
-                </li>
-                <li>
-                  <Typography variant="body2">
-                    Your one-time <code>SETUP_SECRET</code>
-                  </Typography>
-                </li>
-                <li>
-                  <Typography variant="body2">
-                    A strong password for the initial owner account
-                  </Typography>
-                </li>
-              </Box>
-            </Alert>
+      <Box component="form" onSubmit={handleSetupComplete} noValidate>
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          id="setup-household-name"
+          label="Household name"
+          name="setup-household-name"
+          value={setupFormState.householdName}
+          onChange={(e) =>
+            setSetupFormState((current) => ({
+              ...current,
+              householdName: e.target.value,
+            }))
+          }
+        />
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          id="setup-household-slug"
+          label="Household slug"
+          name="setup-household-slug"
+          helperText="Lowercase letters, numbers, and hyphens only."
+          value={setupFormState.householdSlug}
+          onChange={(e) =>
+            setSetupFormState((current) => ({
+              ...current,
+              householdSlug: e.target.value.toLowerCase(),
+            }))
+          }
+        />
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          id="setup-email"
+          label="Owner email"
+          name="setup-email"
+          autoComplete="email"
+          value={setupFormState.email}
+          onChange={(e) =>
+            setSetupFormState((current) => ({
+              ...current,
+              email: e.target.value,
+            }))
+          }
+        />
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          id="setup-name"
+          label="Owner display name"
+          name="setup-name"
+          autoComplete="name"
+          value={setupFormState.name}
+          onChange={(e) =>
+            setSetupFormState((current) => ({
+              ...current,
+              name: e.target.value,
+            }))
+          }
+        />
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          name="setup-password"
+          label="Password"
+          type="password"
+          id="setup-password"
+          autoComplete="new-password"
+          value={setupFormState.password}
+          onChange={(e) =>
+            setSetupFormState((current) => ({
+              ...current,
+              password: e.target.value,
+            }))
+          }
+          slotProps={{ htmlInput: { minLength: 12 } }}
+        />
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          name="setup-secret"
+          label="Setup secret"
+          type="password"
+          id="setup-secret"
+          autoComplete="off"
+          value={setupFormState.setupSecret}
+          onChange={(e) =>
+            setSetupFormState((current) => ({
+              ...current,
+              setupSecret: e.target.value,
+            }))
+          }
+          sx={{ mb: 3 }}
+        />
 
-            <Box component="form" onSubmit={handleSetupComplete} noValidate>
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                id="setup-household-name"
-                label="Household name"
-                name="setup-household-name"
-                value={setupFormState.householdName}
-                onChange={(e) =>
-                  setSetupFormState((current) => ({
-                    ...current,
-                    householdName: e.target.value,
-                  }))
-                }
-              />
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                id="setup-household-slug"
-                label="Household slug"
-                name="setup-household-slug"
-                helperText="Lowercase letters, numbers, and hyphens only."
-                value={setupFormState.householdSlug}
-                onChange={(e) =>
-                  setSetupFormState((current) => ({
-                    ...current,
-                    householdSlug: e.target.value.toLowerCase(),
-                  }))
-                }
-              />
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                id="setup-email"
-                label="Owner email"
-                name="setup-email"
-                autoComplete="email"
-                value={setupFormState.email}
-                onChange={(e) =>
-                  setSetupFormState((current) => ({
-                    ...current,
-                    email: e.target.value,
-                  }))
-                }
-              />
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                id="setup-name"
-                label="Owner display name"
-                name="setup-name"
-                autoComplete="name"
-                value={setupFormState.name}
-                onChange={(e) =>
-                  setSetupFormState((current) => ({
-                    ...current,
-                    name: e.target.value,
-                  }))
-                }
-              />
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                name="setup-password"
-                label="Password"
-                type="password"
-                id="setup-password"
-                autoComplete="new-password"
-                value={setupFormState.password}
-                onChange={(e) =>
-                  setSetupFormState((current) => ({
-                    ...current,
-                    password: e.target.value,
-                  }))
-                }
-                slotProps={{ htmlInput: { minLength: 12 } }}
-              />
-              <TextField
-                margin="normal"
-                required
-                fullWidth
-                name="setup-secret"
-                label="Setup secret"
-                type="password"
-                id="setup-secret"
-                autoComplete="off"
-                value={setupFormState.setupSecret}
-                onChange={(e) =>
-                  setSetupFormState((current) => ({
-                    ...current,
-                    setupSecret: e.target.value,
-                  }))
-                }
-                sx={{ mb: 3 }}
-              />
+        {setupError && (
+          <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
+            {setupError}
+          </Alert>
+        )}
 
-              {setupError && (
-                <Alert severity="error" sx={{ mb: 3 }}>
-                  {setupError}
-                </Alert>
-              )}
-
-              <Button
-                type="submit"
-                fullWidth
-                variant="contained"
-                size="large"
-                disabled={isCompletingSetup}
-                sx={{ py: 1.5 }}
-              >
-                {isCompletingSetup ? "Creating owner…" : "Complete setup"}
-              </Button>
-            </Box>
-          </CardContent>
-        </Card>
+        <Button
+          type="submit"
+          fullWidth
+          variant="contained"
+          size="large"
+          disabled={isCompletingSetup}
+          sx={{ py: 1.5 }}
+        >
+          {isCompletingSetup ? "Creating owner…" : "Complete setup"}
+        </Button>
       </Box>
-    </Container>
+    </PublicEntryShell>
   );
 }

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -26,11 +26,11 @@ export function getProviderAccessToggleRequest(shouldHaveAccess: boolean): {
   return shouldHaveAccess
     ? {
         method: "POST",
-        statusMessage: "Provider access granted.",
+        statusMessage: "Inbox access granted.",
       }
     : {
         method: "DELETE",
-        statusMessage: "Provider access revoked.",
+        statusMessage: "Inbox access revoked.",
       };
 }
 

--- a/src/server/routes/admin.ts
+++ b/src/server/routes/admin.ts
@@ -175,7 +175,7 @@ adminRoutes.patch("/:slug/settings", async (c) => {
   });
 });
 
-adminRoutes.get("/:slug/providers", async (c) => {
+adminRoutes.get("/:slug/inboxes", async (c) => {
   const household = c.get("household");
   if (!household) return c.json({ error: "Forbidden" }, 403);
   const [providers, rules] = await Promise.all([
@@ -189,7 +189,7 @@ adminRoutes.get("/:slug/providers", async (c) => {
   });
 });
 
-adminRoutes.post("/:slug/providers", async (c) => {
+adminRoutes.post("/:slug/inboxes", async (c) => {
   const household = c.get("household");
   if (!household) return c.json({ error: "Forbidden" }, 403);
   let payload: ProviderPayload;
@@ -223,7 +223,7 @@ adminRoutes.post("/:slug/providers", async (c) => {
   return c.json({ provider }, 201);
 });
 
-adminRoutes.patch("/:slug/providers/:providerId", async (c) => {
+adminRoutes.patch("/:slug/inboxes/:providerId", async (c) => {
   const household = c.get("household");
   if (!household) return c.json({ error: "Forbidden" }, 403);
   let payload: ProviderPayload;
@@ -267,7 +267,7 @@ adminRoutes.patch("/:slug/providers/:providerId", async (c) => {
   return c.json({ provider });
 });
 
-adminRoutes.delete("/:slug/providers/:providerId", async (c) => {
+adminRoutes.delete("/:slug/inboxes/:providerId", async (c) => {
   const household = c.get("household");
   if (!household) return c.json({ error: "Forbidden" }, 403);
   const providerId = c.req.param("providerId");

--- a/src/server/routes/inbox.ts
+++ b/src/server/routes/inbox.ts
@@ -32,13 +32,13 @@ export const inboxRoutes = new Hono<{
   Variables: AppVariables;
 }>();
 
-inboxRoutes.use("/providers", requireAuthenticatedUser);
+inboxRoutes.use("/inboxes", requireAuthenticatedUser);
 inboxRoutes.use("/:slug/*", requireAuthenticatedUser);
 inboxRoutes.use("/:slug/*", requireHouseholdContext);
 inboxRoutes.use("/:slug/quarantine", requireOwner);
 inboxRoutes.use("/:slug/quarantine/:messageId/review", requireOwner);
 
-inboxRoutes.get("/:slug/providers", async (c) => {
+inboxRoutes.get("/:slug/inboxes", async (c) => {
   const user = c.get("user");
   const household = c.get("household");
 
@@ -54,7 +54,7 @@ inboxRoutes.get("/:slug/providers", async (c) => {
   return c.json({ providers });
 });
 
-inboxRoutes.get("/:slug/providers/:providerKey", async (c) => {
+inboxRoutes.get("/:slug/inboxes/:providerKey", async (c) => {
   const providerKey = c.req.param("providerKey");
   const user = c.get("user");
   const household = c.get("household");

--- a/test/client-utils.test.ts
+++ b/test/client-utils.test.ts
@@ -7,8 +7,8 @@ import {
 
 describe("buildHouseholdApiPath", () => {
   it("builds inbox household routes under /api/inbox/:slug", () => {
-    expect(buildHouseholdApiPath("home", "/inbox/providers")).toBe(
-      "/api/inbox/home/providers",
+    expect(buildHouseholdApiPath("home", "/inbox/inboxes")).toBe(
+      "/api/inbox/home/inboxes",
     );
   });
 
@@ -29,14 +29,14 @@ describe("getProviderAccessToggleRequest", () => {
   it("uses POST and a granted message when access should be enabled", () => {
     expect(getProviderAccessToggleRequest(true)).toEqual({
       method: "POST",
-      statusMessage: "Provider access granted.",
+      statusMessage: "Inbox access granted.",
     });
   });
 
   it("uses DELETE and a revoked message when access should be disabled", () => {
     expect(getProviderAccessToggleRequest(false)).toEqual({
       method: "DELETE",
-      statusMessage: "Provider access revoked.",
+      statusMessage: "Inbox access revoked.",
     });
   });
 });

--- a/test/inbox-routes.test.ts
+++ b/test/inbox-routes.test.ts
@@ -1007,7 +1007,7 @@ describe("worker routes", () => {
       session: { id: "session-1", userId: "member-home" },
     };
 
-    const response = await invokeWorker("/api/inbox/home/providers");
+    const response = await invokeWorker("/api/inbox/home/inboxes");
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
@@ -1034,7 +1034,7 @@ describe("worker routes", () => {
       session: { id: "session-1", userId: "owner-away" },
     };
 
-    const response = await invokeWorker("/api/inbox/home/providers");
+    const response = await invokeWorker("/api/inbox/home/inboxes");
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({ error: "Forbidden" });

--- a/test/layout.test.tsx
+++ b/test/layout.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  isSettingsPath,
   Layout,
   UserAccountMenuContent,
 } from "../src/client/components/Layout";
@@ -58,13 +59,55 @@ describe("Layout", () => {
     expect(html).toContain("Quarantine");
     expect(html).toContain("Members");
     expect(html).toContain("Providers &amp; rules");
-    expect(html).not.toContain('href="/settings"');
+    expect(html).toContain("Home");
+    expect(html).toContain("Owner");
     expect(html).toContain("AM");
     expect(settingsIndex).toBeGreaterThan(-1);
     expect(membersIndex).toBeGreaterThan(settingsIndex);
     expect(quarantineIndex).toBeGreaterThan(membersIndex);
     expect(providersIndex).toBeGreaterThan(quarantineIndex);
     expect(householdSettingsIndex).toBeGreaterThan(providersIndex);
+  });
+
+  it("treats household settings paths as settings views", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter initialEntries={["/home/settings"]}>
+        <ColorModeContext.Provider value={{ toggleColorMode: vi.fn() }}>
+          <ThemeProvider theme={getTheme("light")}>
+            <CssBaseline />
+            <Layout
+              session={{
+                user: {
+                  email: "alex.member@example.com",
+                },
+              }}
+              households={[
+                {
+                  id: "household-1",
+                  slug: "home",
+                  displayName: "Home",
+                  role: "owner",
+                },
+              ]}
+              isOwner={true}
+              householdSlug="home"
+              householdName="Home"
+              householdRole="owner"
+              onSelectHousehold={vi.fn()}
+              onCreateHousehold={vi.fn()}
+              onLogout={vi.fn()}
+            >
+              <div>Settings content</div>
+            </Layout>
+          </ThemeProvider>
+        </ColorModeContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(html).toContain('href="/home/inbox"');
+    expect(isSettingsPath("/home/settings")).toBe(true);
+    expect(isSettingsPath("/settings")).toBe(true);
+    expect(isSettingsPath("/home/inbox")).toBe(false);
   });
 
   it("hides household settings from members", () => {
@@ -120,6 +163,7 @@ describe("UserAccountMenuContent", () => {
                 },
               }}
               mode="dark"
+              settingsPath="/home/settings"
               onSettingsClick={vi.fn()}
               onToggleColorMode={vi.fn()}
               onLogout={vi.fn()}
@@ -132,7 +176,7 @@ describe("UserAccountMenuContent", () => {
     expect(html).toContain("Alex Member");
     expect(html).toContain("alex.member@example.com");
     expect(html).toContain("Settings");
-    expect(html).toContain('href="/settings"');
+    expect(html).toContain('href="/home/settings"');
     expect(html).toContain("Light mode");
     expect(html).toContain("Sign out");
   });

--- a/test/layout.test.tsx
+++ b/test/layout.test.tsx
@@ -50,7 +50,7 @@ describe("Layout", () => {
     const settingsIndex = html.indexOf("Settings");
     const membersIndex = html.indexOf("Members");
     const quarantineIndex = html.indexOf("Quarantine");
-    const providersIndex = html.indexOf("Providers &amp; rules");
+    const providersIndex = html.indexOf("Inboxes &amp; rules");
     const householdSettingsIndex = html.indexOf("Household settings");
 
     expect(html).toContain("Inbox");
@@ -58,7 +58,7 @@ describe("Layout", () => {
     expect(html).toContain("Household settings");
     expect(html).toContain("Quarantine");
     expect(html).toContain("Members");
-    expect(html).toContain("Providers &amp; rules");
+    expect(html).toContain("Inboxes &amp; rules");
     expect(html).toContain("Home");
     expect(html).toContain("Owner");
     expect(html).toContain("AM");

--- a/test/members-view.test.tsx
+++ b/test/members-view.test.tsx
@@ -59,7 +59,6 @@ describe("MembersView", () => {
         memberFormState={{
           email: "",
           name: "",
-          password: "",
           role: "member",
         }}
         onMemberFormChange={vi.fn()}
@@ -88,6 +87,6 @@ describe("MembersView", () => {
     expect(html).toContain("Resend");
     expect(html).toContain("Cancel");
     expect(html).toContain("Family Member");
-    expect(html).toContain("Provider Access");
+    expect(html).toContain("Inbox Access");
   });
 });

--- a/test/providers-rules-view.test.tsx
+++ b/test/providers-rules-view.test.tsx
@@ -64,12 +64,12 @@ describe("ProvidersRulesView", () => {
       />,
     );
 
-    expect(html).toContain("Provider and rule setup");
-    expect(html).toContain("Connected providers");
+    expect(html).toContain("Inbox and rule setup");
+    expect(html).toContain("Connected inboxes");
     expect(html).toContain("Sender rules");
-    expect(html).toContain("Provider actions");
+    expect(html).toContain("Inbox actions");
     expect(html).toContain("Rule actions");
-    expect(html).toContain("Create provider");
+    expect(html).toContain("Create inbox");
     expect(html).toContain("Add rule");
     expect(html).toContain("Edit selected");
     expect(html).toContain("Match value");


### PR DESCRIPTION
## Summary
- rename the app-facing provider terminology and routes to inboxes across the inbox, admin, quarantine, and members flows
- tighten the inbox UI for desktop with denser list rows, clearer metadata, and a slimmer detail pane
- improve the mobile inbox flow with task-first ordering, chip-based inbox switching, and more intentional loading and empty states

## Testing
- npm test -- --run test/layout.test.tsx test/client-utils.test.ts test/providers-rules-view.test.tsx test/members-view.test.tsx test/inbox-routes.test.ts
- npm test -- --run test/layout.test.tsx test/providers-rules-view.test.tsx test/members-view.test.tsx test/inbox-routes.test.ts

## Notes
- This PR includes the earlier branch commit `feat: refine public entry and household flows` because it was already ahead of `main` on the source branch and had no existing PR.
- `.playwright-mcp/` remains untracked locally and is not included in this PR.