### PR TITLE
fix: restrict CORS to the app origin and reject cross-site mutations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,18 +14,25 @@ import { settingsRoutes } from "./server/routes/settings";
 import { setupRoutes } from "./server/routes/setup";
 import { createAppContext } from "./server/runtime/context";
 import { assertValidEnv, validateEnv } from "./server/runtime/env";
+import {
+  corsOriginFor,
+  rejectCrossSiteMutations,
+} from "./server/security/origin";
 
 const app = new Hono<{ Bindings: Env }>();
 
+// The SPA is same-origin; credentialed CORS is only granted to APP_URL (and
+// localhost during development). Anything else gets no CORS headers at all.
 app.use(
   "/api/*",
   cors({
-    origin: (origin) => origin ?? "http://localhost:8787",
+    origin: (origin, c) => corsOriginFor(c.env, origin),
     allowHeaders: ["Content-Type", "Authorization"],
     allowMethods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
     credentials: true,
   }),
 );
+app.use("/api/*", rejectCrossSiteMutations);
 
 // Fail fast (and loudly) when required configuration is missing, instead of
 // letting auth/email silently degrade. Liveness stays available.

--- a/src/server/auth/auth.ts
+++ b/src/server/auth/auth.ts
@@ -25,6 +25,7 @@ function createAuth(env: Env, options: { disableSignUp: boolean }) {
   return betterAuth({
     appName: "Mi Casa Su Casa",
     baseURL: env.APP_URL,
+    trustedOrigins: [env.APP_URL],
     secret: env.AUTH_SECRET,
     database: drizzleAdapter(dbForEnv(env), {
       provider: "sqlite",

--- a/src/server/security/origin.ts
+++ b/src/server/security/origin.ts
@@ -1,0 +1,99 @@
+import type { MiddlewareHandler } from "hono";
+
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+/** The origin (scheme + host + port) the SPA is served from. */
+export function appOrigin(env: Pick<Env, "APP_URL">): string | null {
+  try {
+    return new URL(env.APP_URL).origin;
+  } catch {
+    return null;
+  }
+}
+
+function isLocalDevOrigin(origin: string) {
+  try {
+    const url = new URL(origin);
+    return (
+      url.protocol === "http:" &&
+      (url.hostname === "localhost" || url.hostname === "127.0.0.1")
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Decides whether a request Origin may receive credentialed CORS responses.
+ * Only the app's own origin is allowed (plus localhost during development).
+ * Returns the allowed origin string, or "" to omit the CORS headers entirely.
+ */
+export function corsOriginFor(
+  env: Pick<Env, "APP_URL" | "ENVIRONMENT">,
+  origin: string | undefined,
+): string {
+  if (!origin) {
+    return "";
+  }
+
+  if (origin === appOrigin(env)) {
+    return origin;
+  }
+
+  if (env.ENVIRONMENT === "development" && isLocalDevOrigin(origin)) {
+    return origin;
+  }
+
+  return "";
+}
+
+/**
+ * Cross-site request forgery guard for cookie-authenticated mutations.
+ *
+ * Browsers always send `Sec-Fetch-Site` and, for non-GET requests, `Origin`.
+ * A request that carries either header with a foreign value is rejected.
+ * Requests without any of these headers (curl, tests, server-to-server) are
+ * not browser-initiated and therefore not CSRF vectors, so they pass.
+ */
+export const rejectCrossSiteMutations: MiddlewareHandler<{
+  Bindings: Env;
+}> = async (c, next) => {
+  if (SAFE_METHODS.has(c.req.method)) {
+    return next();
+  }
+
+  const allowed = appOrigin(c.env);
+  const fetchSite = c.req.header("sec-fetch-site");
+  const origin = c.req.header("origin");
+  const referer = c.req.header("referer");
+
+  const originAllowed = (candidate: string) =>
+    corsOriginFor(c.env, candidate) !== "" ||
+    (allowed !== null && candidate === allowed);
+
+  if (fetchSite && fetchSite !== "same-origin" && fetchSite !== "none") {
+    // cross-site / same-site(sibling subdomain): only allow if Origin matches
+    // exactly (a dev server on another localhost port, for example).
+    if (!origin || !originAllowed(origin)) {
+      return c.json({ error: "Cross-site request rejected" }, 403);
+    }
+  }
+
+  if (origin && !originAllowed(origin)) {
+    return c.json({ error: "Cross-site request rejected" }, 403);
+  }
+
+  if (!origin && referer) {
+    let refererOrigin: string | null = null;
+    try {
+      refererOrigin = new URL(referer).origin;
+    } catch {
+      refererOrigin = null;
+    }
+    if (!refererOrigin || !originAllowed(refererOrigin)) {
+      return c.json({ error: "Cross-site request rejected" }, 403);
+    }
+  }
+
+  await next();
+};

--- a/test/inbox-routes.test.ts
+++ b/test/inbox-routes.test.ts
@@ -1479,3 +1479,106 @@ describe("worker routes", () => {
     expect(payload.session.session.userId).toBe("created-user-1");
   });
 });
+
+describe("cross-origin protections", () => {
+  beforeEach(() => {
+    sessionState.current = {
+      user: { id: "owner-home", email: "owner@example.com", role: "user" },
+      session: { id: "session-1", userId: "owner-home" },
+    };
+    invitationEmailState.calls = [];
+    invitationEmailState.failWith = null;
+  });
+
+  it("does not reflect foreign origins in CORS headers", async () => {
+    const response = await invokeWorker("/api/setup/status", {
+      headers: { Origin: "https://evil.example" },
+    });
+
+    expect(response.status).toBe(200);
+    // Without Allow-Origin the browser blocks the cross-origin read, whatever
+    // Allow-Credentials says.
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  it("grants credentialed CORS to the app's own origin", async () => {
+    const response = await invokeWorker("/api/setup/status", {
+      headers: { Origin: "http://localhost:8787" },
+    });
+
+    expect(response.headers.get("access-control-allow-origin")).toBe(
+      "http://localhost:8787",
+    );
+    expect(response.headers.get("access-control-allow-credentials")).toBe(
+      "true",
+    );
+  });
+
+  it("rejects mutations that carry a foreign Origin or a cross-site fetch metadata header", async () => {
+    const body = JSON.stringify({
+      email: "new@example.com",
+      name: "New Person",
+      role: "member",
+      providerIds: [],
+    });
+
+    const foreignOrigin = await invokeWorker("/api/admin/home/invitations", {
+      method: "POST",
+      headers: {
+        Origin: "https://evil.example",
+        "content-type": "application/json",
+      },
+      body,
+    });
+    expect(foreignOrigin.status).toBe(403);
+
+    const crossSite = await invokeWorker("/api/admin/home/invitations", {
+      method: "POST",
+      headers: {
+        "Sec-Fetch-Site": "cross-site",
+        "content-type": "application/json",
+      },
+      body,
+    });
+    expect(crossSite.status).toBe(403);
+
+    const foreignReferer = await invokeWorker("/api/admin/home/invitations", {
+      method: "POST",
+      headers: {
+        Referer: "https://evil.example/page",
+        "content-type": "application/json",
+      },
+      body,
+    });
+    expect(foreignReferer.status).toBe(403);
+
+    expect(repoState.createInvitationCalls).toHaveLength(0);
+  });
+
+  it("allows same-origin browser mutations and non-browser clients", async () => {
+    const body = JSON.stringify({
+      email: "new@example.com",
+      name: "New Person",
+      role: "member",
+      providerIds: [],
+    });
+
+    const sameOrigin = await invokeWorker("/api/admin/home/invitations", {
+      method: "POST",
+      headers: {
+        Origin: "http://localhost:8787",
+        "Sec-Fetch-Site": "same-origin",
+        "content-type": "application/json",
+      },
+      body,
+    });
+    expect(sameOrigin.status).toBe(201);
+
+    const curlLike = await invokeWorker("/api/admin/home/invitations", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    });
+    expect(curlLike.status).toBe(201);
+  });
+});

--- a/test/origin-policy.test.ts
+++ b/test/origin-policy.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { appOrigin, corsOriginFor } from "../src/server/security/origin";
+
+const production = {
+  APP_URL: "https://casa.example.com",
+  ENVIRONMENT: "production",
+};
+const development = {
+  APP_URL: "http://localhost:8787",
+  ENVIRONMENT: "development",
+};
+
+describe("origin policy", () => {
+  it("derives the app origin from APP_URL", () => {
+    expect(appOrigin(production)).toBe("https://casa.example.com");
+    expect(appOrigin({ APP_URL: "nope" })).toBeNull();
+  });
+
+  it("only grants credentialed CORS to the app's own origin", () => {
+    expect(corsOriginFor(production, "https://casa.example.com")).toBe(
+      "https://casa.example.com",
+    );
+    expect(corsOriginFor(production, "https://evil.example")).toBe("");
+    expect(corsOriginFor(production, "https://sub.casa.example.com")).toBe("");
+    expect(corsOriginFor(production, "http://localhost:5173")).toBe("");
+    expect(corsOriginFor(production, undefined)).toBe("");
+  });
+
+  it("allows localhost origins only in development", () => {
+    expect(corsOriginFor(development, "http://localhost:5173")).toBe(
+      "http://localhost:5173",
+    );
+    expect(corsOriginFor(development, "http://127.0.0.1:5173")).toBe(
+      "http://127.0.0.1:5173",
+    );
+    expect(corsOriginFor(development, "https://evil.example")).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #85.

The API reflected **any** `Origin` with `Access-Control-Allow-Credentials: true` and relied solely on `SameSite=Lax` cookies for CSRF protection of the custom routes.

- `src/server/security/origin.ts`:
  - `corsOriginFor()` — credentialed CORS only for `APP_URL`'s origin (plus `localhost`/`127.0.0.1` when `ENVIRONMENT=development`); everything else gets no `Access-Control-Allow-Origin`.
  - `rejectCrossSiteMutations` — for non-GET/HEAD/OPTIONS `/api/*` requests, rejects with 403 when `Sec-Fetch-Site` is cross-site/same-site without a matching `Origin`, when `Origin` is foreign, or (no `Origin`) when `Referer` is foreign. Requests with none of these headers (curl, `.http` files, tests, server-to-server) are not browser-initiated and pass.
- Better Auth: `trustedOrigins: [env.APP_URL]`.

## Tests

- `test/origin-policy.test.ts` (unit): app origin derivation; only own origin allowed; localhost only in development.
- `test/inbox-routes.test.ts`: foreign `Origin` gets no `Allow-Origin`; own origin gets credentialed CORS; POST with foreign `Origin` / `Sec-Fetch-Site: cross-site` / foreign `Referer` → 403 with no side effects; same-origin browser POST and header-less client POST → 201.

`npm run ci` green: 100 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)