### PR TITLE
fix: remove the seeded 'home' household on fresh installs; document slug = recipient local part

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,10 @@ Cloudflare Email Workers can be tested locally by posting a raw RFC 5322 message
 `/cdn-cgi/handler/email` is a Cloudflare/Wrangler development and testing endpoint that forwards a request to the Worker `email()` handler locally. It is not a normal application API route.
 
 ```bash
-curl -X POST 'http://localhost:8787/cdn-cgi/handler/email?from=sender@example.com&to=codes@example.com' \
-  --data-raw $'From: sender@example.com\nTo: codes@example.com\nSubject: Your verification code\nMessage-ID: <example-1@test>\n\nYour verification code is 123456'
+# The recipient's local part must be the slug of an existing household
+# (the one you chose during /setup, e.g. `casa`); other addresses are dropped.
+curl -X POST 'http://localhost:8787/cdn-cgi/handler/email?from=sender@example.com&to=casa@example.com' \
+  --data-raw $'From: sender@example.com\nTo: casa@example.com\nSubject: Your verification code\nMessage-ID: <example-1@test>\n\nYour verification code is 123456'
 ```
 
 ### Test scheduled cleanup locally
@@ -290,7 +292,7 @@ In the Cloudflare dashboard:
 1. Go to your domain → **Email → Email Routing → Overview**
 2. Enable Email Routing if not already active — accept the MX and SPF DNS record changes Cloudflare proposes
 3. Go to the **Routing rules** tab → **Create address**
-4. Set the custom address to the local part you want (e.g. `codes` for `codes@yourdomain.com`)
+4. Set the custom address to your **household slug** — the local part of the address must equal the slug chosen during `/setup` (e.g. household slug `casa` → `casa@yourdomain.com`). Mail to any other local part is dropped. Add one routing rule per household.
 5. Under **Action**, select **Send to a Worker** and choose your deployed Worker (`mi-casa-su-casa`)
 6. Save the rule
 

--- a/docs/email-routing.md
+++ b/docs/email-routing.md
@@ -27,7 +27,7 @@ sender → Cloudflare Email Routing → Worker email() handler
 ```
 
 1. An external service (e.g. Netflix, Google) sends a verification email to your shared address.
-2. Cloudflare Email Routing matches the recipient and forwards the raw RFC 5322 message to the Worker.
+2. Cloudflare Email Routing matches the recipient and forwards the raw RFC 5322 message to the Worker. The Worker resolves the household from the recipient's local part (`casa@…` → household `casa`); unknown local parts are dropped.
 3. The Worker parses headers and body using PostalMime.
 4. The sender address is checked against `sender_rules` in D1.
    - **Match**: the message is stored in `messages` with any extracted verification code.
@@ -49,7 +49,7 @@ sender → Cloudflare Email Routing → Worker email() handler
 
 1. Still on **Email → Email Routing**, go to the **Routing rules** tab.
 2. Click **Create address**.
-3. Set the **Custom address** to the local part you want to use (e.g. `codes`). This creates the address `codes@yourdomain.com`.
+3. Set the **Custom address** to your **household slug**. The Worker routes mail by the recipient's local part, which must equal the slug of an existing household (chosen during `/setup`, e.g. `casa` → `casa@yourdomain.com`). Mail to any other local part is dropped. Create one routing rule per household.
 4. Under **Action**, select **Send to a Worker**.
 5. Choose your deployed Worker from the dropdown:
    - Production: `mi-casa-su-casa`
@@ -69,7 +69,7 @@ These records are managed by Cloudflare and were added when you enabled Email Ro
 
 ### 4. Send a test email
 
-1. Send an email from an external address to your configured address (e.g. `codes@yourdomain.com`).
+1. Send an email from an external address to your configured address (e.g. `casa@yourdomain.com`, where `casa` is your household slug).
 2. Check your application:
    - If the sender matches a `sender_rules` entry, the message appears in the inbox.
    - If not, it appears in the quarantine view (owner-only).
@@ -85,7 +85,7 @@ Use a subdomain like `home.yourdomain.com` for Email Routing and keep the root d
 
 1. Add the subdomain to Cloudflare if it is not already there.
 2. Enable Email Routing on the subdomain.
-3. Your shared address becomes `codes@home.yourdomain.com`.
+3. Your shared address becomes `<household-slug>@home.yourdomain.com`.
 
 **Option B — Catch-all on root domain**:
 
@@ -110,8 +110,9 @@ If an invitation email cannot be delivered, the API still creates the invitation
 Email routing is a Cloudflare infrastructure feature and does not run locally. To test the email pipeline during development, post a raw RFC 5322 message to the Wrangler dev endpoint:
 
 ```bash
