### PR TITLE
fix: authenticate senders and match rules against the From header with subdomain support

### DIFF
--- a/src/client/components/ProvidersRulesView.tsx
+++ b/src/client/components/ProvidersRulesView.tsx
@@ -814,8 +814,8 @@ export function ProvidersRulesView({
                   size="small"
                   helperText={
                     ruleFormState.matchType === "domain"
-                      ? "Example: netflix.com"
-                      : "Example: login@netflix.com"
+                      ? "Example: netflix.com — also matches subdomains such as em.netflix.com. Checked against the visible From address and the envelope sender."
+                      : "Example: login@netflix.com — checked against the visible From address and the envelope sender."
                   }
                   value={ruleFormState.matchValue}
                   onChange={(event) =>

--- a/src/client/components/QuarantineView.tsx
+++ b/src/client/components/QuarantineView.tsx
@@ -217,7 +217,7 @@ export function QuarantineView({
                                 whiteSpace: "nowrap",
                               }}
                             >
-                              {message.envelope_from}
+                              {message.from_header ?? message.envelope_from}
                             </Typography>
                             <Typography
                               variant="caption"
@@ -289,8 +289,16 @@ export function QuarantineView({
                   {selectedQuarantineMessage.subject ?? "Untitled message"}
                 </Typography>
                 <Typography variant="body1" color="text.secondary">
-                  {selectedQuarantineMessage.envelope_from}
+                  {selectedQuarantineMessage.from_header ??
+                    selectedQuarantineMessage.envelope_from}
                 </Typography>
+                {selectedQuarantineMessage.from_header &&
+                selectedQuarantineMessage.from_header !==
+                  selectedQuarantineMessage.envelope_from ? (
+                  <Typography variant="caption" color="text.disabled">
+                    Envelope sender: {selectedQuarantineMessage.envelope_from}
+                  </Typography>
+                ) : null}
               </Box>
               <Chip
                 icon={<WarningAmberOutlined />}

--- a/src/server/db/repositories/provider-rules.ts
+++ b/src/server/db/repositories/provider-rules.ts
@@ -14,50 +14,101 @@ export type SenderRuleMatch = {
   providerKey: string;
 };
 
+export type SenderCandidate = {
+  address: string;
+  /** Where the address came from; reported back so policy can be applied. */
+  source: "header" | "envelope";
+};
+
+export type SenderRuleMatchWithSource = SenderRuleMatch & {
+  matchedAddress: string;
+  matchedSource: SenderCandidate["source"];
+  matchType: "exact" | "domain";
+};
+
+function senderMatchColumns() {
+  return sql`
+    SELECT providers.id AS providerId,
+           providers.provider_key AS providerKey,
+           providers.household_id AS householdId,
+           households.slug AS householdSlug
+    FROM sender_rules
+    INNER JOIN providers ON providers.id = sender_rules.provider_id
+    INNER JOIN households ON households.id = providers.household_id`;
+}
+
+/**
+ * Finds the provider whose sender rule matches one of the candidate sender
+ * addresses. Exact-address rules win over domain rules; within each type the
+ * candidates are tried in the given order. Domain rules match the domain
+ * itself and any subdomain (`netflix.com` matches `em.netflix.com`).
+ */
 export async function findProviderMatch(
   db: D1Database,
   householdId: string,
-  fromAddress: string,
-): Promise<SenderRuleMatch | null> {
+  candidates: SenderCandidate[] | string,
+): Promise<SenderRuleMatchWithSource | null> {
   const database = dbForDatabase(db);
-  const exact = await database.get<SenderRuleMatch>(sql`
-    SELECT providers.id AS providerId,
-           providers.provider_key AS providerKey,
-           providers.household_id AS householdId,
-           households.slug AS householdSlug
-    FROM sender_rules
-    INNER JOIN providers ON providers.id = sender_rules.provider_id
-    INNER JOIN households ON households.id = providers.household_id
-    WHERE sender_rules.household_id = ${householdId}
-      AND sender_rules.match_type = 'exact'
-      AND lower(sender_rules.match_value) = lower(${fromAddress})
-    LIMIT 1
-  `);
+  const list: SenderCandidate[] =
+    typeof candidates === "string"
+      ? [{ address: candidates, source: "envelope" }]
+      : candidates;
+  const seen = new Set<string>();
+  const normalized = list
+    .map((candidate) => ({
+      ...candidate,
+      address: candidate.address.trim().toLowerCase(),
+    }))
+    .filter((candidate) => {
+      if (!candidate.address || seen.has(candidate.address)) return false;
+      seen.add(candidate.address);
+      return true;
+    });
 
-  if (exact) {
-    return exact;
+  for (const candidate of normalized) {
+    const exact = await database.get<SenderRuleMatch>(sql`
+      ${senderMatchColumns()}
+      WHERE sender_rules.household_id = ${householdId}
+        AND sender_rules.match_type = 'exact'
+        AND lower(sender_rules.match_value) = ${candidate.address}
+      LIMIT 1
+    `);
+    if (exact) {
+      return {
+        ...exact,
+        matchedAddress: candidate.address,
+        matchedSource: candidate.source,
+        matchType: "exact",
+      };
+    }
   }
 
-  const domain = fromAddress.split("@")[1]?.toLowerCase();
-  if (!domain) {
-    return null;
+  for (const candidate of normalized) {
+    const domain = candidate.address.split("@")[1];
+    if (!domain) continue;
+
+    const byDomain = await database.get<SenderRuleMatch>(sql`
+      ${senderMatchColumns()}
+      WHERE sender_rules.household_id = ${householdId}
+        AND sender_rules.match_type = 'domain'
+        AND (
+          lower(sender_rules.match_value) = ${domain}
+          OR ${domain} LIKE '%.' || lower(sender_rules.match_value)
+        )
+      ORDER BY length(sender_rules.match_value) DESC
+      LIMIT 1
+    `);
+    if (byDomain) {
+      return {
+        ...byDomain,
+        matchedAddress: candidate.address,
+        matchedSource: candidate.source,
+        matchType: "domain",
+      };
+    }
   }
 
-  const byDomain = await database.get<SenderRuleMatch>(sql`
-    SELECT providers.id AS providerId,
-           providers.provider_key AS providerKey,
-           providers.household_id AS householdId,
-           households.slug AS householdSlug
-    FROM sender_rules
-    INNER JOIN providers ON providers.id = sender_rules.provider_id
-    INNER JOIN households ON households.id = providers.household_id
-    WHERE sender_rules.household_id = ${householdId}
-      AND sender_rules.match_type = 'domain'
-      AND lower(sender_rules.match_value) = lower(${domain})
-    LIMIT 1
-  `);
-
-  return byDomain ?? null;
+  return null;
 }
 
 export async function userHasProviderAccess(

--- a/src/server/db/types.ts
+++ b/src/server/db/types.ts
@@ -16,11 +16,21 @@ export type ClassificationResult =
       code: string | null;
     };
 
+export type SenderAuthentication = {
+  spf: string | null;
+  dkim: string | null;
+  dmarc: string | null;
+};
+
 export type ParsedIncomingEmail = {
   envelopeFrom: string;
   envelopeTo: string;
   householdSlug: string | null;
   fromHeader: string | null;
+  /** Lower-cased address from the RFC 5322 From: header, if parseable. */
+  fromAddress?: string | null;
+  /** Results from the Authentication-Results header(s), if present. */
+  authentication?: SenderAuthentication | null;
   subject: string | null;
   messageId: string | null;
   dateHeader: string | null;

--- a/src/server/domain/classify-email.ts
+++ b/src/server/domain/classify-email.ts
@@ -1,7 +1,64 @@
 import { getHouseholdBySlug } from "../db/repositories/households";
-import { findProviderMatch } from "../db/repositories/provider-rules";
-import type { ClassificationResult, ParsedIncomingEmail } from "../db/types";
+import {
+  findProviderMatch,
+  type SenderCandidate,
+} from "../db/repositories/provider-rules";
+import type {
+  ClassificationResult,
+  ParsedIncomingEmail,
+  SenderAuthentication,
+} from "../db/types";
 import { extractVerificationCode } from "./extract-code";
+
+function senderCandidates(parsed: ParsedIncomingEmail): SenderCandidate[] {
+  const candidates: SenderCandidate[] = [];
+  if (parsed.fromAddress) {
+    candidates.push({ address: parsed.fromAddress, source: "header" });
+  }
+  candidates.push({ address: parsed.envelopeFrom, source: "envelope" });
+  return candidates;
+}
+
+/**
+ * Decides whether a rule match may be trusted given the upstream
+ * authentication results. Without an Authentication-Results header (local
+ * development, tests) everything is allowed.
+ *
+ * - dmarc=fail: never trusted (the From: domain failed its own policy).
+ * - A match on the From: header address needs DKIM or DMARC to pass; the
+ *   header is otherwise trivially forgeable.
+ * - A match on the envelope (MAIL FROM) address needs SPF to pass.
+ */
+export function authenticationVerdict(
+  auth: SenderAuthentication | null | undefined,
+  source: SenderCandidate["source"],
+): { trusted: true } | { trusted: false; reason: string } {
+  if (!auth) {
+    return { trusted: true };
+  }
+
+  if (auth.dmarc === "fail") {
+    return { trusted: false, reason: "dmarc=fail" };
+  }
+
+  if (source === "header") {
+    if (auth.dkim === "pass" || auth.dmarc === "pass") {
+      return { trusted: true };
+    }
+    return {
+      trusted: false,
+      reason: `From header not authenticated (dkim=${auth.dkim ?? "none"}, dmarc=${auth.dmarc ?? "none"})`,
+    };
+  }
+
+  if (auth.spf === "pass") {
+    return { trusted: true };
+  }
+  return {
+    trusted: false,
+    reason: `envelope sender not authenticated (spf=${auth.spf ?? "none"})`,
+  };
+}
 
 export async function classifyEmail(
   db: D1Database,
@@ -32,7 +89,7 @@ export async function classifyEmail(
   const providerMatch = await findProviderMatch(
     db,
     household.id,
-    parsed.envelopeFrom,
+    senderCandidates(parsed),
   );
 
   if (!providerMatch) {
@@ -41,6 +98,20 @@ export async function classifyEmail(
       householdId: household.id,
       reason:
         "No sender rule matched the inbound email within the addressed household.",
+      code,
+    };
+  }
+
+  const verdict = authenticationVerdict(
+    parsed.authentication,
+    providerMatch.matchedSource,
+  );
+
+  if (!verdict.trusted) {
+    return {
+      kind: "quarantine",
+      householdId: household.id,
+      reason: `Sender ${providerMatch.matchedAddress} matched provider ${providerMatch.providerKey} but sender authentication failed: ${verdict.reason}.`,
       code,
     };
   }

--- a/src/server/email/parse.ts
+++ b/src/server/email/parse.ts
@@ -1,6 +1,6 @@
 import PostalMime from "postal-mime";
 
-import type { ParsedIncomingEmail } from "../db/types";
+import type { ParsedIncomingEmail, SenderAuthentication } from "../db/types";
 
 /** Bodies beyond this are cut; verification codes live in the first few KB. */
 export const MAX_TEXT_BODY_CHARS = 64 * 1024;
@@ -49,6 +49,32 @@ function extractHouseholdSlug(address: string): string | null {
   return /^[a-z0-9-]+$/.test(localPart) ? localPart : null;
 }
 
+/**
+ * Reads spf= / dkim= / dmarc= results from Authentication-Results headers
+ * (Cloudflare Email Routing adds one). Returns null when none is present.
+ */
+export function parseAuthenticationResults(
+  values: string[],
+): SenderAuthentication | null {
+  if (values.length === 0) {
+    return null;
+  }
+
+  const result: SenderAuthentication = { spf: null, dkim: null, dmarc: null };
+
+  for (const value of values) {
+    for (const match of value.matchAll(/\b(spf|dkim|dmarc)=([a-z]+)/gi)) {
+      const mechanism = match[1]?.toLowerCase() as keyof SenderAuthentication;
+      const verdict = match[2]?.toLowerCase() ?? null;
+      if (mechanism && result[mechanism] === null) {
+        result[mechanism] = verdict;
+      }
+    }
+  }
+
+  return result;
+}
+
 function stripHtml(html: string): string {
   return html
     .replace(/<[^>]+>/g, " ")
@@ -75,6 +101,14 @@ export async function parseIncomingEmail(
   const header = (name: string) =>
     parsed.headers.find((entry) => entry.key.toLowerCase() === name)?.value ??
     null;
+  const headersNamed = (name: string) =>
+    parsed.headers
+      .filter((entry) => entry.key.toLowerCase() === name)
+      .map((entry) => entry.value);
+  const fromAddress = parsed.from?.address?.trim().toLowerCase() || null;
+  const authentication = parseAuthenticationResults(
+    headersNamed("authentication-results"),
+  );
   const subject = parsed.subject ?? null;
   const dateHeader = header("date");
   const messageId =
@@ -92,6 +126,8 @@ export async function parseIncomingEmail(
     envelopeTo: message.to,
     householdSlug: extractHouseholdSlug(message.to),
     fromHeader: header("from"),
+    fromAddress,
+    authentication,
     subject,
     messageId,
     dateHeader,

--- a/test/classify-email.test.ts
+++ b/test/classify-email.test.ts
@@ -9,6 +9,9 @@ const repoState = vi.hoisted(() => ({
     householdSlug: string;
     providerId: string;
     providerKey: string;
+    matchedAddress: string;
+    matchedSource: "header" | "envelope";
+    matchType: "exact" | "domain";
   } | null,
 }));
 
@@ -20,7 +23,9 @@ vi.mock("../src/server/db/repositories/provider-rules", () => ({
   findProviderMatch: vi.fn(async () => repoState.match),
 }));
 
-const { classifyEmail } = await import("../src/server/domain/classify-email");
+const { classifyEmail, authenticationVerdict } = await import(
+  "../src/server/domain/classify-email"
+);
 
 function createParsedEmail(
   overrides?: Partial<ParsedIncomingEmail>,
@@ -57,6 +62,9 @@ describe("classifyEmail", () => {
       householdSlug: "casa",
       providerId: "provider-1",
       providerKey: "netflix",
+      matchedAddress: "login@service.example",
+      matchedSource: "envelope",
+      matchType: "domain",
     };
 
     await expect(classifyEmail(db, createParsedEmail())).resolves.toEqual({
@@ -96,5 +104,77 @@ describe("classifyEmail", () => {
     await expect(
       classifyEmail(db, createParsedEmail({ householdSlug: null })),
     ).resolves.toMatchObject({ kind: "quarantine", householdId: null });
+  });
+
+  it("quarantines a rule match whose sender failed authentication", async () => {
+    repoState.match = {
+      householdId: "household-1",
+      householdSlug: "casa",
+      providerId: "provider-1",
+      providerKey: "netflix",
+      matchedAddress: "codes@netflix.com",
+      matchedSource: "envelope",
+      matchType: "domain",
+    };
+
+    await expect(
+      classifyEmail(
+        db,
+        createParsedEmail({
+          envelopeFrom: "codes@netflix.com",
+          fromAddress: "attacker@attacker.example",
+          authentication: { spf: "fail", dkim: "pass", dmarc: "pass" },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      kind: "quarantine",
+      householdId: "household-1",
+      reason: expect.stringMatching(/authentication failed.*spf=fail/),
+    });
+  });
+});
+
+describe("authenticationVerdict", () => {
+  it("trusts everything when no Authentication-Results header is present", () => {
+    expect(authenticationVerdict(null, "header")).toEqual({ trusted: true });
+    expect(authenticationVerdict(undefined, "envelope")).toEqual({
+      trusted: true,
+    });
+  });
+
+  it("never trusts dmarc=fail", () => {
+    expect(
+      authenticationVerdict(
+        { spf: "pass", dkim: "pass", dmarc: "fail" },
+        "envelope",
+      ),
+    ).toMatchObject({ trusted: false, reason: "dmarc=fail" });
+  });
+
+  it("requires DKIM or DMARC for header-From matches and SPF for envelope matches", () => {
+    expect(
+      authenticationVerdict(
+        { spf: "fail", dkim: "pass", dmarc: "none" },
+        "header",
+      ),
+    ).toEqual({ trusted: true });
+    expect(
+      authenticationVerdict(
+        { spf: "pass", dkim: "none", dmarc: "none" },
+        "header",
+      ),
+    ).toMatchObject({ trusted: false });
+    expect(
+      authenticationVerdict(
+        { spf: "pass", dkim: "none", dmarc: "none" },
+        "envelope",
+      ),
+    ).toEqual({ trusted: true });
+    expect(
+      authenticationVerdict(
+        { spf: "softfail", dkim: "pass", dmarc: "none" },
+        "envelope",
+      ),
+    ).toMatchObject({ trusted: false });
   });
 });

--- a/test/integration/email-pipeline.test.ts
+++ b/test/integration/email-pipeline.test.ts
@@ -15,9 +15,14 @@ function rawEmail(input: {
   subject: string;
   body: string;
   messageId?: string;
+  headerFrom?: string;
+  authenticationResults?: string;
 }) {
   return [
-    `From: Service <${input.from}>`,
+    `From: Service <${input.headerFrom ?? input.from}>`,
+    ...(input.authenticationResults
+      ? [`Authentication-Results: ${input.authenticationResults}`]
+      : []),
     `To: ${input.to}`,
     `Subject: ${input.subject}`,
     ...(input.messageId ? [`Message-ID: ${input.messageId}`] : []),
@@ -118,5 +123,74 @@ describe("inbound email pipeline (worker.email against D1)", () => {
     expect(setReject).toHaveBeenCalledWith("Unknown recipient");
     expect(await count("quarantine_messages")).toBe(0);
     expect(await count("messages")).toBe(0);
+  });
+
+  it("files mail by the visible From address when the envelope sender is a bounce address", async () => {
+    const household = await insertHousehold({ slug: "casa" });
+    const provider = await createProvider(
+      db,
+      household.id,
+      "netflix",
+      "Netflix",
+    );
+    await createSenderRule(
+      db,
+      household.id,
+      provider.id,
+      "domain",
+      "netflix.com",
+    );
+
+    const { setReject } = await deliver({
+      from: "bounce+abc@amazonses.com",
+      headerFrom: "info@account.netflix.com",
+      to: "casa@example.com",
+      subject: "Code",
+      body: "Your verification code is 555444",
+      authenticationResults:
+        "mx.cloudflare.net; spf=pass smtp.mailfrom=amazonses.com; dkim=pass header.d=netflix.com; dmarc=pass header.from=netflix.com",
+    });
+
+    expect(setReject).not.toHaveBeenCalled();
+    expect(
+      (await listMessagesForProvider(db, household.id, "netflix"))[0],
+    ).toMatchObject({
+      extracted_code: "555444",
+    });
+  });
+
+  it("quarantines a spoofed envelope sender that fails SPF even though a rule matches", async () => {
+    const household = await insertHousehold({ slug: "casa" });
+    const provider = await createProvider(
+      db,
+      household.id,
+      "netflix",
+      "Netflix",
+    );
+    await createSenderRule(
+      db,
+      household.id,
+      provider.id,
+      "domain",
+      "netflix.com",
+    );
+
+    await deliver({
+      from: "codes@netflix.com",
+      headerFrom: "attacker@attacker.example",
+      to: "casa@example.com",
+      subject: "Your Netflix code",
+      body: "Your verification code is 000000",
+      authenticationResults:
+        "mx.cloudflare.net; spf=fail smtp.mailfrom=netflix.com; dkim=pass header.d=attacker.example; dmarc=pass header.from=attacker.example",
+    });
+
+    expect(
+      await listMessagesForProvider(db, household.id, "netflix"),
+    ).toHaveLength(0);
+    const quarantined = await db
+      .prepare("SELECT quarantine_reason FROM quarantine_messages")
+      .first<{ quarantine_reason: string }>();
+    expect(quarantined?.quarantine_reason).toMatch(/authentication failed/);
   });
 });

--- a/test/integration/provider-rules.test.ts
+++ b/test/integration/provider-rules.test.ts
@@ -88,4 +88,75 @@ describe("provider rule matching (D1)", () => {
       String((error as Error & { cause?: unknown }).cause ?? error),
     ).toMatch(/UNIQUE constraint failed/);
   });
+
+  it("matches subdomains of a domain rule and prefers the most specific domain rule", async () => {
+    const household = await insertHousehold({ slug: "casa" });
+    const netflix = await createProvider(
+      db,
+      household.id,
+      "netflix",
+      "Netflix",
+    );
+    const ses = await createProvider(db, household.id, "ses", "SES");
+    await createSenderRule(
+      db,
+      household.id,
+      netflix.id,
+      "domain",
+      "netflix.com",
+    );
+    await createSenderRule(
+      db,
+      household.id,
+      ses.id,
+      "domain",
+      "em.netflix.com",
+    );
+
+    expect(
+      (await findProviderMatch(db, household.id, "bounces@mail.netflix.com"))
+        ?.providerKey,
+    ).toBe("netflix");
+    expect(
+      (await findProviderMatch(db, household.id, "x@em.netflix.com"))
+        ?.providerKey,
+    ).toBe("ses");
+    expect(
+      await findProviderMatch(db, household.id, "x@notnetflix.com"),
+    ).toBeNull();
+  });
+
+  it("tries the visible From address before the envelope sender and reports the source", async () => {
+    const household = await insertHousehold({ slug: "casa" });
+    const netflix = await createProvider(
+      db,
+      household.id,
+      "netflix",
+      "Netflix",
+    );
+    await createSenderRule(
+      db,
+      household.id,
+      netflix.id,
+      "domain",
+      "netflix.com",
+    );
+
+    const match = await findProviderMatch(db, household.id, [
+      { address: "info@netflix.com", source: "header" },
+      { address: "bounce+123@amazonses.com", source: "envelope" },
+    ]);
+    expect(match).toMatchObject({
+      providerKey: "netflix",
+      matchedAddress: "info@netflix.com",
+      matchedSource: "header",
+      matchType: "domain",
+    });
+
+    const envelopeOnly = await findProviderMatch(db, household.id, [
+      { address: "someone@else.example", source: "header" },
+      { address: "codes@netflix.com", source: "envelope" },
+    ]);
+    expect(envelopeOnly).toMatchObject({ matchedSource: "envelope" });
+  });
 });

--- a/test/parse-email.test.ts
+++ b/test/parse-email.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   MAX_TEXT_BODY_CHARS,
+  parseAuthenticationResults,
   parseIncomingEmail,
 } from "../src/server/email/parse";
 
@@ -109,5 +110,39 @@ describe("parseIncomingEmail", () => {
     expect(again.messageId).toBe(first.messageId);
     expect(different.messageId).not.toBe(first.messageId);
     expect(first.textBodyTruncated).toBe(false);
+  });
+
+  it("exposes the From address and Authentication-Results verdicts", async () => {
+    const parsed = await parseIncomingEmail(
+      createMessage(
+        [
+          "From: Netflix <Info@Account.Netflix.com>",
+          "To: casa@example.com",
+          "Subject: Code",
+          "Authentication-Results: mx.cloudflare.net; dkim=pass header.d=netflix.com; spf=fail smtp.mailfrom=bounce.example; dmarc=pass header.from=netflix.com",
+          "",
+          "Your code is 123456",
+        ].join("\n"),
+      ),
+    );
+
+    expect(parsed.fromAddress).toBe("info@account.netflix.com");
+    expect(parsed.authentication).toEqual({
+      spf: "fail",
+      dkim: "pass",
+      dmarc: "pass",
+    });
+  });
+});
+
+describe("parseAuthenticationResults", () => {
+  it("returns null without a header and reads the first verdict per mechanism", () => {
+    expect(parseAuthenticationResults([])).toBeNull();
+    expect(
+      parseAuthenticationResults([
+        "mx.cloudflare.net; spf=pass smtp.mailfrom=x; dkim=none",
+        "other; dkim=pass; dmarc=fail",
+      ]),
+    ).toEqual({ spf: "pass", dkim: "none", dmarc: "fail" });
   });
 });


### PR DESCRIPTION
## Summary

Closes #91.

Sender rules matched only the spoofable SMTP envelope sender, ignored the `Authentication-Results` header Cloudflare adds, and required exact domain equality (`netflix.com` never matched `em.netflix.com`). Spoofed mail could be filed under a trusted provider with an extracted "code", while legitimate senders using bounce addresses landed in quarantine.

- `parse.ts`: exposes `fromAddress` (RFC 5322 `From:`) and `authentication: {spf, dkim, dmarc}` parsed from `Authentication-Results`.
- `findProviderMatch(db, householdId, candidates)`: tries the visible `From` address then the envelope sender; exact rules before domain rules; **domain rules match the domain or any subdomain** (most specific rule wins); returns which address/source matched.
- `classifyEmail` policy (`authenticationVerdict`): `dmarc=fail` is never trusted; a header-`From` match needs `dkim=pass` or `dmarc=pass`; an envelope match needs `spf=pass`; otherwise quarantine with an explicit *"matched provider X but sender authentication failed: …"* reason. Without an `Authentication-Results` header (dev/test) nothing changes.
- UI: rule helper text explains subdomain + From/envelope matching; quarantine view shows the visible `From` and the envelope sender.

## Tests

- Unit: `parseAuthenticationResults`, `fromAddress` extraction; `authenticationVerdict` matrix; classify quarantines an authenticated-failed rule match.
- D1: subdomain matching + most-specific preference; header-before-envelope candidate order with reported source.
- End-to-end `worker.email()`: bounce-address sender with DKIM/DMARC pass files under Netflix; **spoofed `MAIL FROM: codes@netflix.com` with `spf=fail` is quarantined** with an "authentication failed" reason.

`npm run ci` green: 165 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)