### PR TITLE
fix: align Drizzle schema with the migrated database and guard against drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,21 +91,17 @@ Set `OWNER_EMAIL` in the top-level `vars` section of `wrangler.jsonc` to your em
 npm run db:apply:local
 ```
 
-### Generate Drizzle migrations
+### Database schema and migrations
 
-Better Auth tables and app tables are now represented in Drizzle schema definitions while Cloudflare D1 remains the runtime database.
+The hand-written SQL files in `migrations/` are the **source of truth** for the D1 schema and are applied with Wrangler (`npm run db:apply:local|preview|production`). `src/server/db/schema.ts` is a Drizzle mirror of that schema used for typed queries and by the Better Auth adapter — it must match the migrations exactly, and `test/integration/schema-drift.test.ts` fails CI if it does not (tables, columns, nullability, defaults, unique constraints, indexes).
 
-Generate new migration SQL with:
+To change the schema:
 
-```bash
-npm run db:generate
-```
+1. add a new numbered file under `migrations/` (migrations are append-only; never edit an applied one),
+2. mirror the change in `src/server/db/schema.ts`,
+3. run `npm run test:integration` — the drift test tells you about any mismatch.
 
-Apply the generated SQL through the existing Wrangler migration flow:
-
-```bash
-npm run db:apply:local
-```
+`npm run db:generate` (drizzle-kit) is **not** part of the workflow; there is no Drizzle journal and it would emit a full initial schema.
 
 ### Start development
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -5,6 +5,7 @@ import {
   integer,
   sqliteTable,
   text,
+  unique,
   uniqueIndex,
 } from "drizzle-orm/sqlite-core";
 
@@ -191,7 +192,7 @@ export const householdMemberships = sqliteTable(
     updatedAt: text("updated_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
   },
   (table) => [
-    uniqueIndex("household_memberships_household_user_unique").on(
+    unique("household_memberships_household_user_unique").on(
       table.householdId,
       table.userId,
     ),
@@ -217,9 +218,10 @@ export const householdMemberProviderAccess = sqliteTable(
     createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
   },
   (table) => [
-    uniqueIndex(
-      "household_member_provider_access_membership_provider_unique",
-    ).on(table.householdMembershipId, table.providerId),
+    unique("household_member_provider_access_membership_provider_unique").on(
+      table.householdMembershipId,
+      table.providerId,
+    ),
     index("household_member_provider_access_membership_idx").on(
       table.householdMembershipId,
     ),
@@ -242,7 +244,7 @@ export const senderRules = sqliteTable(
     createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
   },
   (table) => [
-    uniqueIndex("sender_rules_household_match_type_match_value_unique").on(
+    unique("sender_rules_household_match_type_match_value_unique").on(
       table.householdId,
       table.matchType,
       table.matchValue,
@@ -259,29 +261,11 @@ export const senderRules = sqliteTable(
   ],
 );
 
-export const userProviderAccess = sqliteTable(
-  "user_provider_access",
-  {
-    id: text("id").primaryKey(),
-    userId: text("user_id").notNull(),
-    providerId: text("provider_id")
-      .notNull()
-      .references(() => providers.id, { onDelete: "cascade" }),
-    createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
-  },
-  (table) => [
-    uniqueIndex("user_provider_access_user_id_provider_id_unique").on(
-      table.userId,
-      table.providerId,
-    ),
-  ],
-);
-
 export const messages = sqliteTable(
   "messages",
   {
     id: text("id").primaryKey(),
-    messageId: text("message_id").notNull().unique(),
+    messageId: text("message_id").notNull(),
     householdId: text("household_id")
       .notNull()
       .references(() => households.id, { onDelete: "cascade" }),
@@ -294,7 +278,10 @@ export const messages = sqliteTable(
     subject: text("subject"),
     textBody: text("text_body").notNull(),
     extractedCode: text("extracted_code"),
-    status: text("status").$type<"new" | "used" | "expired">().notNull(),
+    status: text("status")
+      .$type<"new" | "used" | "expired">()
+      .notNull()
+      .default("new"),
     classificationReason: text("classification_reason").notNull(),
     rawSize: integer("raw_size").notNull(),
     dateHeader: text("date_header"),
@@ -303,7 +290,7 @@ export const messages = sqliteTable(
     createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
   },
   (table) => [
-    uniqueIndex("messages_household_id_message_id_unique").on(
+    unique("messages_household_id_message_id_unique").on(
       table.householdId,
       table.messageId,
     ),
@@ -347,7 +334,7 @@ export const quarantineMessages = sqliteTable(
     createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
   },
   (table) => [
-    uniqueIndex("quarantine_messages_household_id_message_id_unique").on(
+    unique("quarantine_messages_household_id_message_id_unique").on(
       table.householdId,
       table.messageId,
     ),
@@ -446,7 +433,7 @@ export const householdInvitationProviderAccess = sqliteTable(
     createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
   },
   (table) => [
-    uniqueIndex(
+    unique(
       "household_invitation_provider_access_invitation_provider_unique",
     ).on(table.invitationId, table.providerId),
   ],

--- a/test/integration/schema-drift.test.ts
+++ b/test/integration/schema-drift.test.ts
@@ -1,0 +1,152 @@
+import * as schema from "@server/db/schema";
+import { is } from "drizzle-orm";
+import { getTableConfig, SQLiteTable } from "drizzle-orm/sqlite-core";
+import { describe, expect, it } from "vitest";
+
+import { db } from "./helpers";
+
+/**
+ * The hand-written SQL migrations are the source of truth for the database.
+ * `schema.ts` must mirror them exactly: Better Auth validates writes against
+ * the Drizzle schema, and drift there has already caused production 500s.
+ */
+
+type ColumnInfo = {
+  name: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+};
+type IndexInfo = { name: string; unique: number; origin: string };
+
+const IGNORED_TABLES = new Set(["d1_migrations"]);
+
+async function dbTables(): Promise<string[]> {
+  const result = await db
+    .prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '\\_cf\\_%' ESCAPE '\\'",
+    )
+    .all<{ name: string }>();
+  return result.results
+    .map((row) => row.name)
+    .filter((n) => !IGNORED_TABLES.has(n));
+}
+
+async function dbColumns(table: string): Promise<ColumnInfo[]> {
+  return (await db.prepare(`PRAGMA table_info("${table}")`).all<ColumnInfo>())
+    .results;
+}
+
+async function dbIndexes(table: string) {
+  const list = (
+    await db.prepare(`PRAGMA index_list("${table}")`).all<IndexInfo>()
+  ).results;
+  const detailed = [];
+  for (const index of list) {
+    const cols = (
+      await db
+        .prepare(`PRAGMA index_info("${index.name}")`)
+        .all<{ name: string }>()
+    ).results.map((c) => c.name);
+    detailed.push({ ...index, columns: cols });
+  }
+  return detailed;
+}
+
+function columnSetKey(columns: string[]) {
+  return [...columns].sort().join(",");
+}
+
+const schemaTables = (Object.values(schema) as unknown[]).filter(
+  (value): value is SQLiteTable => is(value, SQLiteTable),
+);
+
+describe("schema.ts mirrors the migrated database", () => {
+  it("declares exactly the tables that exist", async () => {
+    const declared = schemaTables.map((t) => getTableConfig(t).name).sort();
+    const actual = (await dbTables()).sort();
+    expect(declared).toEqual(actual);
+  });
+
+  for (const table of schemaTables) {
+    const config = getTableConfig(table);
+
+    describe(config.name, () => {
+      it("has the same columns, nullability and defaults", async () => {
+        const actual = await dbColumns(config.name);
+        const actualByName = new Map(actual.map((c) => [c.name, c]));
+
+        expect(config.columns.map((c) => c.name).sort()).toEqual(
+          actual.map((c) => c.name).sort(),
+        );
+
+        for (const column of config.columns) {
+          const real = actualByName.get(column.name);
+          expect(real, `column ${config.name}.${column.name}`).toBeDefined();
+          if (!real) continue;
+
+          if (!column.primary) {
+            expect(
+              Boolean(real.notnull),
+              `${config.name}.${column.name} NOT NULL`,
+            ).toBe(column.notNull);
+          }
+          if (!column.primary) {
+            expect(
+              real.dflt_value !== null,
+              `${config.name}.${column.name} DEFAULT`,
+            ).toBe(column.hasDefault);
+          }
+        }
+      });
+
+      it("has the same unique constraints and indexes", async () => {
+        const actual = await dbIndexes(config.name);
+
+        // Unique: inline UNIQUE(...) constraints (autoindex, origin 'u'),
+        // column-level UNIQUE, and CREATE UNIQUE INDEX — compared by column set.
+        const actualUnique = new Set(
+          actual
+            .filter((i) => i.unique === 1 && i.origin !== "pk")
+            .map((i) => columnSetKey(i.columns)),
+        );
+        const declaredUnique = new Set<string>([
+          ...config.uniqueConstraints.map((u) =>
+            columnSetKey(u.columns.map((c) => c.name)),
+          ),
+          ...config.indexes
+            .filter((i) => i.config.unique)
+            .map((i) =>
+              columnSetKey(
+                i.config.columns.map((c) =>
+                  "name" in c ? String(c.name) : String(c),
+                ),
+              ),
+            ),
+          ...config.columns
+            .filter((c) => c.isUnique)
+            .map((c) => columnSetKey([c.name])),
+        ]);
+        expect([...declaredUnique].sort(), "unique column sets").toEqual(
+          [...actualUnique].sort(),
+        );
+
+        // Non-unique indexes: compared by name + columns.
+        const actualPlain = actual
+          .filter((i) => i.unique === 0)
+          .map((i) => `${i.name}(${i.columns.join(",")})`)
+          .sort();
+        const declaredPlain = config.indexes
+          .filter((i) => !i.config.unique)
+          .map(
+            (i) =>
+              `${i.config.name}(${i.config.columns
+                .map((c) => ("name" in c ? String(c.name) : String(c)))
+                .join(",")})`,
+          )
+          .sort();
+        expect(declaredPlain, "indexes").toEqual(actualPlain);
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Closes #87.

The hand-written migrations are the source of truth; `schema.ts` had drifted (and the Better Auth adapter validates writes against it — the 1.7 `issuer` 500 was the first symptom).

- `schema.ts`: remove `userProviderAccess` (table dropped in 0005); drop the **global** unique on `messages.message_id` (DB has `UNIQUE(household_id, message_id)`); add `.default("new")` on `messages.status`; declare the inline `UNIQUE(...)` constraints as `unique()` table constraints instead of named `uniqueIndex()`es that don't exist in the DB (the two real named unique indexes — `providers`, `account` — stay `uniqueIndex`).
- **`test/integration/schema-drift.test.ts`**: for every `SQLiteTable` exported from `schema.ts`, compares against the migrated D1 via `PRAGMA`: exact table set, column set, NOT NULL and DEFAULT per column, unique column sets (inline / column-level / unique index), and non-unique indexes by name + columns. 37 assertions; drift now fails CI.
- README: "Database schema and migrations" section replaces the misleading "Generate Drizzle migrations" one.

`npm run ci` green: 144 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)