### PR TITLE
fix: replace Drizzle transaction() with D1 batch() (setup/households/invitations 500)

### DIFF
--- a/src/server/db/repositories/households.ts
+++ b/src/server/db/repositories/households.ts
@@ -128,25 +128,26 @@ export async function createHousehold(
   },
 ) {
   const householdId = crypto.randomUUID();
+  const database = dbForDatabase(db);
 
-  await dbForDatabase(db).transaction(async (tx) => {
-    await tx.insert(households).values({
+  // D1 does not support SQL transactions (BEGIN/COMMIT); `batch` is atomic.
+  await database.batch([
+    database.insert(households).values({
       id: householdId,
       slug: input.slug,
       displayName: input.displayName,
       createdAt: sql`CURRENT_TIMESTAMP`,
       updatedAt: sql`CURRENT_TIMESTAMP`,
-    });
-
-    await tx.insert(householdMemberships).values({
+    }),
+    database.insert(householdMemberships).values({
       id: crypto.randomUUID(),
       householdId,
       userId: input.ownerUserId,
       role: "owner",
       createdAt: sql`CURRENT_TIMESTAMP`,
       updatedAt: sql`CURRENT_TIMESTAMP`,
-    });
-  });
+    }),
+  ]);
 
   return getHouseholdBySlug(db, input.slug);
 }

--- a/src/server/db/repositories/invitations.ts
+++ b/src/server/db/repositories/invitations.ts
@@ -1,6 +1,6 @@
 import { and, eq, inArray, sql } from "drizzle-orm";
 
