### PR TITLE
fix: harden inbound email handling (reject, size guard, truncation, logging)

### DIFF
--- a/src/server/db/repositories/messages.ts
+++ b/src/server/db/repositories/messages.ts
@@ -182,6 +182,18 @@ export async function listProviderSummariesForUser(
   return result;
 }
 
+export async function countUnreviewedQuarantine(
+  db: D1Database,
+  householdId: string,
+): Promise<number> {
+  const row = await dbForDatabase(db).get<{ total: number }>(sql`
+    SELECT COUNT(*) AS total
+    FROM quarantine_messages
+    WHERE household_id = ${householdId} AND reviewed_at IS NULL
+  `);
+  return Number(row?.total ?? 0);
+}
+
 export async function listQuarantineMessages(
   db: D1Database,
   householdId: string,

--- a/src/server/db/types.ts
+++ b/src/server/db/types.ts
@@ -10,6 +10,8 @@ export type ClassificationResult =
     }
   | {
       kind: "quarantine";
+      /** Resolved household, or null when the recipient is unknown. */
+      householdId: string | null;
       reason: string;
       code: string | null;
     };
@@ -23,6 +25,8 @@ export type ParsedIncomingEmail = {
   messageId: string | null;
   dateHeader: string | null;
   textBody: string;
+  /** True when textBody was cut to MAX_TEXT_BODY_CHARS. */
+  textBodyTruncated?: boolean;
   rawSize: number;
 };
 