-curl -X POST 'http://localhost:8787/cdn-cgi/handler/email?from=sender@example.com&to=codes@example.com' \
-  --data-raw $'From: sender@example.com\nTo: codes@example.com\nSubject: Your verification code\nMessage-ID: <test-1@dev>\n\nYour verification code is 123456'
+# `casa` must be the slug of an existing household in your local database.
+curl -X POST 'http://localhost:8787/cdn-cgi/handler/email?from=sender@example.com&to=casa@example.com' \
+  --data-raw $'From: sender@example.com\nTo: casa@example.com\nSubject: Your verification code\nMessage-ID: <test-1@dev>\n\nYour verification code is 123456'
 ```
 
 `/cdn-cgi/handler/email` is a Cloudflare/Wrangler development endpoint that forwards a request to the Worker `email()` handler locally. It is not a normal application API route. See the [README](../README.md#test-email-ingestion-locally) for more examples.

--- a/migrations/0007_remove_unused_seed_household.sql
+++ b/migrations/0007_remove_unused_seed_household.sql
@@ -1,0 +1,22 @@
+-- Migration 0005 unconditionally seeded a 'home' household to carry legacy
+-- single-tenant data forward. On fresh installs that left an orphan household
+-- nobody belongs to: the slug 'home' could not be used at setup, mail to
+-- home@<domain> landed in an invisible quarantine, and the seeded row masked
+-- misconfigured routing.
+--
+-- Remove the seeded household only when it is clearly unused: no memberships,
+-- no stored mail. Providers / sender rules under it cascade.
+DELETE FROM households
+WHERE id = '00000000-0000-0000-0000-000000000001'
+  AND NOT EXISTS (
+    SELECT 1 FROM household_memberships
+    WHERE household_memberships.household_id = households.id
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM messages
+    WHERE messages.household_id = households.id
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM quarantine_messages
+    WHERE quarantine_messages.household_id = households.id
+  );

--- a/requests/email-ingestion.http
+++ b/requests/email-ingestion.http
@@ -1,24 +1,25 @@
+# NOTE: the recipient local part (casa) must be the slug of an existing household.
 @baseUrl = http://localhost:8787
 
 ### Local email ingestion trigger via Cloudflare/Wrangler dev handler
 # `/cdn-cgi/handler/email` is a Cloudflare-reserved dev/testing path that sends
 # this request to the Worker `email()` handler locally. It is not a normal app API route.
-POST {{baseUrl}}/cdn-cgi/handler/email?from=login@service.example&to=codes@example.com
+POST {{baseUrl}}/cdn-cgi/handler/email?from=login@service.example&to=casa@example.com
 Content-Type: text/plain
 
 From: Service <login@service.example>
-To: codes@example.com
+To: casa@example.com
 Subject: Your verification code
 Message-ID: <provider-match-example@test>
 
 Your verification code is 123456.
 
 ### Local email ingestion trigger that should fall into quarantine until sender rules exist
-POST {{baseUrl}}/cdn-cgi/handler/email?from=unknown@example.net&to=codes@example.com
+POST {{baseUrl}}/cdn-cgi/handler/email?from=unknown@example.net&to=casa@example.com
 Content-Type: text/plain
 
 From: Unknown Sender <unknown@example.net>
-To: codes@example.com
+To: casa@example.com
 Subject: Sign-in request
 Message-ID: <quarantine-example@test>
 

--- a/test/integration/schema.test.ts
+++ b/test/integration/schema.test.ts
@@ -78,10 +78,11 @@ describe("database schema", () => {
   });
 
   it("does not seed any household on a fresh install", async () => {
-    // Documents current behaviour; tightened when #88 lands.
+    // 0005 seeded a 'home' household for legacy data; 0007 removes it when
+    // nothing references it, so a fresh install starts empty (#88).
     const row = await db
       .prepare("SELECT COUNT(*) AS n FROM households")
       .first<{ n: number }>();
-    expect(typeof row?.n).toBe("number");
+    expect(row?.n).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Closes #88.

- `migrations/0007_remove_unused_seed_household.sql`: 0005 unconditionally seeded a `home` household (id `…0001`) to migrate legacy single-tenant data, which on fresh installs left a household nobody belongs to — slug `home` unusable at setup, mail to `home@…` quarantined invisibly, misconfigured routing masked. 0007 deletes it only when it has **no memberships and no stored mail** (providers/rules cascade), so real legacy installs are untouched.
- `test/integration/schema.test.ts` now asserts a fresh install has **zero** households.
- Docs (`README.md`, `docs/email-routing.md`, `requests/email-ingestion.http`): the Email Routing address local part **must equal a household slug** (`casa@…` → household `casa`), one rule per household; smoke tests no longer use a `codes@` address that the handler silently drops.

`npm run ci` green: 93 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)