-import { dbForDatabase } from "../client";
+import { type AppDatabase, dbForDatabase } from "../client";
 import {
   householdInvitationProviderAccess,
   householdInvitations,
@@ -47,9 +47,11 @@ export async function createHouseholdInvitation(
   },
 ) {
   const invitationId = crypto.randomUUID();
+  const database = dbForDatabase(db);
 
-  await dbForDatabase(db).transaction(async (tx) => {
-    await tx.insert(householdInvitations).values({
+  // D1 does not support SQL transactions (BEGIN/COMMIT); `batch` is atomic.
+  await database.batch([
+    database.insert(householdInvitations).values({
       id: invitationId,
       householdId: input.householdId,
       email: input.email,
@@ -64,19 +66,9 @@ export async function createHouseholdInvitation(
       cancelledAt: null,
       createdAt: sql`CURRENT_TIMESTAMP`,
       updatedAt: sql`CURRENT_TIMESTAMP`,
-    });
-
-    if (input.providerIds.length > 0) {
-      await tx.insert(householdInvitationProviderAccess).values(
-        input.providerIds.map((providerId) => ({
-          id: crypto.randomUUID(),
-          invitationId,
-          providerId,
-          createdAt: sql`CURRENT_TIMESTAMP`,
-        })),
-      );
-    }
-  });
+    }),
+    ...invitationProviderInserts(database, invitationId, input.providerIds),
+  ]);
 
   return invitationId;
 }
@@ -223,8 +215,11 @@ export async function acceptInvitation(
     role: InvitationRole;
   },
 ) {
-  await dbForDatabase(db).transaction(async (tx) => {
-    await tx
+  const database = dbForDatabase(db);
+
+  // D1 does not support SQL transactions (BEGIN/COMMIT); `batch` is atomic.
+  await database.batch([
+    database
       .insert(householdMemberships)
       .values({
         id: crypto.randomUUID(),
@@ -240,9 +235,8 @@ export async function acceptInvitation(
           role: input.role,
           updatedAt: sql`CURRENT_TIMESTAMP`,
         },
-      });
-
-    await tx
+      }),
+    database
       .update(householdInvitations)
       .set({
         status: "accepted",
@@ -250,8 +244,8 @@ export async function acceptInvitation(
         acceptedAt: sql`CURRENT_TIMESTAMP`,
         updatedAt: sql`CURRENT_TIMESTAMP`,
       })
-      .where(eq(householdInvitations.id, input.invitationId));
-  });
+      .where(eq(householdInvitations.id, input.invitationId)),
+  ]);
 }
 
 export async function refreshExpiredInvitations(db: D1Database) {
@@ -351,22 +345,34 @@ export async function replaceInvitationProviders(
   invitationId: string,
   providerIds: string[],
 ) {
-  await dbForDatabase(db).transaction(async (tx) => {
-    await tx
-      .delete(householdInvitationProviderAccess)
-      .where(eq(householdInvitationProviderAccess.invitationId, invitationId));
+  const database = dbForDatabase(db);
 
-    if (providerIds.length > 0) {
-      await tx.insert(householdInvitationProviderAccess).values(
-        providerIds.map((providerId) => ({
-          id: crypto.randomUUID(),
-          invitationId,
-          providerId,
-          createdAt: sql`CURRENT_TIMESTAMP`,
-        })),
-      );
-    }
-  });
+  // D1 does not support SQL transactions (BEGIN/COMMIT); `batch` is atomic.
+  await database.batch([
+    database
+      .delete(householdInvitationProviderAccess)
+      .where(eq(householdInvitationProviderAccess.invitationId, invitationId)),
+    ...invitationProviderInserts(database, invitationId, providerIds),
+  ]);
+}
+
+/**
+ * One insert statement per provider so each statement stays well under D1's
+ * bound-parameter limit regardless of how many providers are scoped.
+ */
+function invitationProviderInserts(
+  database: AppDatabase,
+  invitationId: string,
+  providerIds: string[],
+) {
+  return providerIds.map((providerId) =>
+    database.insert(householdInvitationProviderAccess).values({
+      id: crypto.randomUUID(),
+      invitationId,
+      providerId,
+      createdAt: sql`CURRENT_TIMESTAMP`,
+    }),
+  );
 }
 
 export async function getProvidersByIds(db: D1Database, providerIds: string[]) {

--- a/test/integration/invitations-repository.test.ts
+++ b/test/integration/invitations-repository.test.ts
@@ -1,0 +1,183 @@
+import {
+  createHousehold,
+  userBelongsToHousehold,
+} from "@server/db/repositories/households";
+import {
+  acceptInvitation,
+  createHouseholdInvitation,
+  getInvitationByTokenHash,
+  getProvidersForInvitation,
+  replaceInvitationProviders,
+} from "@server/db/repositories/invitations";
+import { createProvider } from "@server/db/repositories/provider-rules";
+import { describe, expect, it } from "vitest";
+
+import { count, createTestUser, db } from "./helpers";
+
+const inAWeek = () =>
+  new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+
+describe("households + invitations multi-statement writes (D1)", () => {
+  it("createHousehold inserts the household and the owner membership", async () => {
+    const owner = await createTestUser({ email: "owner@example.com" });
+
+    const household = await createHousehold(db, {
+      slug: "casa",
+      displayName: "Casa",
+      ownerUserId: owner.id,
+    });
+
+    expect(household).toMatchObject({ slug: "casa", displayName: "Casa" });
+    expect(await userBelongsToHousehold(db, owner.id, "casa")).toMatchObject({
+      role: "owner",
+    });
+    expect(await count("households")).toBe(1);
+    expect(await count("household_memberships")).toBe(1);
+  });
+
+  it("createHouseholdInvitation stores the invitation with its provider scope", async () => {
+    const owner = await createTestUser({ email: "owner@example.com" });
+    const household = await createHousehold(db, {
+      slug: "casa",
+      displayName: "Casa",
+      ownerUserId: owner.id,
+    });
+    const netflix = await createProvider(
+      db,
+      household!.id,
+      "netflix",
+      "Netflix",
+    );
+    const spotify = await createProvider(
+      db,
+      household!.id,
+      "spotify",
+      "Spotify",
+    );
+
+    const invitationId = await createHouseholdInvitation(db, {
+      householdId: household!.id,
+      email: "kid@example.com",
+      name: "Kid",
+      role: "member",
+      tokenHash: "hash-1",
+      invitedByUserId: owner.id,
+      expiresAt: inAWeek(),
+      providerIds: [netflix.id, spotify.id],
+    });
+
+    const invitation = await getInvitationByTokenHash(db, "hash-1");
+    expect(invitation).toMatchObject({
+      id: invitationId,
+      email: "kid@example.com",
+      status: "pending",
+      role: "member",
+    });
+    const scoped = await getProvidersForInvitation(db, invitationId);
+    expect(scoped.map((p) => p.provider_key).sort()).toEqual([
+      "netflix",
+      "spotify",
+    ]);
+
+    // No provider scope is also valid.
+    await createHouseholdInvitation(db, {
+      householdId: household!.id,
+      email: "other@example.com",
+      name: "Other",
+      role: "member",
+      tokenHash: "hash-2",
+      invitedByUserId: owner.id,
+      expiresAt: inAWeek(),
+      providerIds: [],
+    });
+    expect(await count("household_invitations")).toBe(2);
+  });
+
+  it("replaceInvitationProviders swaps the provider scope atomically", async () => {
+    const owner = await createTestUser({ email: "owner@example.com" });
+    const household = await createHousehold(db, {
+      slug: "casa",
+      displayName: "Casa",
+      ownerUserId: owner.id,
+    });
+    const netflix = await createProvider(
+      db,
+      household!.id,
+      "netflix",
+      "Netflix",
+    );
+    const spotify = await createProvider(
+      db,
+      household!.id,
+      "spotify",
+      "Spotify",
+    );
+    const invitationId = await createHouseholdInvitation(db, {
+      householdId: household!.id,
+      email: "kid@example.com",
+      name: "Kid",
+      role: "member",
+      tokenHash: "hash-1",
+      invitedByUserId: owner.id,
+      expiresAt: inAWeek(),
+      providerIds: [netflix.id],
+    });
+
+    await replaceInvitationProviders(db, invitationId, [spotify.id]);
+    expect(
+      (await getProvidersForInvitation(db, invitationId)).map(
+        (p) => p.provider_key,
+      ),
+    ).toEqual(["spotify"]);
+
+    await replaceInvitationProviders(db, invitationId, []);
+    expect(await getProvidersForInvitation(db, invitationId)).toEqual([]);
+  });
+
+  it("acceptInvitation creates the membership, marks the invitation accepted, and is idempotent on re-accept", async () => {
+    const owner = await createTestUser({ email: "owner@example.com" });
+    const kid = await createTestUser({ email: "kid@example.com" });
+    const household = await createHousehold(db, {
+      slug: "casa",
+      displayName: "Casa",
+      ownerUserId: owner.id,
+    });
+    const invitationId = await createHouseholdInvitation(db, {
+      householdId: household!.id,
+      email: "kid@example.com",
+      name: "Kid",
+      role: "member",
+      tokenHash: "hash-1",
+      invitedByUserId: owner.id,
+      expiresAt: inAWeek(),
+      providerIds: [],
+    });
+
+    await acceptInvitation(db, {
+      invitationId,
+      householdId: household!.id,
+      acceptedByUserId: kid.id,
+      role: "member",
+    });
+
+    expect(await userBelongsToHousehold(db, kid.id, "casa")).toMatchObject({
+      role: "member",
+    });
+    expect(await getInvitationByTokenHash(db, "hash-1")).toMatchObject({
+      status: "accepted",
+      acceptedByUserId: kid.id,
+    });
+
+    // Re-accepting with a higher role upserts the membership instead of failing.
+    await acceptInvitation(db, {
+      invitationId,
+      householdId: household!.id,
+      acceptedByUserId: kid.id,
+      role: "owner",
+    });
+    expect(await userBelongsToHousehold(db, kid.id, "casa")).toMatchObject({
+      role: "owner",
+    });
+    expect(await count("household_memberships")).toBe(2);
+  });
+});

--- a/test/integration/invitations-repository.test.ts
+++ b/test/integration/invitations-repository.test.ts
@@ -17,6 +17,18 @@ import { count, createTestUser, db } from "./helpers";
 const inAWeek = () =>
   new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
 
+async function createOwnedHousehold(ownerUserId: string) {
+  const household = await createHousehold(db, {
+    slug: "casa",
+    displayName: "Casa",
+    ownerUserId,
+  });
+  if (!household) {
+    throw new Error("household was not created");
+  }
+  return household;
+}
+
 describe("households + invitations multi-statement writes (D1)", () => {
   it("createHousehold inserts the household and the owner membership", async () => {
     const owner = await createTestUser({ email: "owner@example.com" });
@@ -37,26 +49,22 @@ describe("households + invitations multi-statement writes (D1)", () => {
 
   it("createHouseholdInvitation stores the invitation with its provider scope", async () => {
     const owner = await createTestUser({ email: "owner@example.com" });
-    const household = await createHousehold(db, {
-      slug: "casa",
-      displayName: "Casa",
-      ownerUserId: owner.id,
-    });
+    const household = await createOwnedHousehold(owner.id);
     const netflix = await createProvider(
       db,
-      household!.id,
+      household.id,
       "netflix",
       "Netflix",
     );
     const spotify = await createProvider(
       db,
-      household!.id,
+      household.id,
       "spotify",
       "Spotify",
     );
 
     const invitationId = await createHouseholdInvitation(db, {
-      householdId: household!.id,
+      householdId: household.id,
       email: "kid@example.com",
       name: "Kid",
       role: "member",
@@ -81,7 +89,7 @@ describe("households + invitations multi-statement writes (D1)", () => {
 
     // No provider scope is also valid.
     await createHouseholdInvitation(db, {
-      householdId: household!.id,
+      householdId: household.id,
       email: "other@example.com",
       name: "Other",
       role: "member",
@@ -95,25 +103,21 @@ describe("households + invitations multi-statement writes (D1)", () => {
 
   it("replaceInvitationProviders swaps the provider scope atomically", async () => {
     const owner = await createTestUser({ email: "owner@example.com" });
-    const household = await createHousehold(db, {
-      slug: "casa",
-      displayName: "Casa",
-      ownerUserId: owner.id,
-    });
+    const household = await createOwnedHousehold(owner.id);
     const netflix = await createProvider(
       db,
-      household!.id,
+      household.id,
       "netflix",
       "Netflix",
     );
     const spotify = await createProvider(
       db,
-      household!.id,
+      household.id,
       "spotify",
       "Spotify",
     );
     const invitationId = await createHouseholdInvitation(db, {
-      householdId: household!.id,
+      householdId: household.id,
       email: "kid@example.com",
       name: "Kid",
       role: "member",
@@ -137,13 +141,9 @@ describe("households + invitations multi-statement writes (D1)", () => {
   it("acceptInvitation creates the membership, marks the invitation accepted, and is idempotent on re-accept", async () => {
     const owner = await createTestUser({ email: "owner@example.com" });
     const kid = await createTestUser({ email: "kid@example.com" });
-    const household = await createHousehold(db, {
-      slug: "casa",
-      displayName: "Casa",
-      ownerUserId: owner.id,
-    });
+    const household = await createOwnedHousehold(owner.id);
     const invitationId = await createHouseholdInvitation(db, {
-      householdId: household!.id,
+      householdId: household.id,
       email: "kid@example.com",
       name: "Kid",
       role: "member",
@@ -155,7 +155,7 @@ describe("households + invitations multi-statement writes (D1)", () => {
 
     await acceptInvitation(db, {
       invitationId,
-      householdId: household!.id,
+      householdId: household.id,
       acceptedByUserId: kid.id,
       role: "member",
     });
@@ -171,7 +171,7 @@ describe("households + invitations multi-statement writes (D1)", () => {
     // Re-accepting with a higher role upserts the membership instead of failing.
     await acceptInvitation(db, {
       invitationId,
-      householdId: household!.id,
+      householdId: household.id,
       acceptedByUserId: kid.id,
       role: "owner",
     });

--- a/test/integration/setup-route.test.ts
+++ b/test/integration/setup-route.test.ts
@@ -1,0 +1,69 @@
+import { SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+import { count } from "./helpers";
+
+const setupPayload = {
+  email: "owner@example.com",
+  name: "Owner",
+  password: "averylongpassword123",
+  householdName: "Casa",
+  householdSlug: "casa",
+  setupSecret: "test-setup-secret",
+};
+
+async function postSetup(body: unknown) {
+  return SELF.fetch("http://localhost:8787/api/setup/complete", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("first-run setup (end-to-end against D1)", () => {
+  it("creates the owner, the household and the owner membership, then locks", async () => {
+    const status = await SELF.fetch("http://localhost:8787/api/setup/status");
+    expect(await status.json()).toMatchObject({
+      needsSetup: true,
+      status: "pending",
+    });
+
+    const response = await postSetup(setupPayload);
+    expect(response.status).toBe(201);
+    const payload = await response.json<{
+      member: { email: string; role: string };
+      household: { slug: string };
+    }>();
+    expect(payload.member).toMatchObject({
+      email: "owner@example.com",
+      role: "owner",
+    });
+    expect(payload.household).toMatchObject({ slug: "casa" });
+    expect(response.headers.getSetCookie().join(";")).toMatch(/better-auth/);
+
+    expect(await count("user")).toBe(1);
+    expect(await count("households", "slug = ?1", "casa")).toBe(1);
+    expect(await count("household_memberships", "role = 'owner'")).toBe(1);
+
+    const locked = await SELF.fetch("http://localhost:8787/api/setup/status");
+    expect(await locked.json()).toMatchObject({
+      needsSetup: false,
+      setupLocked: true,
+    });
+
+    const again = await postSetup(setupPayload);
+    expect(again.status).toBe(409);
+  });
+
+  it("rejects a wrong setup secret or a non-owner email without creating anything", async () => {
+    expect(
+      (await postSetup({ ...setupPayload, setupSecret: "nope" })).status,
+    ).toBe(403);
+    expect(
+      (await postSetup({ ...setupPayload, email: "someone-else@example.com" }))
+        .status,
+    ).toBe(403);
+    expect(await count("user")).toBe(0);
+    expect(await count("households")).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #80.

D1 rejects SQL `BEGIN`/`COMMIT`, so every Drizzle `db.transaction()` call failed with `Failed query: begin` → first-run `/setup`, "Create household", invitation create/resend/accept and provider-scope updates all returned 500 (on `main` since #38).

- `createHousehold`, `createHouseholdInvitation`, `acceptInvitation`, `replaceInvitationProviders` now use `db.batch([...])`, which D1 executes atomically; provider-scope rows are one insert per provider (bound-parameter limit).
- No `.transaction(` remains under `src/server`.

## Tests (TDD — red first, then green)

- `test/integration/invitations-repository.test.ts`: the four functions against real D1, including the re-accept upsert path and empty provider scopes.
- `test/integration/setup-route.test.ts`: **end-to-end `POST /api/setup/complete`** via `SELF.fetch` — creates owner + household + membership, sets the session cookie, locks setup (409 on retry), rejects wrong secret / non-owner email without side effects.

`npm run ci` green: biome, tsc, 70 tests (51 unit + 19 integration), build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)