### PR TITLE
fix: keep dashboard variables across deploys (keep_vars) and correct config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Fill in:
 - `AUTH_SECRET`
 - `SETUP_SECRET`
 
-Set `OWNER_EMAIL` in the top-level `vars` section of `wrangler.jsonc` to your email address for local development. For CI/CD deployments, all environment-specific values (D1 database IDs, URLs, owner email) are injected automatically from GitHub secrets and variables — see [`docs/ci-cd-architecture.md`](./docs/ci-cd-architecture.md).
+Set `OWNER_EMAIL` in the top-level `vars` section of `wrangler.jsonc` to your email address for local development. For CI/CD deployments, the D1 database IDs are injected from GitHub secrets, while runtime variables (`APP_URL`, `OWNER_EMAIL`, `OUTBOUND_EMAIL_FROM`) and secrets are set once per Worker in the Cloudflare dashboard and preserved across deploys (`keep_vars` in `wrangler.jsonc`) — see [`docs/ci-cd-architecture.md`](./docs/ci-cd-architecture.md).
 
 ### Apply local migrations
 

--- a/docs/ci-cd-architecture.md
+++ b/docs/ci-cd-architecture.md
@@ -81,7 +81,9 @@ This is the explicit production schema step required by issue #8.
 
 D1 `database_id` values are **not hardcoded** in `wrangler.jsonc`. They are injected at deploy time by the GitHub Actions workflows via `sed` from GitHub secrets before Wrangler runs.
 
-Runtime variables (`APP_URL`, `OWNER_EMAIL`) and secrets (`AUTH_SECRET`, `SETUP_SECRET`) are configured directly in the Cloudflare dashboard for each Worker. They persist across deploys and do not depend on GitHub Actions.
+Runtime variables (`APP_URL`, `OWNER_EMAIL`, `OUTBOUND_EMAIL_FROM`) and secrets (`AUTH_SECRET`, `SETUP_SECRET`) are configured directly in the Cloudflare dashboard for each Worker. They persist across deploys and do not depend on GitHub Actions.
+
+> **Why `keep_vars` matters:** by default Wrangler treats `wrangler.jsonc` as the source of truth and **deletes** any plaintext variable that is set in the dashboard but not in the config on every `wrangler deploy` (secrets are never touched). `wrangler.jsonc` sets `"keep_vars": true` so dashboard variables survive deploys. Do not remove it unless you move those variables into the config or pass them with `wrangler deploy --var`.
 
 This design means forkers never need to edit `wrangler.jsonc` — just add the required secrets and variables to their GitHub repository and Cloudflare dashboard.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@cloudflare/vite-plugin": "1.53.1",
         "@cloudflare/vitest-pool-workers": "^0.22.0",
         "@cloudflare/workers-types": "5.20260820.1",
+        "@types/node": "^26.2.0",
         "@types/react": "19.2.18",
         "@types/react-dom": "19.2.4",
         "@vitejs/plugin-react": "6.1.0",
@@ -3010,6 +3011,16 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -5467,6 +5478,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.24",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@cloudflare/vite-plugin": "1.53.1",
     "@cloudflare/vitest-pool-workers": "^0.22.0",
     "@cloudflare/workers-types": "5.20260820.1",
+    "@types/node": "^26.2.0",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",
     "@vitejs/plugin-react": "6.1.0",

