### PR TITLE
fix: deliver invitation and reset emails reliably and surface failures

### DIFF
--- a/docs/email-routing.md
+++ b/docs/email-routing.md
@@ -96,6 +96,15 @@ Cloudflare Email Routing can coexist with another provider if you:
 
 > **Warning**: Enabling Email Routing changes MX records to point to Cloudflare. All mail for the domain flows through Cloudflare first. Make sure the fallback address is configured correctly or you may lose mail intended for your primary provider.
 
+## Sending email (invitations and password resets)
+
+The Worker sends invitation and password-reset emails through the `send_email` binding (`EMAIL` in `wrangler.jsonc`). For that to work:
+
+1. Set `OUTBOUND_EMAIL_FROM` on the Worker (Cloudflare dashboard → Settings → Variables) to an address on a domain where Email Routing is enabled, e.g. `noreply@home.yourdomain.com`. Cloudflare only allows sending from addresses on your Email Routing domains.
+2. While the destination domain is not yet verified for sending, Cloudflare may reject sends to arbitrary addresses; add verified destination addresses under **Email → Email Routing → Destination addresses** if you hit rejections.
+
+If an invitation email cannot be delivered, the API still creates the invitation and returns `emailSent: false` together with the `inviteUrl`; the app shows a **Copy invite link** action so the owner can share it directly. Delivery failures are logged as `{"event":"invitation_email_failed", ...}` in Workers Logs.
+
 ## Local development
 
 Email routing is a Cloudflare infrastructure feature and does not run locally. To test the email pipeline during development, post a raw RFC 5322 message to the Wrangler dev endpoint:

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,6 +1,7 @@
 import {
   Alert,
   Box,
+  Button,
   CircularProgress,
   Snackbar,
   Typography,
@@ -36,6 +37,7 @@ import type {
   HouseholdSettingsResponse,
   HouseholdSummary,
   InboxMessage,
+  InvitationDeliveryResponse,
   InvitationFormState,
   InvitationSummary,
   MemberFormState,
@@ -215,6 +217,38 @@ export function App() {
 
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [viewError, setViewError] = useState<string | null>(null);
+  const [pendingInviteLink, setPendingInviteLink] = useState<string | null>(
+    null,
+  );
+
+  function reportInvitationDelivery(
+    result: InvitationDeliveryResponse,
+    sentMessage: string,
+  ) {
+    if (result.emailSent) {
+      setPendingInviteLink(null);
+      setStatusMessage(sentMessage);
+      return;
+    }
+
+    setPendingInviteLink(result.inviteUrl);
+    setViewError(
+      "The invitation was created, but the email could not be sent. Copy the invite link and share it directly.",
+    );
+  }
+
+  async function copyPendingInviteLink() {
+    if (!pendingInviteLink) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(pendingInviteLink);
+      setViewError(null);
+      setStatusMessage("Invite link copied.");
+    } catch {
+      window.prompt("Copy the invite link:", pendingInviteLink);
+    }
+  }
 
   const isAuthenticated = Boolean(session?.user?.email);
   const currentHousehold = routeSlug
@@ -1328,7 +1362,7 @@ export function App() {
     setViewError(null);
 
     try {
-      await fetchJson<{ invitation: InvitationSummary }>(
+      const result = await fetchJson<InvitationDeliveryResponse>(
         householdApiPath("/admin/members"),
         {
           method: "POST",
@@ -1337,7 +1371,7 @@ export function App() {
       );
 
       setMemberFormState(INITIAL_MEMBER_FORM_STATE);
-      setStatusMessage("Invitation email sent.");
+      reportInvitationDelivery(result, "Invitation email sent.");
       await refreshInvitations();
       return true;
     } catch (error) {
@@ -1361,7 +1395,7 @@ export function App() {
     setViewError(null);
 
     try {
-      await fetchJson<{ invitation: InvitationSummary }>(
+      const result = await fetchJson<InvitationDeliveryResponse>(
         householdApiPath("/admin/invitations"),
         {
           method: "POST",
@@ -1370,7 +1404,7 @@ export function App() {
       );
 
       setInvitationFormState(INITIAL_INVITATION_FORM_STATE);
-      setStatusMessage("Invitation email sent.");
+      reportInvitationDelivery(result, "Invitation email sent.");
       await refreshInvitations();
       return true;
     } catch (error) {
@@ -1389,14 +1423,14 @@ export function App() {
     setViewError(null);
 
     try {
-      await fetchJson<{ invitation: InvitationSummary }>(
+      const result = await fetchJson<InvitationDeliveryResponse>(
         householdApiPath(`/admin/invitations/${invitationId}/resend`),
         {
           method: "POST",
         },
       );
 
-      setStatusMessage("Invitation resent.");
+      reportInvitationDelivery(result, "Invitation resent.");
       await refreshInvitations();
     } catch (error) {
       setViewError(
@@ -2057,6 +2091,17 @@ export function App() {
           severity={viewError ? "error" : "success"}
           variant="filled"
           sx={{ width: "100%" }}
+          action={
+            viewError && pendingInviteLink ? (
+              <Button
+                color="inherit"
+                size="small"
+                onClick={() => void copyPendingInviteLink()}
+              >
+                Copy invite link
+              </Button>
+            ) : undefined
+          }
         >
           {viewError || statusMessage}
         </Alert>

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -223,3 +223,10 @@ export type CreateHouseholdFormState = {
   displayName: string;
   slug: string;
 };
+
+export type InvitationDeliveryResponse = {
+  invitation: InvitationSummary;
+  inviteUrl: string;
+  emailSent: boolean;
+  emailError?: string;
+};

--- a/src/server/auth/auth-context.ts
+++ b/src/server/auth/auth-context.ts
@@ -2,6 +2,7 @@ export type AuthContext = {
   user: {
     id: string;
     email: string;
+    name: string;
     role: string;
     households: Array<{
       id: string;

--- a/src/server/auth/auth.ts
+++ b/src/server/auth/auth.ts
@@ -36,11 +36,22 @@ function createAuth(env: Env, options: { disableSignUp: boolean }) {
       minPasswordLength: 12,
       maxPasswordLength: 128,
       sendResetPassword: async ({ user, url }) => {
-        void sendPasswordResetEmail(env, {
-          to: user.email,
-          recipientName: user.name,
-          resetUrl: url,
-        });
+        try {
+          await sendPasswordResetEmail(env, {
+            to: user.email,
+            recipientName: user.name,
+            resetUrl: url,
+          });
+        } catch (error) {
+          console.error(
+            JSON.stringify({
+              event: "password_reset_email_failed",
+              userId: user.id,
+              error: error instanceof Error ? error.message : String(error),
+            }),
+          );
+          throw error;
+        }
       },
     },
     user: {

--- a/src/server/auth/middleware.ts
+++ b/src/server/auth/middleware.ts
@@ -29,6 +29,10 @@ export const loadAuthSession: MiddlewareHandler<{
       ? {
           id: result.user.id,
           email: result.user.email,
+          name:
+            typeof result.user.name === "string" && result.user.name.trim()
+              ? result.user.name.trim()
+              : result.user.email,
           role,
           households,
         }

--- a/src/server/routes/admin.ts
+++ b/src/server/routes/admin.ts
@@ -43,6 +43,58 @@ import {
 import { sendHouseholdInvitationEmail } from "../email/sender";
 import { createInvitationToken } from "../security/tokens";
 
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isValidEmail(value: string) {
+  return EMAIL_PATTERN.test(value) && value.length <= 254;
+}
+
+function buildInviteUrl(env: Env, token: string) {
+  return `${env.APP_URL.replace(/\/$/, "")}/invite/${token}`;
+}
+
+/**
+ * Sends the invitation email and reports whether it was delivered to the
+ * email binding. Failures are logged and surfaced to the caller instead of
+ * being swallowed, so the owner can fall back to sharing the link manually.
+ */
+async function deliverInvitationEmail(
+  env: Env,
+  input: {
+    invitationId: string;
+    to: string;
+    inviteeName: string;
+    inviter: { name: string; email: string };
+    inviteUrl: string;
+    expiresAt: string;
+    role: InvitationRole;
+  },
+): Promise<{ emailSent: boolean; emailError?: string }> {
+  try {
+    await sendHouseholdInvitationEmail(env, {
+      to: input.to,
+      inviteeName: input.inviteeName,
+      inviterName: input.inviter.name,
+      inviterEmail: input.inviter.email,
+      inviteUrl: input.inviteUrl,
+      expiresAt: input.expiresAt,
+      role: input.role,
+    });
+    return { emailSent: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(
+      JSON.stringify({
+        event: "invitation_email_failed",
+        invitationId: input.invitationId,
+        to: input.to,
+        error: message,
+      }),
+    );
+    return { emailSent: false, emailError: message };
+  }
+}
+
 type AccessPayload = {
   providerKey?: string;
 };
@@ -463,6 +515,10 @@ adminRoutes.post("/:slug/invitations", async (c) => {
     return c.json({ error: "email and name are required" }, 400);
   }
 
+  if (!isValidEmail(email)) {
+    return c.json({ error: "email must be a valid email address" }, 400);
+  }
+
   const providersBelong = await assertProvidersBelongToHousehold(
     c.env.DB,
     household.id,
@@ -505,17 +561,18 @@ adminRoutes.post("/:slug/invitations", async (c) => {
     return c.json({ error: "Unable to create invitation" }, 500);
   }
 
-  void sendHouseholdInvitationEmail(c.env, {
+  const inviteUrl = buildInviteUrl(c.env, token);
+  const delivery = await deliverInvitationEmail(c.env, {
+    invitationId,
     to: email,
     inviteeName: name,
-    inviterName: inviter.email,
-    inviterEmail: inviter.email,
-    inviteUrl: `${c.env.APP_URL.replace(/\/$/, "")}/invite/${token}`,
+    inviter,
+    inviteUrl,
     expiresAt,
     role,
   });
 
-  return c.json({ invitation }, 201);
+  return c.json({ invitation, inviteUrl, ...delivery }, 201);
 });
 
 adminRoutes.post("/:slug/invitations/:invitationId/resend", async (c) => {
@@ -564,17 +621,18 @@ adminRoutes.post("/:slug/invitations/:invitationId/resend", async (c) => {
     return c.json({ error: "Unable to resend invitation" }, 500);
   }
 
-  void sendHouseholdInvitationEmail(c.env, {
+  const inviteUrl = buildInviteUrl(c.env, token);
+  const delivery = await deliverInvitationEmail(c.env, {
+    invitationId: replacementId,
     to: replacement.email,
     inviteeName: replacement.name,
-    inviterName: inviter.email,
-    inviterEmail: inviter.email,
-    inviteUrl: `${c.env.APP_URL.replace(/\/$/, "")}/invite/${token}`,
+    inviter,
+    inviteUrl,
     expiresAt,
     role: replacement.role,
   });
 
-  return c.json({ invitation: replacement });
+  return c.json({ invitation: replacement, inviteUrl, ...delivery });
 });
 
 adminRoutes.delete("/:slug/invitations/:invitationId", async (c) => {
@@ -606,6 +664,12 @@ adminRoutes.post("/:slug/members", async (c) => {
     return c.json({ error: "email and name are required" }, 400);
   }
 
+  const memberEmail = normalizeEmail(payload.email);
+
+  if (!isValidEmail(memberEmail)) {
+    return c.json({ error: "email must be a valid email address" }, 400);
+  }
+
   const inviter = c.get("user");
 
   if (!inviter) {
@@ -621,7 +685,7 @@ adminRoutes.post("/:slug/members", async (c) => {
 
   const invitationId = await createHouseholdInvitation(c.env.DB, {
     householdId: household.id,
-    email: normalizeEmail(payload.email),
+    email: memberEmail,
     name: payload.name.trim(),
     role: invitationRole,
     tokenHash,
@@ -636,17 +700,18 @@ adminRoutes.post("/:slug/members", async (c) => {
     return c.json({ error: "Unable to create invitation" }, 500);
   }
 
-  void sendHouseholdInvitationEmail(c.env, {
+  const inviteUrl = buildInviteUrl(c.env, token);
+  const delivery = await deliverInvitationEmail(c.env, {
+    invitationId,
     to: invitation.email,
     inviteeName: invitation.name,
-    inviterName: inviter.email,
-    inviterEmail: inviter.email,
-    inviteUrl: `${c.env.APP_URL.replace(/\/$/, "")}/invite/${token}`,
+    inviter,
+    inviteUrl,
     expiresAt,
     role: invitation.role,
   });
 
-  return c.json({ invitation }, 201);
+  return c.json({ invitation, inviteUrl, ...delivery }, 201);
 });
 
 adminRoutes.patch("/:slug/members/:userId/role", async (c) => {

--- a/test/inbox-routes.test.ts
+++ b/test/inbox-routes.test.ts
@@ -65,7 +65,8 @@ const authApiState = vi.hoisted(() => ({
 }));
 
 const invitationEmailState = vi.hoisted(() => ({
-  calls: [] as unknown[],
+  calls: [] as Array<{ env: unknown; input: Record<string, unknown> }>,
+  failWith: null as string | null,
 }));
 
 const repoState = vi.hoisted(() => ({
@@ -189,8 +190,14 @@ function invitationSummary(invitation: InvitationRecord) {
 }
 
 vi.mock("../src/server/email/sender", () => ({
-  sendHouseholdInvitationEmail: async (env: unknown, input: unknown) => {
+  sendHouseholdInvitationEmail: async (
+    env: unknown,
+    input: Record<string, unknown>,
+  ) => {
     invitationEmailState.calls.push({ env, input });
+    if (invitationEmailState.failWith) {
+      throw new Error(invitationEmailState.failWith);
+    }
   },
   sendPasswordResetEmail: async () => {},
   sendTransactionalEmail: async () => {},
@@ -866,6 +873,7 @@ describe("worker routes", () => {
     sessionState.current = null;
     authApiState.signUpEmailCalls = [];
     invitationEmailState.calls = [];
+    invitationEmailState.failWith = null;
     repoState.users = [
       {
         id: "owner-home",
@@ -1279,7 +1287,64 @@ describe("worker routes", () => {
         role: "member",
         status: "pending",
       }),
+      inviteUrl: "http://localhost:8787/invite/invite-token",
+      emailSent: true,
     });
+  });
+
+  it("still creates the invitation and returns the link when the email cannot be sent", async () => {
+    sessionState.current = {
+      user: {
+        id: "owner-home",
+        email: "owner@example.com",
+        role: "user",
+        name: "Olivia Owner",
+      },
+      session: { id: "session-1", userId: "owner-home" },
+    };
+    invitationEmailState.failWith =
+      "OUTBOUND_EMAIL_FROM must be configured before sending email.";
+
+    const response = await invokeWorker("/api/admin/home/invitations", {
+      method: "POST",
+      body: JSON.stringify({
+        email: "new@example.com",
+        name: "New Person",
+        role: "member",
+        providerIds: [],
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(repoState.createInvitationCalls).toHaveLength(1);
+    // The inviter's display name (not the email) is used in the message.
+    expect(invitationEmailState.calls[0]?.input).toMatchObject({
+      inviterName: "Olivia Owner",
+      inviterEmail: "owner@example.com",
+    });
+    await expect(response.json()).resolves.toEqual({
+      invitation: expect.objectContaining({ email: "new@example.com" }),
+      inviteUrl: "http://localhost:8787/invite/invite-token",
+      emailSent: false,
+      emailError:
+        "OUTBOUND_EMAIL_FROM must be configured before sending email.",
+    });
+  });
+
+  it("rejects invitations to malformed email addresses", async () => {
+    sessionState.current = {
+      user: { id: "owner-home", email: "owner@example.com", role: "user" },
+      session: { id: "session-1", userId: "owner-home" },
+    };
+
+    const response = await invokeWorker("/api/admin/home/invitations", {
+      method: "POST",
+      body: JSON.stringify({ email: "not-an-email", name: "Nope" }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(repoState.createInvitationCalls).toHaveLength(0);
+    expect(invitationEmailState.calls).toHaveLength(0);
   });
 
   it("rejects role changes for a user outside the active household", async () => {

--- a/test/integration/auth.test.ts
+++ b/test/integration/auth.test.ts
@@ -1,5 +1,5 @@
 import { authForEnv, provisioningAuthForEnv } from "@server/auth/auth";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { count, testEnv } from "./helpers";
 
@@ -37,5 +37,70 @@ describe("Better Auth against the real schema (D1)", () => {
       }),
     ).rejects.toThrow();
     expect(await count("user")).toBe(0);
+  });
+});
+
+describe("password reset email delivery", () => {
+  async function signUpOwner(env: Env) {
+    await provisioningAuthForEnv(env).api.signUpEmail({
+      body: {
+        email: "owner@example.com",
+        name: "Owner",
+        password: "averylongpassword123",
+      },
+    });
+  }
+
+  it("awaits the reset email and logs a structured error when delivery fails", async () => {
+    // Better Auth deliberately keeps the public response enumeration-safe, so
+    // the request still succeeds; what must not happen is a silently dropped
+    // promise. The callback now awaits the send and logs the failure.
+    const failing = testEnv({
+      EMAIL: {
+        send: async () => {
+          throw new Error("email binding unavailable");
+        },
+      } as unknown as Env["EMAIL"],
+    });
+    await signUpOwner(failing);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await authForEnv(failing).api.requestPasswordReset({
+        body: { email: "owner@example.com", redirectTo: "/reset-password" },
+      });
+
+      const logged = errorSpy.mock.calls
+        .map((call) => String(call[0]))
+        .find((line) => line.includes("password_reset_email_failed"));
+      expect(logged).toBeDefined();
+      expect(JSON.parse(logged as string)).toMatchObject({
+        event: "password_reset_email_failed",
+        error: "email binding unavailable",
+      });
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("sends the reset email through the binding when configured", async () => {
+    const sent: Array<{ to: unknown; subject: unknown }> = [];
+    const working = testEnv({
+      EMAIL: {
+        send: async (message: { to: unknown; subject: unknown }) => {
+          sent.push({ to: message.to, subject: message.subject });
+          return { messageId: "m-1" };
+        },
+      } as unknown as Env["EMAIL"],
+    });
+    await signUpOwner(working);
+
+    await authForEnv(working).api.requestPasswordReset({
+      body: { email: "owner@example.com", redirectTo: "/reset-password" },
+    });
+
+    expect(sent).toEqual([
+      { to: "owner@example.com", subject: expect.stringMatching(/reset/i) },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Closes #82.

- Invitation **create / resend / "create member"** routes now `await` the email send, log a structured `invitation_email_failed` event on failure, and return `{ invitation, inviteUrl, emailSent, emailError? }` so the owner can fall back to sharing the link. The client shows a **Copy invite link** action in the alert when `emailSent` is false.
- Invitee email addresses are format-validated (400 on garbage).
- The inviter's display name from the session is used in the email instead of `owner@x (owner@x) invited you…`.
- Password-reset callback awaits `sendPasswordResetEmail` and logs `password_reset_email_failed` instead of `void`-ing the promise (Better Auth keeps the public response enumeration-safe, so the request still succeeds — but nothing is silently dropped any more).
- `docs/email-routing.md`: new **Sending email** section (`OUTBOUND_EMAIL_FROM`, sending-domain requirements, failure behaviour). `OUTBOUND_EMAIL_FROM` itself is required/validated since #124.

## Tests

- `test/inbox-routes.test.ts`: success returns `inviteUrl` + `emailSent: true`; sender failure still creates the invitation and returns `emailSent: false` + `emailError` + link, using the inviter's name; malformed email → 400 with no side effects.
- `test/integration/auth.test.ts` (workerd): reset email is sent through the binding; when the binding throws, the structured failure log is emitted.

`npm run ci` green: 86 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)