### PR TITLE
feat: rate limit auth, setup and invitation endpoints (D1-backed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ Highlights:
 
 Mi Casa Su Casa is intended as a private household tool. The app should not be treated as a password vault in v1, and it does not store service account passwords.
 
+Brute-force protection is built in and backed by D1 (Workers have no shared memory): Better Auth limits sign-in to 5 attempts per minute per IP (reset/2FA/passkey endpoints have their own limits), `/api/setup/complete` allows 5 attempts per 15 minutes per IP, invitation-token lookups 20 per 10 minutes, and household creation 10 per hour. The client IP comes from Cloudflare's `cf-connecting-ip` header. For additional protection you can add Cloudflare WAF rate-limiting rules in front of `/api/auth/*` and `/api/setup/*`.
+
 ## License
 
 [MIT](./LICENSE)

--- a/migrations/0009_rate_limit.sql
+++ b/migrations/0009_rate_limit.sql
@@ -1,0 +1,12 @@
+-- Fixed-window rate limit counters, shared by Better Auth (storage: "database")
+-- and the app's own limiter for secret-bearing endpoints (/api/setup/complete,
+-- /api/invitations/*, POST /api/households). In-memory limiting is per-isolate
+-- on Workers and therefore ineffective.
+CREATE TABLE rate_limit (
+  id TEXT PRIMARY KEY NOT NULL,
+  key TEXT NOT NULL UNIQUE,
+  count INTEGER NOT NULL,
+  last_request INTEGER NOT NULL
+);
+
+CREATE INDEX rate_limit_last_request_idx ON rate_limit(last_request);

--- a/src/server/auth/auth.ts
+++ b/src/server/auth/auth.ts
@@ -65,9 +65,29 @@ function createAuth(env: Env, options: { disableSignUp: boolean }) {
         },
       },
     },
+    // Workers never set NODE_ENV, so Better Auth would otherwise leave rate
+    // limiting off; memory storage is per-isolate, so persist counters in D1.
+    rateLimit: {
+      enabled: true,
+      window: 60,
+      max: 60,
+      storage: "database",
+      customRules: {
+        "/sign-in/email": { window: 60, max: 5 },
+        "/request-password-reset": { window: 5 * 60, max: 3 },
+        "/reset-password": { window: 5 * 60, max: 5 },
+        "/two-factor/verify-totp": { window: 60, max: 5 },
+        "/two-factor/verify-backup-code": { window: 60, max: 5 },
+        "/sign-in/passkey": { window: 60, max: 10 },
+      },
+    },
     advanced: {
       database: {
         generateId: "uuid",
+      },
+      ipAddress: {
+        // Set by Cloudflare on every request; not client-spoofable.
+        ipAddressHeaders: ["cf-connecting-ip"],
       },
     },
     plugins: [

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -78,6 +78,17 @@ export const account = sqliteTable(
   ],
 );
 
+export const rateLimit = sqliteTable(
+  "rate_limit",
+  {
+    id: text("id").primaryKey(),
+    key: text("key").notNull().unique(),
+    count: integer("count").notNull(),
+    lastRequest: integer("last_request").notNull(),
+  },
+  (table) => [index("rate_limit_last_request_idx").on(table.lastRequest)],
+);
+
 export const verification = sqliteTable(
   "verification",
   {

--- a/src/server/routes/households.ts
+++ b/src/server/routes/households.ts
@@ -9,6 +9,7 @@ import {
   getHouseholdBySlug,
   listHouseholdsForUser,
 } from "../db/repositories/households";
+import { RATE_LIMITS, rateLimit } from "../security/rate-limit";
 
 type CreateHouseholdPayload = {
   slug?: string;
@@ -40,7 +41,7 @@ householdRoutes.get("/me", async (c) => {
   return c.json({ households: await listHouseholdsForUser(c.env.DB, user.id) });
 });
 
-householdRoutes.post("/", async (c) => {
+householdRoutes.post("/", rateLimit(RATE_LIMITS.householdCreate), async (c) => {
   const user = c.get("user");
 
   if (!user) {

--- a/src/server/routes/invitations.ts
+++ b/src/server/routes/invitations.ts
@@ -10,6 +10,7 @@ import {
   refreshExpiredInvitations,
 } from "../db/repositories/invitations";
 import { deleteUserById, findUserByEmail } from "../db/repositories/users";
+import { RATE_LIMITS, rateLimit } from "../security/rate-limit";
 import { hashInvitationToken } from "../security/tokens";
 
 type AcceptInvitationPayload = {
@@ -33,6 +34,7 @@ export const invitationRoutes = new Hono<{
 }>();
 
 invitationRoutes.use("*", loadAuthSession);
+invitationRoutes.use("*", rateLimit(RATE_LIMITS.invitations));
 
 invitationRoutes.get("/:token", async (c) => {
   await refreshExpiredInvitations(c.env.DB);

--- a/src/server/routes/setup.ts
+++ b/src/server/routes/setup.ts
@@ -13,6 +13,7 @@ import {
   resetInstallationSetup,
 } from "../db/repositories/installation-state";
 import { deleteUserById, findUserByEmail } from "../db/repositories/users";
+import { RATE_LIMITS, rateLimit } from "../security/rate-limit";
 
 type SetupPayload = {
   email?: string;
@@ -71,7 +72,7 @@ setupRoutes.get("/status", async (c) => {
   return c.json(mapInstallationStatus(state, c.env));
 });
 
-setupRoutes.post("/complete", async (c) => {
+setupRoutes.post("/complete", rateLimit(RATE_LIMITS.setup), async (c) => {
   if (!c.env.OWNER_EMAIL || !c.env.SETUP_SECRET) {
     return c.json(
       {

--- a/src/server/security/rate-limit.ts
+++ b/src/server/security/rate-limit.ts
@@ -1,0 +1,108 @@
+import type { MiddlewareHandler } from "hono";
+
+export type RateLimitRule = {
+  /** Short label used in the storage key, e.g. "setup". */
+  name: string;
+  /** Window length in seconds. */
+  windowSeconds: number;
+  /** Maximum requests per window per client. */
+  max: number;
+};
+
+export type RateLimitDecision =
+  | { allowed: true; remaining: number }
+  | { allowed: false; retryAfterSeconds: number };
+
+/**
+ * Resolves the client address. Cloudflare sets cf-connecting-ip on every
+ * request that reaches a Worker; it cannot be spoofed by the client.
+ */
+export function clientAddress(headers: Headers): string {
+  return (
+    headers.get("cf-connecting-ip")?.trim() ||
+    headers.get("x-real-ip")?.trim() ||
+    "unknown"
+  );
+}
+
+/**
+ * Atomic fixed-window counter in D1 (single upsert with RETURNING), keyed by
+ * rule name + client. Shared-table layout with Better Auth's rateLimit model.
+ */
+export async function consumeRateLimit(
+  db: D1Database,
+  rule: RateLimitRule,
+  client: string,
+  now: number = Date.now(),
+): Promise<RateLimitDecision> {
+  const key = `app:${rule.name}:${client}`;
+  const windowMs = rule.windowSeconds * 1000;
+  const windowStartCutoff = now - windowMs;
+
+  const row = await db
+    .prepare(
+      `INSERT INTO rate_limit (id, key, count, last_request)
+       VALUES (?1, ?2, 1, ?3)
+       ON CONFLICT(key) DO UPDATE SET
+         count = CASE
+           WHEN rate_limit.last_request <= ?4 THEN 1
+           ELSE rate_limit.count + 1
+         END,
+         last_request = CASE
+           WHEN rate_limit.last_request <= ?4 THEN ?3
+           ELSE rate_limit.last_request
+         END
+       RETURNING count, last_request`,
+    )
+    .bind(crypto.randomUUID(), key, now, windowStartCutoff)
+    .first<{ count: number; last_request: number }>();
+
+  const count = Number(row?.count ?? 1);
+  const lastRequest = Number(row?.last_request ?? now);
+
+  if (count > rule.max) {
+    const retryAfterSeconds = Math.max(
+      1,
+      Math.ceil((lastRequest + windowMs - now) / 1000),
+    );
+    return { allowed: false, retryAfterSeconds };
+  }
+
+  return { allowed: true, remaining: rule.max - count };
+}
+
+/** Hono middleware that enforces `rule` per client address. */
+export function rateLimit(
+  rule: RateLimitRule,
+): MiddlewareHandler<{ Bindings: Env }> {
+  return async (c, next) => {
+    const decision = await consumeRateLimit(
+      c.env.DB,
+      rule,
+      clientAddress(c.req.raw.headers),
+    );
+
+    if (!decision.allowed) {
+      c.header("Retry-After", String(decision.retryAfterSeconds));
+      return c.json(
+        { error: "Too many requests. Please try again later." },
+        429,
+      );
+    }
+
+    await next();
+  };
+}
+
+export const RATE_LIMITS = {
+  /** Guessing SETUP_SECRET must be slow. */
+  setup: { name: "setup", windowSeconds: 15 * 60, max: 5 },
+  /** Invitation token lookups / acceptance. */
+  invitations: { name: "invitations", windowSeconds: 10 * 60, max: 20 },
+  /** Household creation by authenticated users. */
+  householdCreate: {
+    name: "household-create",
+    windowSeconds: 60 * 60,
+    max: 10,
+  },
+} as const satisfies Record<string, RateLimitRule>;