--- a/test/wrangler-config.test.ts
+++ b/test/wrangler-config.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function loadWranglerConfig() {
+  const raw = readFileSync(
+    new URL("../wrangler.jsonc", import.meta.url),
+    "utf8",
+  );
+  // Strip // line comments (the file has no block comments or URLs in strings).
+  const json = raw
+    .split("\n")
+    .map((line: string) => line.replace(/^\s*\/\/.*$/, ""))
+    .join("\n");
+  return JSON.parse(json) as {
+    keep_vars?: boolean;
+    vars?: Record<string, string>;
+    env?: Record<string, { vars?: Record<string, string> }>;
+  };
+}
+
+describe("wrangler.jsonc deployment contract", () => {
+  const config = loadWranglerConfig();
+
+  it("preserves dashboard-configured variables across deploys", () => {
+    // Operators set APP_URL / OWNER_EMAIL / OUTBOUND_EMAIL_FROM in the dashboard;
+    // without keep_vars every deploy would delete them (#81).
+    expect(config.keep_vars).toBe(true);
+  });
+
+  it("sets NODE_ENV=production for deployed environments so Better Auth enforces production safeguards", () => {
+    expect(config.env?.preview?.vars?.NODE_ENV).toBe("production");
+    expect(config.env?.production?.vars?.NODE_ENV).toBe("production");
+  });
+
+  it("never ships local development values to deployed environments", () => {
+    for (const name of ["preview", "production"]) {
+      const vars = config.env?.[name]?.vars ?? {};
+      expect(vars.APP_URL, `${name} must not hardcode APP_URL`).toBeUndefined();
+      expect(
+        vars.OWNER_EMAIL,
+        `${name} must not hardcode OWNER_EMAIL`,
+      ).toBeUndefined();
+      expect(vars.ENVIRONMENT).toBe(name);
+    }
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "types": [
       "@cloudflare/workers-types",
       "@cloudflare/vitest-pool-workers/types",
+      "node",
       "vitest/globals"
     ],
     "paths": {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,6 +4,11 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-05-10",
   "compatibility_flags": ["nodejs_compat"],
+  // Runtime variables such as APP_URL, OWNER_EMAIL and OUTBOUND_EMAIL_FROM are
+  // set per Worker in the Cloudflare dashboard. By default Wrangler treats this
+  // file as the source of truth and DELETES dashboard vars on every deploy;
+  // keep_vars makes deploys preserve them.
+  "keep_vars": true,
   "assets": {
     "directory": "./dist/client",
     "binding": "ASSETS",
@@ -49,7 +54,8 @@
           "name": "EMAIL"
         }
       ],
-      // APP_URL and OWNER_EMAIL are injected at deploy time via --var from GitHub variables.
+      // APP_URL, OWNER_EMAIL and OUTBOUND_EMAIL_FROM are set in the Cloudflare
+      // dashboard for this Worker and preserved across deploys (keep_vars).
       "vars": {
         "APP_NAME": "Mi Casa Su Casa (Preview)",
         "ENVIRONMENT": "preview",
@@ -73,7 +79,8 @@
           "name": "EMAIL"
         }
       ],
-      // APP_URL and OWNER_EMAIL are injected at deploy time via --var from GitHub variables.
+      // APP_URL, OWNER_EMAIL and OUTBOUND_EMAIL_FROM are set in the Cloudflare
+      // dashboard for this Worker and preserved across deploys (keep_vars).
       "vars": {
         "APP_NAME": "Mi Casa Su Casa",
         "ENVIRONMENT": "production",


### PR DESCRIPTION
## Summary

Closes #81.

Wrangler treats `wrangler.jsonc` as the source of truth and **deletes dashboard plaintext vars on every deploy**, so the documented setup (`APP_URL` / `OWNER_EMAIL` / `OUTBOUND_EMAIL_FROM` in the dashboard) was undone by each push to `main` — leaving Better Auth without a `baseURL`, passkeys bound to `localhost`, invitation creation throwing, and `/setup` unavailable. (After #124 this now surfaces as a loud 503 `misconfigured` instead of silent degradation.)

- `wrangler.jsonc`: `"keep_vars": true` with an explanatory comment; removed the stale "injected via `--var` from GitHub variables" comments (no workflow ever did that).
- README / `docs/ci-cd-architecture.md`: describe the actual mechanism (D1 ids via GitHub secrets; runtime vars + secrets once in the dashboard, preserved by `keep_vars`).
- `test/wrangler-config.test.ts`: config-contract test — `keep_vars` is true, deployed envs set `NODE_ENV=production`, and never hardcode dev `APP_URL`/`OWNER_EMAIL`.
- `@types/node` added for the test (reads the config file).

`npm run ci` green: 82 tests, build, `wrangler deploy --dry-run --env production` OK.

## Operator note
After this merges, set `APP_URL`, `OWNER_EMAIL`, `OUTBOUND_EMAIL_FROM` (plaintext) and `AUTH_SECRET`, `SETUP_SECRET` (secrets) once on each Worker in the Cloudflare dashboard — they will now survive deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)