--- a/src/server/domain/classify-email.ts
+++ b/src/server/domain/classify-email.ts
@@ -12,6 +12,7 @@ export async function classifyEmail(
   if (!parsed.householdSlug) {
     return {
       kind: "quarantine",
+      householdId: null,
       reason: "No household slug could be resolved from the recipient address.",
       code,
     };
@@ -22,6 +23,7 @@ export async function classifyEmail(
   if (!household) {
     return {
       kind: "quarantine",
+      householdId: null,
       reason: "No household matched the inbound recipient address.",
       code,
     };
@@ -36,6 +38,7 @@ export async function classifyEmail(
   if (!providerMatch) {
     return {
       kind: "quarantine",
+      householdId: household.id,
       reason:
         "No sender rule matched the inbound email within the addressed household.",
       code,

--- a/src/server/email/handler.ts
+++ b/src/server/email/handler.ts
@@ -1,5 +1,5 @@
-import { getHouseholdBySlug } from "../db/repositories/households";
 import {
+  countUnreviewedQuarantine,
   insertMessage,
   insertQuarantineMessage,
 } from "../db/repositories/messages";
@@ -7,42 +7,117 @@ import { classifyEmail } from "../domain/classify-email";
 import type { AppContext } from "../runtime/context";
 import { parseIncomingEmail } from "./parse";
 
+/** Email Routing accepts up to 25 MB; OTP mail is tiny. Reject the rest early. */
+export const MAX_RAW_MESSAGE_BYTES = 2 * 1024 * 1024;
+/** Unreviewed quarantine rows per household before new unmatched mail is refused. */
+export const MAX_UNREVIEWED_QUARANTINE = 200;
+
+function log(event: string, fields: Record<string, unknown>) {
+  console.log(JSON.stringify({ event, ...fields }));
+}
+
+function logError(event: string, fields: Record<string, unknown>) {
+  console.error(JSON.stringify({ event, ...fields }));
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Inbound Email Worker entrypoint. Known-bad input (unknown recipient, too
+ * large, quarantine full) is rejected permanently with a reason; unexpected
+ * failures are logged with context and re-thrown so Cloudflare answers with a
+ * temporary error and the sender retries.
+ */
 export async function handleIncomingEmail(
   message: ForwardableEmailMessage,
   appContext: AppContext,
 ) {
-  const parsed = await parseIncomingEmail(message);
-  const classification = await classifyEmail(appContext.env.DB, parsed);
+  const base = {
+    from: message.from,
+    to: message.to,
+    rawSize: message.rawSize,
+  };
 
-  if (!parsed.householdSlug) {
+  if (message.rawSize > MAX_RAW_MESSAGE_BYTES) {
+    log("email_rejected", { ...base, reason: "too_large" });
+    message.setReject("Message too large");
     return;
   }
 
-  if (classification.kind === "quarantine") {
-    const household = await getHouseholdBySlug(
-      appContext.env.DB,
-      parsed.householdSlug,
-    );
-    const householdId = household?.id ?? null;
+  let parsed: Awaited<ReturnType<typeof parseIncomingEmail>>;
+  try {
+    parsed = await parseIncomingEmail(message);
+  } catch (error) {
+    logError("email_parse_failed", { ...base, error: errorMessage(error) });
+    message.setReject("Message could not be parsed");
+    return;
+  }
 
-    if (!householdId) {
+  const context = { ...base, messageId: parsed.messageId };
+
+  try {
+    const classification = await classifyEmail(appContext.env.DB, parsed);
+
+    if (classification.kind === "quarantine") {
+      if (!classification.householdId) {
+        log("email_rejected", {
+          ...context,
+          reason: "unknown_recipient",
+          detail: classification.reason,
+        });
+        message.setReject("Unknown recipient");
+        return;
+      }
+
+      const pending = await countUnreviewedQuarantine(
+        appContext.env.DB,
+        classification.householdId,
+      );
+
+      if (pending >= MAX_UNREVIEWED_QUARANTINE) {
+        log("email_rejected", {
+          ...context,
+          householdId: classification.householdId,
+          reason: "quarantine_full",
+          pending,
+        });
+        message.setReject("Mailbox quarantine is full");
+        return;
+      }
+
+      await insertQuarantineMessage(
+        appContext.env.DB,
+        parsed,
+        classification.householdId,
+        classification,
+      );
+      log("email_quarantined", {
+        ...context,
+        householdId: classification.householdId,
+        reason: classification.reason,
+        truncated: parsed.textBodyTruncated === true,
+      });
       return;
     }
 
-    await insertQuarantineMessage(
+    await insertMessage(
       appContext.env.DB,
       parsed,
-      householdId,
+      classification.householdId,
+      classification.providerId,
       classification,
     );
-    return;
+    log("email_stored", {
+      ...context,
+      householdId: classification.householdId,
+      providerKey: classification.providerKey,
+      codeFound: classification.code !== null,
+      truncated: parsed.textBodyTruncated === true,
+    });
+  } catch (error) {
+    logError("email_ingest_failed", { ...context, error: errorMessage(error) });
+    throw error;
   }
-
-  await insertMessage(
-    appContext.env.DB,
-    parsed,
-    classification.householdId,
-    classification.providerId,
-    classification,
-  );
 }

--- a/src/server/email/parse.ts
+++ b/src/server/email/parse.ts
@@ -2,6 +2,42 @@ import PostalMime from "postal-mime";
 
 import type { ParsedIncomingEmail } from "../db/types";
 
+/** Bodies beyond this are cut; verification codes live in the first few KB. */
+export const MAX_TEXT_BODY_CHARS = 64 * 1024;
+
+async function sha256Hex(value: string) {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Messages without a Message-ID get a deterministic synthetic one so a
+ * redelivery of the same message is still de-duplicated.
+ */
+async function syntheticMessageId(parts: {
+  from: string;
+  to: string;
+  date: string | null;
+  subject: string | null;
+  body: string;
+}) {
+  const hash = await sha256Hex(
+    [
+      parts.from,
+      parts.to,
+      parts.date ?? "",
+      parts.subject ?? "",
+      parts.body,
+    ].join("\u0000"),
+  );
+  return `<synthetic-${hash.slice(0, 32)}@mi-casa-su-casa>`;
+}
+
 function extractHouseholdSlug(address: string): string | null {
   const normalized = address.trim().toLowerCase();
   const localPart = normalized.split("@")[0]?.trim();
@@ -27,26 +63,40 @@ export async function parseIncomingEmail(
   const parsed = await parser.parse(
     await new Response(message.raw).arrayBuffer(),
   );
-  const textBody =
+  const fullTextBody =
     parsed.text?.trim() ||
     (parsed.html ? stripHtml(parsed.html) : "") ||
     "[empty email body]";
+  const textBodyTruncated = fullTextBody.length > MAX_TEXT_BODY_CHARS;
+  const textBody = textBodyTruncated
+    ? `${fullTextBody.slice(0, MAX_TEXT_BODY_CHARS)}\n[truncated]`
+    : fullTextBody;
+
+  const header = (name: string) =>
+    parsed.headers.find((entry) => entry.key.toLowerCase() === name)?.value ??
+    null;
+  const subject = parsed.subject ?? null;
+  const dateHeader = header("date");
+  const messageId =
+    header("message-id") ??
+    (await syntheticMessageId({
+      from: message.from,
+      to: message.to,
+      date: dateHeader,
+      subject,
+      body: textBody,
+    }));
 
   return {
     envelopeFrom: message.from,
     envelopeTo: message.to,
     householdSlug: extractHouseholdSlug(message.to),
-    fromHeader:
-      parsed.headers.find((header) => header.key.toLowerCase() === "from")
-        ?.value ?? null,
-    subject: parsed.subject ?? null,
-    messageId:
-      parsed.headers.find((header) => header.key.toLowerCase() === "message-id")
-        ?.value ?? null,
-    dateHeader:
-      parsed.headers.find((header) => header.key.toLowerCase() === "date")
-        ?.value ?? null,
+    fromHeader: header("from"),
+    subject,
+    messageId,
+    dateHeader,
     textBody,
+    textBodyTruncated,
     rawSize: message.rawSize,
   };
 }

--- a/test/classify-email.test.ts
+++ b/test/classify-email.test.ts
@@ -1,52 +1,34 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ParsedIncomingEmail } from "../src/server/db/types";
-import { classifyEmail } from "../src/server/domain/classify-email";
 
-function createDbStub(
-  match: {
+const repoState = vi.hoisted(() => ({
+  household: null as { id: string; slug: string; displayName: string } | null,
+  match: null as {
     householdId: string;
     householdSlug: string;
     providerId: string;
     providerKey: string;
   } | null,
-): D1Database {
-  let call = 0;
+}));
 
-  const nextResult = () => {
-    call += 1;
+vi.mock("../src/server/db/repositories/households", () => ({
+  getHouseholdBySlug: vi.fn(async () => repoState.household),
+}));
 
-    if (call === 1) {
-      return { id: "household-1", slug: "codes", displayName: "Codes" };
-    }
+vi.mock("../src/server/db/repositories/provider-rules", () => ({
+  findProviderMatch: vi.fn(async () => repoState.match),
+}));
 
-    return match;
-  };
-
-  return {
-    prepare: () => ({
-      bind: () => ({
-        all: async () => {
-          const result = nextResult();
-          return { results: result ? [result] : [] };
-        },
-        first: async () => nextResult(),
-        raw: async () => {
-          const result = nextResult();
-          return result ? [result] : [];
-        },
-      }),
-    }),
-  } as unknown as D1Database;
-}
+const { classifyEmail } = await import("../src/server/domain/classify-email");
 
 function createParsedEmail(
   overrides?: Partial<ParsedIncomingEmail>,
 ): ParsedIncomingEmail {
   return {
     envelopeFrom: "login@service.example",
-    envelopeTo: "codes@example.com",
-    householdSlug: "codes",
+    envelopeTo: "casa@example.com",
+    householdSlug: "casa",
     fromHeader: "Service <login@service.example>",
     subject: "Your verification code",
     messageId: "<test-1@example.com>",
@@ -57,22 +39,30 @@ function createParsedEmail(
   };
 }
 
-describe("classifyEmail", () => {
-  it("matches a configured provider and extracts the code", async () => {
-    const result = await classifyEmail(
-      createDbStub({
-        householdId: "household-1",
-        householdSlug: "codes",
-        providerId: "provider-1",
-        providerKey: "netflix",
-      }),
-      createParsedEmail(),
-    );
+const db = {} as D1Database;
 
-    expect(result).toEqual({
+describe("classifyEmail", () => {
+  beforeEach(() => {
+    repoState.household = {
+      id: "household-1",
+      slug: "casa",
+      displayName: "Casa",
+    };
+    repoState.match = null;
+  });
+
+  it("matches a configured provider and extracts the code", async () => {
+    repoState.match = {
+      householdId: "household-1",
+      householdSlug: "casa",
+      providerId: "provider-1",
+      providerKey: "netflix",
+    };
+
+    await expect(classifyEmail(db, createParsedEmail())).resolves.toEqual({
       kind: "matched",
       householdId: "household-1",
-      householdSlug: "codes",
+      householdSlug: "casa",
       providerId: "provider-1",
       providerKey: "netflix",
       code: "123456",
@@ -81,14 +71,30 @@ describe("classifyEmail", () => {
     });
   });
 
-  it("quarantines when there is no sender rule match", async () => {
-    const result = await classifyEmail(createDbStub(null), createParsedEmail());
-
-    expect(result).toEqual({
+  it("quarantines within the household when there is no sender rule match", async () => {
+    await expect(classifyEmail(db, createParsedEmail())).resolves.toEqual({
       kind: "quarantine",
+      householdId: "household-1",
       reason:
         "No sender rule matched the inbound email within the addressed household.",
       code: "123456",
     });
+  });
+
+  it("reports an unknown household (no householdId) when the slug does not resolve", async () => {
+    repoState.household = null;
+
+    await expect(classifyEmail(db, createParsedEmail())).resolves.toMatchObject(
+      {
+        kind: "quarantine",
+        householdId: null,
+      },
+    );
+  });
+
+  it("reports an unknown household when the recipient has no usable slug", async () => {
+    await expect(
+      classifyEmail(db, createParsedEmail({ householdSlug: null })),
+    ).resolves.toMatchObject({ kind: "quarantine", householdId: null });
   });
 });

--- a/test/email-handler.test.ts
+++ b/test/email-handler.test.ts
@@ -1,57 +1,31 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type {
+  ClassificationResult,
+  ParsedIncomingEmail,
+} from "../src/server/db/types";
+
 const parseState = vi.hoisted(() => ({
-  result: {
-    envelopeFrom: "login@service.example",
-    envelopeTo: "codes@example.com",
-    householdSlug: "codes",
-    fromHeader: "Service <login@service.example>",
-    subject: "Verification code",
-    messageId: "<message-1@test>",
-    dateHeader: "2026-05-10T12:00:00.000Z",
-    textBody: "Your verification code is 123456",
-    rawSize: 128,
-  },
+  result: null as unknown as ParsedIncomingEmail,
+  error: null as Error | null,
 }));
 
 const classifyState = vi.hoisted(() => ({
-  result: {
-    kind: "matched",
-    householdId: "household-1",
-    householdSlug: "codes",
-    providerId: "provider-1",
-    providerKey: "netflix",
-    code: "123456",
-    reason:
-      "Sender matched a configured rule and a likely verification code was found.",
-  } as
-    | {
-        kind: "matched";
-        householdId: string;
-        householdSlug: string;
-        providerId: string;
-        providerKey: string;
-        code: string | null;
-        reason: string;
-      }
-    | {
-        kind: "quarantine";
-        reason: string;
-        code: string | null;
-      },
+  result: null as unknown as ClassificationResult,
 }));
 
 const messageRepoState = vi.hoisted(() => ({
   insertMessage: vi.fn(),
   insertQuarantineMessage: vi.fn(),
-}));
-
-const householdRepoState = vi.hoisted(() => ({
-  getHouseholdBySlug: vi.fn(),
+  countUnreviewedQuarantine: vi.fn(),
 }));
 
 vi.mock("../src/server/email/parse", () => ({
-  parseIncomingEmail: vi.fn(async () => parseState.result),
+  MAX_TEXT_BODY_CHARS: 65536,
+  parseIncomingEmail: vi.fn(async () => {
+    if (parseState.error) throw parseState.error;
+    return parseState.result;
+  }),
 }));
 
 vi.mock("../src/server/domain/classify-email", () => ({
@@ -61,27 +35,29 @@ vi.mock("../src/server/domain/classify-email", () => ({
 vi.mock("../src/server/db/repositories/messages", () => ({
   insertMessage: messageRepoState.insertMessage,
   insertQuarantineMessage: messageRepoState.insertQuarantineMessage,
+  countUnreviewedQuarantine: messageRepoState.countUnreviewedQuarantine,
 }));
 
-vi.mock("../src/server/db/repositories/households", () => ({
-  getHouseholdBySlug: householdRepoState.getHouseholdBySlug,
-}));
+const {
+  handleIncomingEmail,
+  MAX_RAW_MESSAGE_BYTES,
+  MAX_UNREVIEWED_QUARANTINE,
+} = await import("../src/server/email/handler");
 
-const { handleIncomingEmail } = await import("../src/server/email/handler");
-
-function createMessage(): ForwardableEmailMessage {
-  return {
+function createMessage(overrides: Partial<{ rawSize: number }> = {}) {
+  const setReject = vi.fn();
+  const message = {
     from: "login@service.example",
-    to: "codes@example.com",
+    to: "casa@example.com",
     raw: new ReadableStream<Uint8Array>({
       start(controller) {
         controller.enqueue(new TextEncoder().encode("raw"));
         controller.close();
       },
     }),
-    rawSize: 128,
+    rawSize: overrides.rawSize ?? 128,
     headers: new Headers(),
-    setReject() {},
+    setReject,
     forward() {
       return Promise.resolve();
     },
@@ -89,13 +65,12 @@ function createMessage(): ForwardableEmailMessage {
       return Promise.resolve();
     },
   } as unknown as ForwardableEmailMessage;
+  return { message, setReject };
 }
 
 function createAppContext(): import("../src/server/runtime/context").AppContext {
   return {
-    env: {
-      DB: {} as D1Database,
-    } as Env,
+    env: { DB: {} as D1Database } as Env,
     executionContext: {
       waitUntil() {},
       passThroughOnException() {},
@@ -104,12 +79,28 @@ function createAppContext(): import("../src/server/runtime/context").AppContext 
   };
 }
 
+const matched: ClassificationResult = {
+  kind: "matched",
+  householdId: "household-1",
+  householdSlug: "casa",
+  providerId: "provider-1",
+  providerKey: "netflix",
+  code: "123456",
+  reason:
+    "Sender matched a configured rule and a likely verification code was found.",
+};
+
 describe("handleIncomingEmail", () => {
+  type Spy = { mock: { calls: unknown[][] } };
+  let logSpy: Spy;
+  let errorSpy: Spy;
+
   beforeEach(() => {
+    parseState.error = null;
     parseState.result = {
       envelopeFrom: "login@service.example",
-      envelopeTo: "codes@example.com",
-      householdSlug: "codes",
+      envelopeTo: "casa@example.com",
+      householdSlug: "casa",
       fromHeader: "Service <login@service.example>",
       subject: "Verification code",
       messageId: "<message-1@test>",
@@ -117,79 +108,144 @@ describe("handleIncomingEmail", () => {
       textBody: "Your verification code is 123456",
       rawSize: 128,
     };
-    classifyState.result = {
-      kind: "matched",
-      householdId: "household-1",
-      householdSlug: "codes",
-      providerId: "provider-1",
-      providerKey: "netflix",
-      code: "123456",
-      reason:
-        "Sender matched a configured rule and a likely verification code was found.",
-    };
+    classifyState.result = matched;
     messageRepoState.insertMessage.mockReset();
     messageRepoState.insertQuarantineMessage.mockReset();
-    householdRepoState.getHouseholdBySlug.mockReset();
-    householdRepoState.getHouseholdBySlug.mockResolvedValue({
-      id: "household-1",
-      slug: "codes",
-      displayName: "Codes",
-    });
+    messageRepoState.countUnreviewedQuarantine.mockReset();
+    messageRepoState.countUnreviewedQuarantine.mockResolvedValue(0);
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
-  it("persists matched emails to messages", async () => {
-    await handleIncomingEmail(createMessage(), createAppContext());
+  function events(spy: { mock: { calls: unknown[][] } }) {
+    return spy.mock.calls.map(
+      (call: unknown[]) =>
+        JSON.parse(String(call[0])) as Record<string, unknown> & {
+          event: string;
+        },
+    );
+  }
+
+  it("persists matched emails and logs a summary without the body or code", async () => {
+    const { message, setReject } = createMessage();
+
+    await handleIncomingEmail(message, createAppContext());
 
     expect(messageRepoState.insertMessage).toHaveBeenCalledWith(
       expect.anything(),
       parseState.result,
       "household-1",
       "provider-1",
-      classifyState.result,
+      matched,
     );
-    expect(messageRepoState.insertQuarantineMessage).not.toHaveBeenCalled();
+    expect(setReject).not.toHaveBeenCalled();
+    const stored = events(logSpy).find((e) => e.event === "email_stored");
+    expect(stored).toMatchObject({ providerKey: "netflix", codeFound: true });
+    expect(JSON.stringify(stored)).not.toContain("123456");
   });
 
-  it("routes unmatched senders into quarantine within the resolved household", async () => {
+  it("quarantines unmatched senders within the resolved household", async () => {
     classifyState.result = {
       kind: "quarantine",
+      householdId: "household-1",
       reason:
         "No sender rule matched the inbound email within the addressed household.",
       code: "654321",
     };
-    parseState.result = {
-      ...parseState.result,
-      envelopeFrom: "unknown@example.net",
-      fromHeader: "Unknown <unknown@example.net>",
-      textBody: "Use 654321 to continue.",
-    };
+    const { message, setReject } = createMessage();
 
-    await handleIncomingEmail(createMessage(), createAppContext());
+    await handleIncomingEmail(message, createAppContext());
 
-    expect(householdRepoState.getHouseholdBySlug).toHaveBeenCalledWith(
-      expect.anything(),
-      "codes",
-    );
     expect(messageRepoState.insertQuarantineMessage).toHaveBeenCalledWith(
       expect.anything(),
       parseState.result,
       "household-1",
       classifyState.result,
     );
+    expect(setReject).not.toHaveBeenCalled();
+    expect(events(logSpy).some((e) => e.event === "email_quarantined")).toBe(
+      true,
+    );
+  });
+
+  it("rejects mail for unknown recipients with a reason instead of dropping it silently", async () => {
+    classifyState.result = {
+      kind: "quarantine",
+      householdId: null,
+      reason: "No household matched the inbound recipient address.",
+      code: null,
+    };
+    const { message, setReject } = createMessage();
+
+    await handleIncomingEmail(message, createAppContext());
+
+    expect(setReject).toHaveBeenCalledWith("Unknown recipient");
+    expect(messageRepoState.insertQuarantineMessage).not.toHaveBeenCalled();
+    expect(events(logSpy)).toContainEqual(
+      expect.objectContaining({
+        event: "email_rejected",
+        reason: "unknown_recipient",
+      }),
+    );
+  });
+
+  it("rejects oversized messages before parsing", async () => {
+    const { message, setReject } = createMessage({
+      rawSize: MAX_RAW_MESSAGE_BYTES + 1,
+    });
+
+    await handleIncomingEmail(message, createAppContext());
+
+    expect(setReject).toHaveBeenCalledWith("Message too large");
     expect(messageRepoState.insertMessage).not.toHaveBeenCalled();
   });
 
-  it("drops quarantined emails when no household can be resolved", async () => {
+  it("refuses new quarantine rows once a household's quarantine is full", async () => {
     classifyState.result = {
       kind: "quarantine",
-      reason: "No household matched the inbound recipient address.",
-      code: "654321",
+      householdId: "household-1",
+      reason: "no rule",
+      code: null,
     };
-    householdRepoState.getHouseholdBySlug.mockResolvedValue(null);
+    messageRepoState.countUnreviewedQuarantine.mockResolvedValue(
+      MAX_UNREVIEWED_QUARANTINE,
+    );
+    const { message, setReject } = createMessage();
 
-    await handleIncomingEmail(createMessage(), createAppContext());
+    await handleIncomingEmail(message, createAppContext());
 
+    expect(setReject).toHaveBeenCalledWith("Mailbox quarantine is full");
     expect(messageRepoState.insertQuarantineMessage).not.toHaveBeenCalled();
-    expect(messageRepoState.insertMessage).not.toHaveBeenCalled();
+  });
+
+  it("rejects unparseable messages permanently", async () => {
+    parseState.error = new Error("boom");
+    const { message, setReject } = createMessage();
+
+    await handleIncomingEmail(message, createAppContext());
+
+    expect(setReject).toHaveBeenCalledWith("Message could not be parsed");
+    expect(events(errorSpy)).toContainEqual(
+      expect.objectContaining({ event: "email_parse_failed" }),
+    );
+  });
+
+  it("logs and re-throws unexpected storage failures so the sender retries", async () => {
+    messageRepoState.insertMessage.mockRejectedValue(
+      new Error("D1 unavailable"),
+    );
+    const { message, setReject } = createMessage();
+
+    await expect(
+      handleIncomingEmail(message, createAppContext()),
+    ).rejects.toThrow("D1 unavailable");
+    expect(setReject).not.toHaveBeenCalled();
+    expect(events(errorSpy)).toContainEqual(
+      expect.objectContaining({
+        event: "email_ingest_failed",
+        messageId: "<message-1@test>",
+        error: "D1 unavailable",
+      }),
+    );
   });
 });

--- a/test/integration/email-pipeline.test.ts
+++ b/test/integration/email-pipeline.test.ts
@@ -1,0 +1,122 @@
+import { createExecutionContext, env } from "cloudflare:test";
+import { listMessagesForProvider } from "@server/db/repositories/messages";
+import {
+  createProvider,
+  createSenderRule,
+} from "@server/db/repositories/provider-rules";
+import { describe, expect, it, vi } from "vitest";
+import worker from "../../src/index";
+
+import { count, db, insertHousehold } from "./helpers";
+
+function rawEmail(input: {
+  from: string;
+  to: string;
+  subject: string;
+  body: string;
+  messageId?: string;
+}) {
+  return [
+    `From: Service <${input.from}>`,
+    `To: ${input.to}`,
+    `Subject: ${input.subject}`,
+    ...(input.messageId ? [`Message-ID: ${input.messageId}`] : []),
+    "Date: Sun, 10 May 2026 12:00:00 +0000",
+    "Content-Type: text/plain; charset=utf-8",
+    "",
+    input.body,
+  ].join("\r\n");
+}
+
+function emailMessage(input: Parameters<typeof rawEmail>[0]) {
+  const raw = rawEmail(input);
+  const setReject = vi.fn();
+  const message = {
+    from: input.from,
+    to: input.to,
+    raw: new Response(raw).body as ReadableStream<Uint8Array>,
+    rawSize: raw.length,
+    headers: new Headers(),
+    setReject,
+    forward: async () => ({ messageId: "fwd" }),
+    reply: async () => ({ messageId: "rpl" }),
+  } as unknown as ForwardableEmailMessage;
+  return { message, setReject };
+}
+
+async function deliver(input: Parameters<typeof rawEmail>[0]) {
+  const { message, setReject } = emailMessage(input);
+  await worker.email?.(
+    message,
+    env as unknown as Env,
+    createExecutionContext(),
+  );
+  return { setReject };
+}
+
+describe("inbound email pipeline (worker.email against D1)", () => {
+  it("stores a matched message with its code, and de-duplicates redelivery", async () => {
+    const household = await insertHousehold({ slug: "casa" });
+    const provider = await createProvider(
+      db,
+      household.id,
+      "netflix",
+      "Netflix",
+    );
+    await createSenderRule(
+      db,
+      household.id,
+      provider.id,
+      "domain",
+      "netflix.com",
+    );
+
+    const mail = {
+      from: "info@netflix.com",
+      to: "casa@example.com",
+      subject: "Your verification code",
+      body: "Your verification code is 482913",
+      messageId: "<abc@netflix.com>",
+    };
+    const first = await deliver(mail);
+    const second = await deliver(mail);
+
+    expect(first.setReject).not.toHaveBeenCalled();
+    expect(second.setReject).not.toHaveBeenCalled();
+    const rows = await listMessagesForProvider(db, household.id, "netflix");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      extracted_code: "482913",
+      provider_key: "netflix",
+    });
+  });
+
+  it("quarantines unmatched senders for a known household", async () => {
+    const household = await insertHousehold({ slug: "casa" });
+
+    const { setReject } = await deliver({
+      from: "someone@unknown.example",
+      to: "casa@example.com",
+      subject: "Hello",
+      body: "No rule for me",
+    });
+
+    expect(setReject).not.toHaveBeenCalled();
+    expect(
+      await count("quarantine_messages", "household_id = ?1", household.id),
+    ).toBe(1);
+  });
+
+  it("rejects mail addressed to an unknown household instead of dropping it silently", async () => {
+    const { setReject } = await deliver({
+      from: "info@netflix.com",
+      to: "nobody@example.com",
+      subject: "Code",
+      body: "123456",
+    });
+
+    expect(setReject).toHaveBeenCalledWith("Unknown recipient");
+    expect(await count("quarantine_messages")).toBe(0);
+    expect(await count("messages")).toBe(0);
+  });
+});

--- a/test/integration/messages-repository.test.ts
+++ b/test/integration/messages-repository.test.ts
@@ -116,14 +116,24 @@ describe("messages repository (D1)", () => {
       db,
       parsedEmail({ messageId: "<q-1@test>" }),
       household.id,
-      { kind: "quarantine", reason: "no rule", code: null },
+      {
+        kind: "quarantine",
+        householdId: household.id,
+        reason: "no rule",
+        code: null,
+      },
       new Date("2020-01-01T00:00:00Z"),
     );
     await insertQuarantineMessage(
       db,
       parsedEmail({ messageId: "<q-2@test>" }),
       household.id,
-      { kind: "quarantine", reason: "no rule", code: null },
+      {
+        kind: "quarantine",
+        householdId: household.id,
+        reason: "no rule",
+        code: null,
+      },
     );
 
     expect(await listQuarantineMessages(db, household.id)).toHaveLength(2);

--- a/test/messages-repository.test.ts
+++ b/test/messages-repository.test.ts
@@ -93,6 +93,7 @@ describe("messages repository inserts", () => {
         "household-1",
         {
           kind: "quarantine",
+          householdId: "household-1",
           reason: "No sender rule matched the inbound email.",
           code: "123456",
         },

--- a/test/parse-email.test.ts
+++ b/test/parse-email.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { parseIncomingEmail } from "../src/server/email/parse";
+import {
+  MAX_TEXT_BODY_CHARS,
+  parseIncomingEmail,
+} from "../src/server/email/parse";
 
 function createMessage(
   raw: string,
@@ -60,5 +63,51 @@ describe("parseIncomingEmail", () => {
     );
 
     expect(parsed.textBody).toBe("[empty email body]");
+  });
+
+  it("truncates very large bodies and flags it", async () => {
+    const body = `Your verification code is 123456 ${"x".repeat(MAX_TEXT_BODY_CHARS + 500)}`;
+    const parsed = await parseIncomingEmail(
+      createMessage(
+        [
+          "From: Service <login@service.example>",
+          "To: casa@example.com",
+          "Subject: Big",
+          "",
+          body,
+        ].join("\n"),
+      ),
+    );
+
+    expect(parsed.textBodyTruncated).toBe(true);
+    expect(parsed.textBody.length).toBeLessThanOrEqual(
+      MAX_TEXT_BODY_CHARS + 20,
+    );
+    expect(parsed.textBody.endsWith("[truncated]")).toBe(true);
+    expect(parsed.textBody).toContain("123456");
+  });
+
+  it("derives a stable synthetic Message-ID when the header is missing", async () => {
+    const raw = [
+      "From: Service <login@service.example>",
+      "To: casa@example.com",
+      "Subject: No id",
+      "Date: Sun, 10 May 2026 12:00:00 +0000",
+      "",
+      "Your code is 424242",
+    ].join("\n");
+
+    const first = await parseIncomingEmail(createMessage(raw));
+    const again = await parseIncomingEmail(createMessage(raw));
+    const different = await parseIncomingEmail(
+      createMessage(raw.replace("424242", "999999")),
+    );
+
+    expect(first.messageId).toMatch(
+      /^<synthetic-[0-9a-f]{32}@mi-casa-su-casa>$/,
+    );
+    expect(again.messageId).toBe(first.messageId);
+    expect(different.messageId).not.toBe(first.messageId);
+    expect(first.textBodyTruncated).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Closes #90.

- **No more silent drops**: mail for an unknown household is rejected with `setReject("Unknown recipient")` + a structured `email_rejected` log; messages over **2 MB** and unparseable messages are rejected permanently with a reason; a household with **200+** unreviewed quarantine rows refuses new unmatched mail (`Mailbox quarantine is full`).
- **Unexpected failures** (D1 down, constraint errors) are logged as `email_ingest_failed` with `from/to/messageId/rawSize/error` and **re-thrown** so Cloudflare answers with a temporary error and the sender retries, instead of losing the OTP.
- `parse.ts`: bodies cut at **64 KB** (`textBodyTruncated`, keeps the code-bearing head); a deterministic **synthetic `Message-ID`** (hash of from/to/date/subject/body) when the header is missing so redelivery still de-duplicates.
- `classifyEmail` returns `householdId` for quarantine results → one household lookup instead of two.
- Structured `email_stored` / `email_quarantined` summaries — never the body or the code.

## Tests

- `test/email-handler.test.ts` (rewritten, 7 cases): stored + summary log without the code; quarantined; unknown recipient → `setReject`; oversize → reject before parse; quarantine full → reject; parse failure → reject; storage failure → log + rethrow, no reject.
- `test/parse-email.test.ts`: truncation flag/marker; stable synthetic Message-ID.
- `test/classify-email.test.ts`: rewritten with module mocks (no order-dependent DB stub); covers `householdId` in all quarantine outcomes.
- **`test/integration/email-pipeline.test.ts`** (real D1, `worker.email()`): matched mail stored with its code and de-duplicated on redelivery; unmatched sender quarantined; unknown household rejected with no rows written.

`npm run ci` green: 155 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)