--- a/test/integration/helpers.ts
+++ b/test/integration/helpers.ts
@@ -94,6 +94,7 @@ const RESET_ORDER = [
   "account",
   "verification",
   "user",
+  "rate_limit",
 ];
 
 /** Empties every application table so each test starts from a clean database. */

--- a/test/integration/rate-limit.test.ts
+++ b/test/integration/rate-limit.test.ts
@@ -1,0 +1,129 @@
+import { SELF } from "cloudflare:test";
+import { authForEnv, provisioningAuthForEnv } from "@server/auth/auth";
+import { consumeRateLimit, RATE_LIMITS } from "@server/security/rate-limit";
+import { describe, expect, it } from "vitest";
+
+import { db, testEnv } from "./helpers";
+
+const WRONG_SETUP = {
+  email: "owner@example.com",
+  name: "Owner",
+  password: "averylongpassword123",
+  householdName: "Casa",
+  householdSlug: "casa",
+  setupSecret: "wrong",
+};
+
+async function postSetup(ip: string) {
+  return SELF.fetch("http://localhost:8787/api/setup/complete", {
+    method: "POST",
+    headers: { "content-type": "application/json", "cf-connecting-ip": ip },
+    body: JSON.stringify(WRONG_SETUP),
+  });
+}
+
+describe("rate limiting (D1-backed)", () => {
+  it("consumeRateLimit counts per window and resets after it", async () => {
+    const rule = { name: "t", windowSeconds: 60, max: 2 };
+    const t0 = 1_000_000;
+
+    expect(await consumeRateLimit(db, rule, "1.1.1.1", t0)).toEqual({
+      allowed: true,
+      remaining: 1,
+    });
+    expect(await consumeRateLimit(db, rule, "1.1.1.1", t0 + 1000)).toEqual({
+      allowed: true,
+      remaining: 0,
+    });
+    const blocked = await consumeRateLimit(db, rule, "1.1.1.1", t0 + 2000);
+    expect(blocked.allowed).toBe(false);
+    if (!blocked.allowed) {
+      expect(blocked.retryAfterSeconds).toBeGreaterThan(0);
+      expect(blocked.retryAfterSeconds).toBeLessThanOrEqual(60);
+    }
+
+    // Other clients are independent; the window eventually resets.
+    expect(
+      (await consumeRateLimit(db, rule, "2.2.2.2", t0 + 2000)).allowed,
+    ).toBe(true);
+    expect(
+      (await consumeRateLimit(db, rule, "1.1.1.1", t0 + 61_000)).allowed,
+    ).toBe(true);
+  });
+
+  it("throttles SETUP_SECRET guessing per client address", async () => {
+    for (let attempt = 0; attempt < RATE_LIMITS.setup.max; attempt += 1) {
+      expect((await postSetup("203.0.113.7")).status).toBe(403);
+    }
+
+    const blocked = await postSetup("203.0.113.7");
+    expect(blocked.status).toBe(429);
+    expect(Number(blocked.headers.get("retry-after"))).toBeGreaterThan(0);
+
+    // A different client is unaffected.
+    expect((await postSetup("203.0.113.8")).status).toBe(403);
+  });
+
+  it("throttles invitation token probing", async () => {
+    const probe = () =>
+      SELF.fetch("http://localhost:8787/api/invitations/does-not-exist", {
+        headers: { "cf-connecting-ip": "198.51.100.2" },
+      });
+
+    for (let attempt = 0; attempt < RATE_LIMITS.invitations.max; attempt += 1) {
+      expect((await probe()).status).toBe(404);
+    }
+    expect((await probe()).status).toBe(429);
+  });
+
+  it("Better Auth limits password sign-in attempts per IP using cf-connecting-ip", async () => {
+    const env = testEnv();
+    await provisioningAuthForEnv(env).api.signUpEmail({
+      body: {
+        email: "owner@example.com",
+        name: "Owner",
+        password: "averylongpassword123",
+      },
+    });
+
+    const attempt = () =>
+      SELF.fetch("http://localhost:8787/api/auth/sign-in/email", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:8787",
+          "cf-connecting-ip": "192.0.2.10",
+        },
+        body: JSON.stringify({
+          email: "owner@example.com",
+          password: "wrong-password-123",
+        }),
+      });
+
+    for (let i = 0; i < 5; i += 1) {
+      expect((await attempt()).status).toBe(401);
+    }
+    expect((await attempt()).status).toBe(429);
+
+    // Unrelated client still gets through (and is still rejected for the wrong password).
+    const other = await SELF.fetch(
+      "http://localhost:8787/api/auth/sign-in/email",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:8787",
+          "cf-connecting-ip": "192.0.2.11",
+        },
+        body: JSON.stringify({
+          email: "owner@example.com",
+          password: "wrong-password-123",
+        }),
+      },
+    );
+    expect(other.status).toBe(401);
+
+    // Sanity: the configured auth instance is the one SELF serves.
+    expect(authForEnv(env)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #84.

Better Auth's rate limiter was effectively off on Workers (it keys on `NODE_ENV`) and its default memory storage is per-isolate; the custom secret-bearing endpoints had no throttling at all.

- **Better Auth**: `rateLimit: { enabled: true, window: 60, max: 60, storage: "database", customRules: { "/sign-in/email": 5/min, "/request-password-reset": 3/5min, "/reset-password": 5/5min, "/two-factor/verify-totp": 5/min, "/two-factor/verify-backup-code": 5/min, "/sign-in/passkey": 10/min } }` and `advanced.ipAddress.ipAddressHeaders: ["cf-connecting-ip"]`.
- `migrations/0009_rate_limit.sql` + Drizzle `rateLimit` table (`rate_limit`) so the Better Auth adapter can persist counters.
- `src/server/security/rate-limit.ts`: atomic fixed-window counter in D1 (single upsert with `RETURNING`) + Hono middleware returning `429` with `Retry-After`; applied to `POST /api/setup/complete` (5 / 15 min per IP), `/api/invitations/*` (20 / 10 min), `POST /api/households` (10 / h).
- README security notes updated.

## Tests (real D1 / workerd)

- `consumeRateLimit`: counts per window, blocks at `max+1` with a sane `Retry-After`, independent per client, resets after the window.
- `/api/setup/complete`: 5 wrong secrets → 403, 6th → 429 with `Retry-After`; another IP unaffected.
- Invitation token probing: 20 → 404, 21st → 429.
- Better Auth: 5 wrong passwords → 401, 6th → 429 keyed by `cf-connecting-ip`; other IP still 401.

`npm run ci` green: 107 tests, build; migrations 0001–0009 apply cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)