### PR TITLE
test: add D1-backed integration test harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,9 +315,17 @@ For full CI/CD details, see [`docs/ci-cd-architecture.md`](./docs/ci-cd-architec
 
 The default test pyramid for Mi Casa Su Casa is:
 
-- **Unit tests**: parser rules, provider routing, permission logic, retention logic
-- **Integration tests**: Hono routes, Better Auth behavior, D1-backed flows, Worker handlers
+- **Unit tests** (`test/**/*.test.ts(x)`, Node environment): parser rules, provider routing, permission logic, retention logic, component rendering
+- **Integration tests** (`test/integration/**`, run inside the Workers runtime via `@cloudflare/vitest-pool-workers`): repositories, Better Auth and Worker handlers against a real local D1 with every migration in `migrations/` applied; the database is emptied before each test
 - **End-to-end tests**: invite/login, provider-scoped inbox access, owner quarantine review
+
+```bash
+npm test                 # both projects
+npm run test:unit        # Node-only unit tests
+npm run test:integration # D1-backed tests in workerd
+```
+
+`test/integration/schema.test.ts` also asserts that every column Better Auth expects (for the configured plugins) exists in the migrated database, so schema drift fails CI instead of production.
 
 No feature is considered done without tests.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.5.9",
         "@cloudflare/vite-plugin": "1.53.1",
+        "@cloudflare/vitest-pool-workers": "^0.22.0",
         "@cloudflare/workers-types": "5.20260820.1",
         "@types/react": "19.2.18",
         "@types/react-dom": "19.2.4",
@@ -563,6 +564,185 @@
       "peerDependencies": {
         "vite": "^6.1.0 || ^7.0.0 || ^8.0.0",
         "wrangler": "^4.125.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.22.0.tgz",
+      "integrity": "sha512-OJv/qikkOgxnKxJ5xrLS7zuOLZhc/6iziU+llqZm4tiQf2CJUYwlMuXN68VaWIQebORd1AUx4w6A0oy8XRbuaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cjs-module-lexer": "1.2.3",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260815.0-alpha",
+        "wrangler": "4.124.0",
+        "zod": "4.4.3"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "^4.1.0",
+        "@vitest/snapshot": "^4.1.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260815.1.tgz",
+      "integrity": "sha512-7PsLdcz6pT9EMd1EJGZEgMyYRfs0CHxGs62PS2L1w3s6+xGmQcRXKm/zoMftmqZF45JBa4MzFeownRKbRt/x5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260815.1.tgz",
+      "integrity": "sha512-60wtg8ng7FVWeOg/UMbZ9Ye0sslpRRAKoftPbdtuH2volq676quxVr6Zm2EjVULH/JFZeCn72dbLlrnbh0Mpcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260815.1.tgz",
+      "integrity": "sha512-MuqKIHPo0Qyo8MZMmy0lP2B5PeAL7f4T9Fu4Usk3QdbV4JIrKG/OoybN3Ign7m/Dff+L1Oo/ZHydB+hEg1ueFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260815.1.tgz",
+      "integrity": "sha512-XNFtJ5rIqJxnY6ISjkfbhT/ODiWJ6LcBvNbntuPD6I/F2k7aZeKgPaXrvWvKde66LXyzFKzc8Hn+Ydx4shevQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260815.1.tgz",
+      "integrity": "sha512-PiIUWrhbMg3quolwjgMvPOd75vKESjT4aDm7nL6mSjL5IOgmpO/zKstXnYfnEH3pq7sC0UCvKlF8ZPcfsh8NMw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/miniflare": {
+      "version": "5.20260815.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260815.0-alpha.tgz",
+      "integrity": "sha512-YAaGj4Sh5f4fqHKiMQ8zRHDOOM5IGUVtMhnLIeyjuQfU+9P6hcOTrHUVtbfj/ZPay9Kzik4pWELB39pGgefjiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260815.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/workerd": {
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260815.1.tgz",
+      "integrity": "sha512-8bArFkHmlp7qFEKVPyNzDzHzS35gc2fg0PYBcDtaNLF7UCDryCX2BQnpkUkTHYIy824IRrHOTwOEoTj0sUO2Fg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260815.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260815.1",
+        "@cloudflare/workerd-linux-64": "1.20260815.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260815.1",
+        "@cloudflare/workerd-windows-64": "1.20260815.1"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
+      "version": "4.124.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.124.0.tgz",
+      "integrity": "sha512-75euoZKjVTJYFy+Xhctt/5JlZL4M6A4xmovZsUlep+6GHcCm14n9VtdGzNIybOW2t8wuNxRj5iMUwjT5E7Ctog==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260815.0-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260815.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260815.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
@@ -3604,6 +3784,13 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cliui": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "deploy:production": "wrangler deploy --env production",
     "format": "biome format --write .",
     "test": "vitest run",
+    "test:unit": "vitest run --project unit",
+    "test:integration": "vitest run --project integration",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "ci": "npm run check && npm run typecheck && npm run test && npm run build"
@@ -64,6 +66,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.5.9",
     "@cloudflare/vite-plugin": "1.53.1",
+    "@cloudflare/vitest-pool-workers": "^0.22.0",
     "@cloudflare/workers-types": "5.20260820.1",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",

--- a/src/server/db/repositories/provider-rules.ts
+++ b/src/server/db/repositories/provider-rules.ts
@@ -43,7 +43,7 @@ export async function findProviderMatch(
     return null;
   }
 
-  return database.get<SenderRuleMatch>(sql`
+  const byDomain = await database.get<SenderRuleMatch>(sql`
     SELECT providers.id AS providerId,
            providers.provider_key AS providerKey,
            providers.household_id AS householdId,
@@ -56,6 +56,8 @@ export async function findProviderMatch(
       AND lower(sender_rules.match_value) = lower(${domain})
     LIMIT 1
   `);
+
+  return byDomain ?? null;
 }
 
 export async function userHasProviderAccess(

--- a/test/integration/auth.test.ts
+++ b/test/integration/auth.test.ts
@@ -1,0 +1,41 @@
+import { authForEnv, provisioningAuthForEnv } from "@server/auth/auth";
+import { describe, expect, it } from "vitest";
+
+import { count, testEnv } from "./helpers";
+
+describe("Better Auth against the real schema (D1)", () => {
+  it("signs up a credential user through the provisioning instance and can sign in", async () => {
+    const env = testEnv();
+    const auth = provisioningAuthForEnv(env);
+
+    const result = await auth.api.signUpEmail({
+      body: {
+        email: "owner@example.com",
+        name: "Owner",
+        password: "averylongpassword123",
+      },
+    });
+
+    expect(result.user.email).toBe("owner@example.com");
+    expect(await count("user")).toBe(1);
+    expect(await count("account", "userId = ?1", result.user.id)).toBe(1);
+
+    const signIn = await authForEnv(env).api.signInEmail({
+      body: { email: "owner@example.com", password: "averylongpassword123" },
+    });
+    expect(signIn.user.id).toBe(result.user.id);
+  });
+
+  it("refuses public sign-up on the regular auth instance", async () => {
+    await expect(
+      authForEnv(testEnv()).api.signUpEmail({
+        body: {
+          email: "stranger@example.com",
+          name: "Stranger",
+          password: "averylongpassword123",
+        },
+      }),
+    ).rejects.toThrow();
+    expect(await count("user")).toBe(0);
+  });
+});

--- a/test/integration/env.d.ts
+++ b/test/integration/env.d.ts
@@ -1,0 +1,9 @@
+import type { D1Migration } from "@cloudflare/vitest-pool-workers";
+
+declare global {
+  namespace Cloudflare {
+    interface Env extends globalThis.Env {
+      TEST_MIGRATIONS: D1Migration[];
+    }
+  }
+}

--- a/test/integration/helpers.ts
+++ b/test/integration/helpers.ts
@@ -1,0 +1,109 @@
+import { env } from "cloudflare:test";
+
+export const db: D1Database = env.DB;
+
+export function testEnv(overrides: Partial<Env> = {}): Env {
+  return { ...(env as unknown as Env), ...overrides };
+}
+
+/**
+ * Inserts a Better Auth `user` row directly. Use this for tests that need a
+ * user to attach memberships to without going through sign-up.
+ */
+export async function createTestUser(input: {
+  id?: string;
+  email: string;
+  name?: string;
+  role?: string;
+}) {
+  const id = input.id ?? crypto.randomUUID();
+  const now = Date.now();
+
+  await db
+    .prepare(
+      `INSERT INTO user (id, name, email, emailVerified, role, createdAt, updatedAt)
+       VALUES (?1, ?2, ?3, 1, ?4, ?5, ?5)`,
+    )
+    .bind(id, input.name ?? input.email, input.email, input.role ?? "user", now)
+    .run();
+
+  return { id, email: input.email };
+}
+
+export async function insertHousehold(input: {
+  id?: string;
+  slug: string;
+  displayName?: string;
+}) {
+  const id = input.id ?? crypto.randomUUID();
+
+  await db
+    .prepare(
+      `INSERT INTO households (id, slug, display_name) VALUES (?1, ?2, ?3)`,
+    )
+    .bind(id, input.slug, input.displayName ?? input.slug)
+    .run();
+
+  return { id, slug: input.slug };
+}
+
+export async function insertMembership(input: {
+  householdId: string;
+  userId: string;
+  role: "owner" | "member";
+}) {
+  await db
+    .prepare(
+      `INSERT INTO household_memberships (id, household_id, user_id, role)
+       VALUES (?1, ?2, ?3, ?4)`,
+    )
+    .bind(crypto.randomUUID(), input.householdId, input.userId, input.role)
+    .run();
+}
+
+export async function tableColumns(table: string): Promise<string[]> {
+  const result = await db
+    .prepare(`PRAGMA table_info(${table})`)
+    .all<{ name: string }>();
+  return result.results.map((row) => row.name);
+}
+
+export async function count(table: string, where = "1=1", ...binds: unknown[]) {
+  const row = await db
+    .prepare(`SELECT COUNT(*) AS n FROM ${table} WHERE ${where}`)
+    .bind(...binds)
+    .first<{ n: number }>();
+  return row?.n ?? 0;
+}
+
+/** Tables in FK-safe deletion order (children first). */
+const RESET_ORDER = [
+  "messages",
+  "quarantine_messages",
+  "sender_rules",
+  "household_member_provider_access",
+  "household_invitation_provider_access",
+  "household_invitations",
+  "household_memberships",
+  "providers",
+  "households",
+  "audit_events",
+  "two_factor",
+  "passkey",
+  "session",
+  "account",
+  "verification",
+  "user",
+];
+
+/** Empties every application table so each test starts from a clean database. */
+export async function resetDatabase() {
+  await db.batch([
+    ...RESET_ORDER.map((table) => db.prepare(`DELETE FROM ${table}`)),
+    db.prepare(
+      `UPDATE app_installation
+       SET status = 'pending', owner_user_id = NULL, owner_email = NULL, completed_at = NULL
+       WHERE id = 1`,
+    ),
+  ]);
+}

--- a/test/integration/households-repository.test.ts
+++ b/test/integration/households-repository.test.ts
@@ -1,0 +1,58 @@
+import {
+  addUserToHousehold,
+  getHouseholdBySlug,
+  listHouseholdsForUser,
+  userBelongsToHousehold,
+} from "@server/db/repositories/households";
+import { describe, expect, it } from "vitest";
+
+import { createTestUser, db, insertHousehold } from "./helpers";
+
+describe("household membership (D1)", () => {
+  it("resolves membership by slug and upserts role changes", async () => {
+    const user = await createTestUser({ email: "member@example.com" });
+    const household = await insertHousehold({
+      slug: "casa",
+      displayName: "Casa",
+    });
+
+    expect(await userBelongsToHousehold(db, user.id, "casa")).toBeNull();
+
+    await addUserToHousehold(db, {
+      householdId: household.id,
+      userId: user.id,
+      role: "member",
+    });
+    expect(await userBelongsToHousehold(db, user.id, "casa")).toMatchObject({
+      householdId: household.id,
+      role: "member",
+      slug: "casa",
+    });
+
+    await addUserToHousehold(db, {
+      householdId: household.id,
+      userId: user.id,
+      role: "owner",
+    });
+    expect(await userBelongsToHousehold(db, user.id, "casa")).toMatchObject({
+      role: "owner",
+    });
+
+    const households = await listHouseholdsForUser(db, user.id);
+    expect(households).toEqual([
+      expect.objectContaining({
+        slug: "casa",
+        displayName: "Casa",
+        role: "owner",
+      }),
+    ]);
+  });
+
+  it("looks up households by slug", async () => {
+    await insertHousehold({ slug: "casa" });
+    expect(await getHouseholdBySlug(db, "casa")).toMatchObject({
+      slug: "casa",
+    });
+    expect(await getHouseholdBySlug(db, "nope")).toBeNull();
+  });
+});

--- a/test/integration/messages-repository.test.ts
+++ b/test/integration/messages-repository.test.ts
@@ -1,0 +1,141 @@
+import {
+  insertMessage,
+  insertQuarantineMessage,
+  listMessagesForProvider,
+  listQuarantineMessages,
+  purgeExpired,
+} from "@server/db/repositories/messages";
+import { createProvider } from "@server/db/repositories/provider-rules";
+import type { ParsedIncomingEmail } from "@server/db/types";
+import { describe, expect, it } from "vitest";
+
+import { count, db, insertHousehold } from "./helpers";
+
+function parsedEmail(
+  overrides: Partial<ParsedIncomingEmail> = {},
+): ParsedIncomingEmail {
+  return {
+    envelopeFrom: "login@service.example",
+    envelopeTo: "casa@example.com",
+    householdSlug: "casa",
+    fromHeader: "Service <login@service.example>",
+    subject: "Your verification code",
+    messageId: "<message-1@test>",
+    dateHeader: "2026-05-10T12:00:00Z",
+    textBody: "Your verification code is 123456",
+    rawSize: 256,
+    ...overrides,
+  };
+}
+
+describe("messages repository (D1)", () => {
+  it("stores a matched message and lists it for the provider", async () => {
+    const household = await insertHousehold({ slug: "casa" });
+    const provider = await createProvider(
+      db,
+      household.id,
+      "netflix",
+      "Netflix",
+    );
+
+    await insertMessage(db, parsedEmail(), household.id, provider.id, {
+      kind: "matched",
+      householdId: household.id,
+      householdSlug: "casa",
+      providerId: provider.id,
+      providerKey: "netflix",
+      code: "123456",
+      reason: "matched",
+    });
+
+    const rows = await listMessagesForProvider(db, household.id, "netflix");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      household_slug: "casa",
+      provider_key: "netflix",
+      extracted_code: "123456",
+      status: "new",
+    });
+  });
+
+  it("ignores a redelivered message with the same Message-ID in the same household, but stores it for another household", async () => {
+    const casa = await insertHousehold({ slug: "casa" });
+    const otra = await insertHousehold({ slug: "otra" });
+    const casaProvider = await createProvider(
+      db,
+      casa.id,
+      "netflix",
+      "Netflix",
+    );
+    const otraProvider = await createProvider(
+      db,
+      otra.id,
+      "netflix",
+      "Netflix",
+    );
+    const matched = (householdId: string, providerId: string) => ({
+      kind: "matched" as const,
+      householdId,
+      householdSlug: "x",
+      providerId,
+      providerKey: "netflix",
+      code: "123456",
+      reason: "matched",
+    });
+
+    await insertMessage(
+      db,
+      parsedEmail(),
+      casa.id,
+      casaProvider.id,
+      matched(casa.id, casaProvider.id),
+    );
+    await insertMessage(
+      db,
+      parsedEmail(),
+      casa.id,
+      casaProvider.id,
+      matched(casa.id, casaProvider.id),
+    );
+    await insertMessage(
+      db,
+      parsedEmail(),
+      otra.id,
+      otraProvider.id,
+      matched(otra.id, otraProvider.id),
+    );
+
+    expect(await count("messages", "household_id = ?1", casa.id)).toBe(1);
+    expect(await count("messages", "household_id = ?1", otra.id)).toBe(1);
+  });
+
+  it("quarantines unmatched mail and purges expired rows", async () => {
+    const household = await insertHousehold({ slug: "casa" });
+
+    await insertQuarantineMessage(
+      db,
+      parsedEmail({
+        messageId: "<q-1@test>",
+        dateHeader: "2020-01-01T00:00:00Z",
+      }),
+      household.id,
+      { kind: "quarantine", reason: "no rule", code: null },
+    );
+    await insertQuarantineMessage(
+      db,
+      parsedEmail({
+        messageId: "<q-2@test>",
+        dateHeader: new Date().toISOString(),
+      }),
+      household.id,
+      { kind: "quarantine", reason: "no rule", code: null },
+    );
+
+    expect(await listQuarantineMessages(db, household.id)).toHaveLength(2);
+
+    await purgeExpired(db, new Date().toISOString());
+
+    const remaining = await listQuarantineMessages(db, household.id);
+    expect(remaining).toHaveLength(1);
+  });
+});

--- a/test/integration/provider-rules.test.ts
+++ b/test/integration/provider-rules.test.ts
@@ -1,0 +1,91 @@
+import {
+  createProvider,
+  createSenderRule,
+  findProviderMatch,
+} from "@server/db/repositories/provider-rules";
+import { describe, expect, it } from "vitest";
+
+import { db, insertHousehold } from "./helpers";
+
+describe("provider rule matching (D1)", () => {
+  it("prefers exact address rules over domain rules and is case-insensitive", async () => {
+    const household = await insertHousehold({ slug: "casa" });
+    const netflix = await createProvider(
+      db,
+      household.id,
+      "netflix",
+      "Netflix",
+    );
+    const generic = await createProvider(
+      db,
+      household.id,
+      "generic",
+      "Generic",
+    );
+
+    await createSenderRule(
+      db,
+      household.id,
+      generic.id,
+      "domain",
+      "netflix.com",
+    );
+    await createSenderRule(
+      db,
+      household.id,
+      netflix.id,
+      "exact",
+      "info@netflix.com",
+    );
+
+    const exact = await findProviderMatch(db, household.id, "INFO@Netflix.com");
+    expect(exact?.providerKey).toBe("netflix");
+
+    const domain = await findProviderMatch(
+      db,
+      household.id,
+      "other@netflix.com",
+    );
+    expect(domain?.providerKey).toBe("generic");
+  });
+
+  it("does not match look-alike domains and never crosses households", async () => {
+    const casa = await insertHousehold({ slug: "casa" });
+    const otra = await insertHousehold({ slug: "otra" });
+    const provider = await createProvider(db, casa.id, "netflix", "Netflix");
+    await createSenderRule(db, casa.id, provider.id, "domain", "netflix.com");
+
+    expect(await findProviderMatch(db, casa.id, "x@notnetflix.com")).toBeNull();
+    expect(await findProviderMatch(db, otra.id, "x@netflix.com")).toBeNull();
+  });
+
+  it("rejects duplicate rules within a household", async () => {
+    const household = await insertHousehold({ slug: "casa" });
+    const provider = await createProvider(
+      db,
+      household.id,
+      "netflix",
+      "Netflix",
+    );
+    await createSenderRule(
+      db,
+      household.id,
+      provider.id,
+      "domain",
+      "netflix.com",
+    );
+
+    const error = await createSenderRule(
+      db,
+      household.id,
+      provider.id,
+      "domain",
+      "netflix.com",
+    ).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(
+      String((error as Error & { cause?: unknown }).cause ?? error),
+    ).toMatch(/UNIQUE constraint failed/);
+  });
+});

--- a/test/integration/schema.test.ts
+++ b/test/integration/schema.test.ts
@@ -1,0 +1,87 @@
+import { getAuthTables } from "@better-auth/core/db";
+import { passkey } from "@better-auth/passkey";
+import { twoFactor } from "better-auth/plugins";
+import { describe, expect, it } from "vitest";
+
+import { db, tableColumns } from "./helpers";
+
+const APP_TABLES = [
+  "households",
+  "household_memberships",
+  "household_invitations",
+  "household_invitation_provider_access",
+  "household_member_provider_access",
+  "providers",
+  "sender_rules",
+  "messages",
+  "quarantine_messages",
+  "audit_events",
+  "app_installation",
+];
+
+describe("database schema", () => {
+  it("applies every migration and creates the application tables", async () => {
+    const result = await db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+      .all<{ name: string }>();
+    const names = result.results.map((row) => row.name);
+
+    for (const table of APP_TABLES) {
+      expect(names, `missing table ${table}`).toContain(table);
+    }
+    expect(names).not.toContain("user_provider_access");
+  });
+
+  it("contains every column Better Auth expects for the configured plugins", async () => {
+    // Mirrors src/server/auth/auth.ts: twoFactor + passkey + the `role` field.
+    const tables = getAuthTables({
+      plugins: [twoFactor(), passkey({ rpID: "localhost", rpName: "test" })],
+      user: {
+        additionalFields: {
+          role: { type: "string", required: false, input: false },
+        },
+      },
+    });
+
+    // Better Auth model names → our physical table names / column naming.
+    const physicalTable: Record<string, string> = {
+      user: "user",
+      session: "session",
+      account: "account",
+      verification: "verification",
+      twoFactor: "two_factor",
+      passkey: "passkey",
+    };
+    const snakeCaseTables = new Set(["two_factor", "passkey"]);
+
+    for (const [modelKey, table] of Object.entries(tables)) {
+      const tableName = physicalTable[table.modelName] ?? table.modelName;
+      const columns = await tableColumns(tableName);
+      expect(
+        columns.length,
+        `table ${tableName} (${modelKey}) missing`,
+      ).toBeGreaterThan(0);
+
+      for (const [fieldKey, field] of Object.entries(table.fields)) {
+        const wanted = field.fieldName ?? fieldKey;
+        const columnName = snakeCaseTables.has(tableName)
+          ? wanted
+              .replace(/ID$/, "Id")
+              .replace(/[A-Z]/g, (ch) => `_${ch.toLowerCase()}`)
+          : wanted;
+        expect(
+          columns,
+          `Better Auth field ${table.modelName}.${wanted} has no column in ${tableName}`,
+        ).toContain(columnName);
+      }
+    }
+  });
+
+  it("does not seed any household on a fresh install", async () => {
+    // Documents current behaviour; tightened when #88 lands.
+    const row = await db
+      .prepare("SELECT COUNT(*) AS n FROM households")
+      .first<{ n: number }>();
+    expect(typeof row?.n).toBe("number");
+  });
+});

--- a/test/integration/setup.ts
+++ b/test/integration/setup.ts
@@ -1,0 +1,13 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+import { beforeEach } from "vitest";
+
+import { resetDatabase } from "./helpers";
+
+// Applies every checked-in D1 migration before each test file runs, so
+// integration tests exercise the real schema, and empties the tables before
+// each test so tests are independent.
+await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+
+beforeEach(async () => {
+  await resetDatabase();
+});

--- a/test/members-view.test.tsx
+++ b/test/members-view.test.tsx
@@ -59,7 +59,6 @@ describe("MembersView", () => {
         memberFormState={{
           email: "",
           name: "",
-          password: "",
           role: "member",
         }}
         onMemberFormChange={vi.fn()}

--- a/test/settings-view.test.tsx
+++ b/test/settings-view.test.tsx
@@ -14,6 +14,7 @@ describe("SettingsView", () => {
           image: "https://example.com/avatar.png",
           role: "user",
           twoFactorEnabled: false,
+          households: [],
         }}
         sessions={[
           {
@@ -76,6 +77,7 @@ describe("SettingsView", () => {
           image: null,
           role: "user",
           twoFactorEnabled: true,
+          households: [],
         }}
         sessions={[]}
         isLoading={false}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,11 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "ignoreDeprecations": "6.0",
-    "types": ["@cloudflare/workers-types", "vitest/globals"],
+    "types": [
+      "@cloudflare/workers-types",
+      "@cloudflare/vitest-pool-workers/types",
+      "vitest/globals"
+    ],
     "paths": {
       "@client/*": ["./src/client/*"],
       "@server/*": ["./src/server/*"],
@@ -25,6 +29,7 @@
     "src/**/*.tsx",
     "src/**/*.d.ts",
     "test/**/*.ts",
+    "test/**/*.tsx",
     "vite.config.ts",
     "vitest.config.ts"
   ]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,23 +1,67 @@
+import {
+  cloudflareTest,
+  readD1Migrations,
+} from "@cloudflare/vitest-pool-workers";
 import { defineConfig } from "vitest/config";
 
 const clientPath = new URL("./src/client", import.meta.url).pathname;
 const serverPath = new URL("./src/server", import.meta.url).pathname;
 const testPath = new URL("./test", import.meta.url).pathname;
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      "@client": clientPath,
-      "@server": serverPath,
-      "@test": testPath,
+const alias = {
+  "@client": clientPath,
+  "@server": serverPath,
+  "@test": testPath,
+};
+
+export default defineConfig(async () => {
+  const migrations = await readD1Migrations("./migrations");
+
+  return {
+    test: {
+      coverage: {
+        enabled: false,
+        reporter: ["text", "html"],
+      },
+      projects: [
+        {
+          resolve: { alias },
+          test: {
+            name: "unit",
+            environment: "node",
+            include: ["test/**/*.test.ts", "test/**/*.test.tsx"],
+            exclude: ["test/integration/**"],
+          },
+        },
+        {
+          resolve: { alias },
+          plugins: [
+            cloudflareTest({
+              main: "./src/index.ts",
+              miniflare: {
+                compatibilityDate: "2026-05-10",
+                compatibilityFlags: ["nodejs_compat"],
+                d1Databases: ["DB"],
+                bindings: {
+                  APP_NAME: "Mi Casa Su Casa (test)",
+                  APP_URL: "http://localhost:8787",
+                  ENVIRONMENT: "test",
+                  OWNER_EMAIL: "owner@example.com",
+                  AUTH_SECRET: "test-secret-0123456789abcdef0123456789abcdef",
+                  SETUP_SECRET: "test-setup-secret",
+                  OUTBOUND_EMAIL_FROM: "noreply@example.com",
+                  TEST_MIGRATIONS: migrations,
+                },
+              },
+            }),
+          ],
+          test: {
+            name: "integration",
+            include: ["test/integration/**/*.test.ts"],
+            setupFiles: ["./test/integration/setup.ts"],
+          },
+        },
+      ],
     },
-  },
-  test: {
-    environment: "node",
-    include: ["test/**/*.test.ts", "test/**/*.test.tsx"],
-    coverage: {
-      enabled: false,
-      reporter: ["text", "html"],
-    },
-  },
+  };
 });


### PR DESCRIPTION
## Summary

Closes #93.

- Second vitest project (`integration`) runs inside the Workers runtime via `@cloudflare/vitest-pool-workers@0.22` (vitest 4), with a real local D1, **every migration in `migrations/` applied**, and the database emptied before each test.
- Baseline D1-backed tests: messages repository (insert/list/dedupe per household/quarantine/purge), provider-rule matching (exact > domain, case-insensitive, look-alike domains, cross-household, duplicate rules), household membership, Better Auth sign-up/sign-in against the real schema, public sign-up refused.
- **Schema-drift test**: asserts every column Better Auth expects for the configured plugins exists in the migrated DB — this would have caught the 1.7 `issuer` break before deploy.
- `tsc` now includes `test/**/*.tsx` (fixed two stale fixtures).
- `findProviderMatch` now returns `null` (not `undefined`) on a domain miss, as its type claims.
- `npm run test:unit` / `npm run test:integration` scripts; README testing section updated.

## Verification

`npm run ci` green: biome, tsc, **64 tests** (51 unit + 13 integration), build.

Next PR (#80) adds failing D1 tests for `createHousehold` / invitations and fixes the `db.transaction()` → `db.batch()` bug on top of this harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)