### PR TITLE
fix: stop returning session tokens in API responses

### DIFF
--- a/src/client/components/SettingsView.tsx
+++ b/src/client/components/SettingsView.tsx
@@ -414,9 +414,7 @@ export function SettingsView({
                 }
               >
                 <ListItemText
-                  primary={
-                    session.userAgent ? session.userAgent : "Unknown Device"
-                  }
+                  primary={`${session.userAgent ? session.userAgent : "Unknown Device"}${session.isCurrent ? " · this device" : ""}`}
                   secondary={
                     <>
                       {session.ipAddress && `IP: ${session.ipAddress} • `}

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -134,7 +134,7 @@ export type InvitationSummary = {
 
 export type AccountSession = {
   id: string;
-  token: string;
+  isCurrent: boolean;
   expiresAt: string | null;
   ipAddress: string | null;
   userAgent: string | null;

--- a/src/server/db/repositories/settings.ts
+++ b/src/server/db/repositories/settings.ts
@@ -63,7 +63,6 @@ export async function listUserSessions(db: D1Database, userId: string) {
   const rows = await dbForDatabase(db)
     .select({
       id: session.id,
-      token: session.token,
       expiresAt: session.expiresAt,
       ipAddress: session.ipAddress,
       userAgent: session.userAgent,
@@ -77,7 +76,6 @@ export async function listUserSessions(db: D1Database, userId: string) {
 
   return rows.map((row) => ({
     id: row.id,
-    token: row.token,
     expiresAt: normalizeTimestamp(row.expiresAt),
     ipAddress: row.ipAddress,
     userAgent: row.userAgent,

--- a/src/server/routes/invitations.ts
+++ b/src/server/routes/invitations.ts
@@ -159,7 +159,6 @@ invitationRoutes.post("/:token/accept", async (c) => {
           role: invitation.role,
         },
         household,
-        session: signUpResult.response,
       },
       201,
     );

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -31,6 +31,7 @@ settingsRoutes.get("/", async (c) => {
     return c.json({ error: "Unauthorized" }, 401);
   }
 
+  const currentSession = c.get("session");
   const [profile, sessions] = await Promise.all([
     getUserProfile(c.env.DB, currentUser.id),
     listUserSessions(c.env.DB, currentUser.id),
@@ -40,7 +41,15 @@ settingsRoutes.get("/", async (c) => {
     return c.json({ error: "User not found" }, 404);
   }
 
-  return c.json({ profile, sessions });
+  // Session tokens are bearer secrets and never leave the server; the client
+  // only needs to know which row is the session it is using right now.
+  return c.json({
+    profile,
+    sessions: sessions.map((session) => ({
+      ...session,
+      isCurrent: session.id === currentSession?.id,
+    })),
+  });
 });
 
 settingsRoutes.get("/households", async (c) => {

--- a/src/server/routes/setup.ts
+++ b/src/server/routes/setup.ts
@@ -226,7 +226,6 @@ setupRoutes.post("/complete", async (c) => {
           role: "owner",
         },
         household,
-        session: signUpResult.response,
       },
       201,
     );

--- a/test/inbox-routes.test.ts
+++ b/test/inbox-routes.test.ts
@@ -1417,7 +1417,6 @@ describe("worker routes", () => {
     const payload = (await response.json()) as {
       member: { id: string; email: string; role: string };
       household: { slug: string };
-      session: { session: { userId: string } };
     };
 
     expect(payload.member).toEqual({
@@ -1427,7 +1426,7 @@ describe("worker routes", () => {
       role: "member",
     });
     expect(payload.household.slug).toBe("home");
-    expect(payload.session.session.userId).toBe("created-user-1");
+    expect("session" in payload).toBe(false);
     expect(response.headers.get("set-cookie")).toContain(
       "better-auth.session_token=test-token",
     );
@@ -1466,7 +1465,6 @@ describe("worker routes", () => {
     const payload = (await response.json()) as {
       member: { role: string; email: string };
       household: { slug: string };
-      session: { session: { userId: string } };
     };
 
     expect(payload.member).toEqual({
@@ -1476,7 +1474,7 @@ describe("worker routes", () => {
       role: "owner",
     });
     expect(payload.household.slug).toBe("home-setup");
-    expect(payload.session.session.userId).toBe("created-user-1");
+    expect("session" in payload).toBe(false);
   });
 });
 

--- a/test/integration/settings-route.test.ts
+++ b/test/integration/settings-route.test.ts
@@ -1,0 +1,48 @@
+import { SELF } from "cloudflare:test";
+import { provisioningAuthForEnv } from "@server/auth/auth";
+import { listUserSessions } from "@server/db/repositories/settings";
+import { describe, expect, it } from "vitest";
+
+import { db, testEnv } from "./helpers";
+
+async function signUpWithCookie() {
+  const result = await provisioningAuthForEnv(testEnv()).api.signUpEmail({
+    body: {
+      email: "owner@example.com",
+      name: "Owner",
+      password: "averylongpassword123",
+    },
+    returnHeaders: true,
+  });
+  const cookie = result.headers
+    .getSetCookie()
+    .map((entry) => entry.split(";")[0])
+    .join("; ");
+  return { userId: result.response.user.id, cookie };
+}
+
+describe("account settings (end-to-end against D1)", () => {
+  it("lists sessions without exposing tokens and flags the current one", async () => {
+    const { userId, cookie } = await signUpWithCookie();
+
+    const response = await SELF.fetch("http://localhost:8787/api/settings", {
+      headers: { cookie },
+    });
+    expect(response.status).toBe(200);
+
+    const payload = await response.json<{
+      sessions: Array<Record<string, unknown>>;
+    }>();
+    expect(payload.sessions).toHaveLength(1);
+    expect(payload.sessions[0]).toMatchObject({ isCurrent: true });
+    expect(JSON.stringify(payload)).not.toMatch(/"token"/);
+
+    const rows = await listUserSessions(db, userId);
+    expect(rows[0]).not.toHaveProperty("token");
+  });
+
+  it("requires a session", async () => {
+    const response = await SELF.fetch("http://localhost:8787/api/settings");
+    expect(response.status).toBe(401);
+  });
+});

--- a/test/settings-view.test.tsx
+++ b/test/settings-view.test.tsx
@@ -19,7 +19,7 @@ describe("SettingsView", () => {
         sessions={[
           {
             id: "session-1",
-            token: "token-1",
+            isCurrent: true,
             expiresAt: "2026-06-01T12:00:00.000Z",
             ipAddress: "127.0.0.1",
             userAgent: "Safari",


### PR DESCRIPTION
## Summary

Closes #97.

- `GET /api/settings` no longer includes `session.token` for the user's sessions; each session carries `isCurrent` instead (derived server-side from the active session) and the UI marks it "this device".
- `POST /api/setup/complete` and `POST /api/invitations/:token/accept` no longer echo Better Auth's full sign-up response (which contains the session token). The `Set-Cookie` header is the only credential returned; the client never used the body field.

## Tests

- `test/integration/settings-route.test.ts` (workerd, real D1): sign up → `GET /api/settings` with the cookie lists the session with `isCurrent: true` and **no `token` anywhere in the payload**; unauthenticated → 401.
- Unit route tests assert setup/accept payloads no longer contain `session`; settings-view fixture updated.

`npm run ci` green: 102 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)