### PR TITLE
fix: make first-run setup and invitation acceptance recoverable

### DIFF
--- a/src/server/db/repositories/installation-state.ts
+++ b/src/server/db/repositories/installation-state.ts
@@ -32,14 +32,25 @@ export async function getInstallationState(
   return row;
 }
 
+/**
+ * An in-progress claim older than this is considered abandoned (the isolate
+ * died mid-setup) and may be reclaimed by a new attempt.
+ */
+export const SETUP_CLAIM_TIMEOUT_MINUTES = 10;
+
 export async function beginInstallationSetup(db: D1Database) {
   await ensureInstallationState(db);
 
+  const staleBefore = `-${SETUP_CLAIM_TIMEOUT_MINUTES} minutes`;
   const result = await dbForDatabase(db).run(sql`
     UPDATE app_installation
     SET status = 'in_progress',
         updated_at = CURRENT_TIMESTAMP
-    WHERE id = 1 AND status = 'pending'
+    WHERE id = 1
+      AND (
+        status = 'pending'
+        OR (status = 'in_progress' AND updated_at < datetime('now', ${staleBefore}))
+      )
   `);
 
   return Number(result.meta.changes ?? 0) > 0;

--- a/src/server/db/repositories/users.ts
+++ b/src/server/db/repositories/users.ts
@@ -1,0 +1,22 @@
+import { eq } from "drizzle-orm";
+
+import { dbForDatabase } from "../client";
+import { user } from "../schema";
+
+export async function findUserByEmail(db: D1Database, email: string) {
+  const rows = await dbForDatabase(db)
+    .select({ id: user.id, email: user.email, name: user.name })
+    .from(user)
+    .where(eq(user.email, email.trim().toLowerCase()))
+    .limit(1);
+
+  return rows[0] ?? null;
+}
+
+/**
+ * Deletes a Better Auth user; accounts, sessions, passkeys and memberships
+ * cascade via foreign keys. Only used to compensate for interrupted flows.
+ */
+export async function deleteUserById(db: D1Database, userId: string) {
+  await dbForDatabase(db).delete(user).where(eq(user.id, userId));
+}

--- a/src/server/routes/invitations.ts
+++ b/src/server/routes/invitations.ts
@@ -9,6 +9,7 @@ import {
   getInvitationByTokenHash,
   refreshExpiredInvitations,
 } from "../db/repositories/invitations";
+import { deleteUserById, findUserByEmail } from "../db/repositories/users";
 import { hashInvitationToken } from "../security/tokens";
 
 type AcceptInvitationPayload = {
@@ -109,6 +110,23 @@ invitationRoutes.post("/:token/accept", async (c) => {
     );
   }
 
+  // An account for the invited address already exists (e.g. an earlier
+  // attempt was interrupted after sign-up, or the person already has an
+  // account): they must sign in and accept, instead of a confusing
+  // USER_ALREADY_EXISTS from sign-up.
+  if (await findUserByEmail(c.env.DB, invitation.email)) {
+    return c.json(
+      {
+        error:
+          "An account with the invited email already exists. Sign in with it, then open the invitation link again.",
+        code: "ACCOUNT_EXISTS",
+      },
+      409,
+    );
+  }
+
+  let createdUserId: string | null = null;
+
   try {
     const signUpResult = await auth.api.signUpEmail({
       body: {
@@ -121,6 +139,7 @@ invitationRoutes.post("/:token/accept", async (c) => {
     });
 
     const createdUser = signUpResult.response.user;
+    createdUserId = createdUser.id;
 
     await acceptInvitation(c.env.DB, {
       invitationId: invitation.id,
@@ -151,9 +170,23 @@ invitationRoutes.post("/:token/accept", async (c) => {
 
     return response;
   } catch (error) {
+    console.error(
+      JSON.stringify({
+        event: "invitation_accept_failed",
+        invitationId: invitation.id,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
+
+    // Compensate: the sign-up succeeded but the membership did not; remove the
+    // half-created account so the invitee can simply retry the link.
+    if (createdUserId) {
+      await deleteUserById(c.env.DB, createdUserId).catch(() => undefined);
+    }
+
     if (isAPIError(error)) {
-      c.status(typeof error.status === "number" ? 400 : 400);
-      return c.json({ error: error.message });
+      const status = typeof error.status === "number" ? error.status : 400;
+      return c.json({ error: error.message }, status as 400);
     }
 
     return c.json({ error: "Unable to accept invitation" }, 500);

--- a/src/server/routes/setup.ts
+++ b/src/server/routes/setup.ts
@@ -2,13 +2,17 @@ import { isAPIError } from "better-auth/api";
 import { Hono } from "hono";
 
 import { provisioningAuthForEnv } from "../auth/auth";
-import { createHousehold } from "../db/repositories/households";
+import {
+  createHousehold,
+  listHouseholdsForUser,
+} from "../db/repositories/households";
 import {
   beginInstallationSetup,
   completeInstallationSetup,
   getInstallationState,
   resetInstallationSetup,
 } from "../db/repositories/installation-state";
+import { deleteUserById, findUserByEmail } from "../db/repositories/users";
 
 type SetupPayload = {
   email?: string;
@@ -39,6 +43,23 @@ function mapInstallationStatus(
     status: row.status,
     ownerEmail: row.owner_email,
   };
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    const message = (current as { message?: unknown }).message;
+    if (
+      typeof message === "string" &&
+      /UNIQUE constraint failed/.test(message)
+    ) {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
 }
 
 function normalizeSlug(value: string | undefined) {
@@ -128,7 +149,51 @@ setupRoutes.post("/complete", async (c) => {
     );
   }
 
+  // Recover from an interrupted earlier attempt: a user for OWNER_EMAIL may
+  // already exist without the installation ever being marked complete.
+  const existingOwner = await findUserByEmail(c.env.DB, requestedEmail);
+
+  if (existingOwner) {
+    const ownedHouseholds = (
+      await listHouseholdsForUser(c.env.DB, existingOwner.id)
+    ).filter((household) => household.role === "owner");
+
+    if (ownedHouseholds.length > 0) {
+      // Sign-up and household creation both succeeded last time; only the
+      // final bookkeeping step was lost. Finish it and tell the caller.
+      await completeInstallationSetup(
+        c.env.DB,
+        existingOwner.id,
+        requestedEmail,
+      );
+      console.warn(
+        JSON.stringify({
+          event: "setup_recovered_existing_owner",
+          userId: existingOwner.id,
+        }),
+      );
+      return c.json(
+        {
+          error:
+            "Setup has already been completed for this owner. Sign in with your owner account.",
+        },
+        409,
+      );
+    }
+
+    // Orphan from a failed attempt (no memberships): remove it so the retry
+    // starts from a clean slate.
+    console.warn(
+      JSON.stringify({
+        event: "setup_orphan_user_removed",
+        userId: existingOwner.id,
+      }),
+    );
+    await deleteUserById(c.env.DB, existingOwner.id);
+  }
+
   const auth = provisioningAuthForEnv(c.env);
+  let createdUserId: string | null = null;
 
   try {
     const signUpResult = await auth.api.signUpEmail({
@@ -142,6 +207,7 @@ setupRoutes.post("/complete", async (c) => {
     });
 
     const createdUser = signUpResult.response.user;
+    createdUserId = createdUser.id;
 
     const household = await createHousehold(c.env.DB, {
       slug: householdSlug,
@@ -171,9 +237,38 @@ setupRoutes.post("/complete", async (c) => {
 
     return response;
   } catch (error) {
-    console.error("Setup completion failed:", error);
+    console.error(
+      JSON.stringify({
+        event: "setup_failed",
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
+
+    // Compensate: remove the owner user created in this attempt so the next
+    // attempt does not fail with USER_ALREADY_EXISTS, then release the claim.
+    if (createdUserId) {
+      await deleteUserById(c.env.DB, createdUserId).catch((cleanupError) => {
+        console.error(
+          JSON.stringify({
+            event: "setup_cleanup_failed",
+            userId: createdUserId,
+            error:
+              cleanupError instanceof Error
+                ? cleanupError.message
+                : String(cleanupError),
+          }),
+        );
+      });
+    }
 
     await resetInstallationSetup(c.env.DB);
+
+    if (isUniqueConstraintError(error)) {
+      return c.json(
+        { error: "A household with that slug already exists" },
+        409,
+      );
+    }
 
     if (isAPIError(error)) {
       const status = typeof error.status === "number" ? error.status : 400;

--- a/test/integration/invitation-accept.test.ts
+++ b/test/integration/invitation-accept.test.ts
@@ -1,0 +1,80 @@
+import { SELF } from "cloudflare:test";
+import { createHousehold } from "@server/db/repositories/households";
+import { createHouseholdInvitation } from "@server/db/repositories/invitations";
+import { hashInvitationToken } from "@server/security/tokens";
+import { describe, expect, it } from "vitest";
+
+import { count, createTestUser, db } from "./helpers";
+
+async function seedInvitation(email = "kid@example.com") {
+  const owner = await createTestUser({ email: "owner@example.com" });
+  const household = await createHousehold(db, {
+    slug: "casa",
+    displayName: "Casa",
+    ownerUserId: owner.id,
+  });
+  const token = "invite-token-1";
+  await createHouseholdInvitation(db, {
+    householdId: household?.id ?? "",
+    email,
+    name: "Kid",
+    role: "member",
+    tokenHash: await hashInvitationToken(token),
+    invitedByUserId: owner.id,
+    expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+    providerIds: [],
+  });
+  return { token, householdId: household?.id ?? "" };
+}
+
+async function postAccept(token: string, body: unknown) {
+  return SELF.fetch(`http://localhost:8787/api/invitations/${token}/accept`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("invitation acceptance (end-to-end against D1)", () => {
+  it("creates the account, the membership and marks the invitation accepted", async () => {
+    const { token } = await seedInvitation();
+
+    const response = await postAccept(token, {
+      name: "Kid",
+      password: "averylongpassword123",
+    });
+
+    expect(response.status).toBe(201);
+    expect(await count("user", "email = ?1", "kid@example.com")).toBe(1);
+    expect(await count("household_memberships", "role = 'member'")).toBe(1);
+    expect(await count("household_invitations", "status = 'accepted'")).toBe(1);
+  });
+
+  it("tells an existing account holder to sign in instead of failing with 'user already exists'", async () => {
+    const { token } = await seedInvitation();
+    await createTestUser({ email: "kid@example.com" });
+
+    const response = await postAccept(token, {
+      name: "Kid",
+      password: "averylongpassword123",
+    });
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "ACCOUNT_EXISTS",
+    });
+    // Nothing was accepted or created.
+    expect(await count("household_invitations", "status = 'pending'")).toBe(1);
+    expect(await count("user")).toBe(2);
+  });
+
+  it("rejects unknown tokens without side effects", async () => {
+    await seedInvitation();
+    const response = await postAccept("nope", {
+      name: "Kid",
+      password: "averylongpassword123",
+    });
+    expect(response.status).toBe(404);
+    expect(await count("user")).toBe(1);
+  });
+});

--- a/test/integration/setup-recovery.test.ts
+++ b/test/integration/setup-recovery.test.ts
@@ -1,0 +1,91 @@
+import { SELF } from "cloudflare:test";
+import { createHousehold } from "@server/db/repositories/households";
+import {
+  beginInstallationSetup,
+  getInstallationState,
+} from "@server/db/repositories/installation-state";
+import { describe, expect, it } from "vitest";
+
+import { count, createTestUser, db, insertHousehold } from "./helpers";
+
+const setupPayload = {
+  email: "owner@example.com",
+  name: "Owner",
+  password: "averylongpassword123",
+  householdName: "Casa",
+  householdSlug: "casa",
+  setupSecret: "test-setup-secret",
+};
+
+async function postSetup(body: unknown = setupPayload) {
+  return SELF.fetch("http://localhost:8787/api/setup/complete", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("first-run setup recovery", () => {
+  it("recovers when a previous attempt left an orphan owner user behind", async () => {
+    // Simulates: sign-up succeeded, household creation failed, isolate died.
+    await createTestUser({ email: "owner@example.com" });
+    expect(await count("user")).toBe(1);
+
+    const response = await postSetup();
+
+    expect(response.status).toBe(201);
+    expect(await count("user")).toBe(1);
+    expect(await count("household_memberships", "role = 'owner'")).toBe(1);
+    expect((await getInstallationState(db)).status).toBe("complete");
+  });
+
+  it("finishes the installation when the owner already owns a household from an interrupted attempt", async () => {
+    const owner = await createTestUser({ email: "owner@example.com" });
+    await createHousehold(db, {
+      slug: "casa",
+      displayName: "Casa",
+      ownerUserId: owner.id,
+    });
+
+    const response = await postSetup();
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      error: expect.stringMatching(/already/i),
+    });
+    const state = await getInstallationState(db);
+    expect(state.status).toBe("complete");
+    expect(state.owner_user_id).toBe(owner.id);
+  });
+
+  it("reclaims a stale in_progress claim but respects a fresh one", async () => {
+    expect(await beginInstallationSetup(db)).toBe(true);
+    // A second concurrent attempt must not win the claim.
+    expect(await beginInstallationSetup(db)).toBe(false);
+    expect((await postSetup()).status).toBe(409);
+
+    // Make the claim stale (older than the recovery window) and retry.
+    await db
+      .prepare(
+        "UPDATE app_installation SET updated_at = datetime('now', '-30 minutes') WHERE id = 1",
+      )
+      .run();
+    expect((await postSetup()).status).toBe(201);
+  });
+
+  it("rolls back the created owner user when household creation fails", async () => {
+    // Pre-existing household with the requested slug makes createHousehold throw.
+    await insertHousehold({ slug: "casa" });
+
+    const response = await postSetup();
+
+    expect(response.status).toBe(409);
+    expect(await count("user")).toBe(0);
+    expect((await getInstallationState(db)).status).toBe("pending");
+
+    // A corrected retry succeeds.
+    expect(
+      (await postSetup({ ...setupPayload, householdSlug: "otra" })).status,
+    ).toBe(201);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #86.

- `beginInstallationSetup` reclaims an `in_progress` claim older than 10 minutes (abandoned by a dead isolate) while still rejecting a fresh concurrent claim.
- `POST /api/setup/complete` recovers from interrupted attempts:
  - an orphan owner user with no memberships is removed before retrying (no more `USER_ALREADY_EXISTS` wedge);
  - an owner who already owns a household (only the final bookkeeping step was lost) gets the installation marked complete and a 409 "sign in";
  - a failure after sign-up deletes the just-created user and releases the claim;
  - a household-slug collision returns 409 instead of a raw 500.
- `POST /api/invitations/:token/accept` returns `409 {code:"ACCOUNT_EXISTS"}` when an account for the invited email already exists, and deletes the half-created account if the membership step fails. Better Auth API errors keep their real status (was always 400).
- New `repositories/users.ts` (`findUserByEmail`, `deleteUserById`); structured logs for every recovery path.

## Tests (D1-backed, end-to-end via `SELF.fetch`)

- `test/integration/setup-recovery.test.ts`: orphan owner recovered; existing owner-with-household finishes install; stale claim reclaimed / fresh claim respected; slug collision rolls back the created user, and a corrected retry succeeds.
- `test/integration/invitation-accept.test.ts`: happy path creates account + membership + accepted status; existing account → 409 `ACCOUNT_EXISTS` with no side effects; unknown token → 404.

`npm run ci` green: 93 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)