### PR TITLE
fix: make verification-code extraction precise (no words, years, CSS colours or zip codes)

### DIFF
--- a/src/server/domain/extract-code.ts
+++ b/src/server/domain/extract-code.ts
@@ -1,21 +1,124 @@
-const KEYWORD_PATTERNS = [
-  /verification code\s*(?:is|:)?\s*([A-Z0-9-]{4,12})/i,
-  /security code\s*(?:is|:)?\s*([A-Z0-9-]{4,12})/i,
-  /one[- ]time code\s*(?:is|:)?\s*([A-Z0-9-]{4,12})/i,
-  /passcode\s*(?:is|:)?\s*([A-Z0-9-]{4,12})/i,
-  /code\s*(?:is|:)?\s*([0-9]{4,8})/i,
-];
+/**
+ * Extracts a one-time verification code from an email body.
+ *
+ * Strategy:
+ * 1. Look for a code keyword ("verification code", "passcode", "OTP",
+ *    "code", …) and scan a short window after it for the first plausible
+ *    token: digits (optionally grouped with a space or hyphen) or an
+ *    uppercase alphanumeric token that contains at least one digit.
+ * 2. Without a keyword, fall back to a conservative scan: return the code
+ *    only when the body contains exactly one 6-digit token. Anything else
+ *    yields null rather than a confident wrong code.
+ */
 
-const FALLBACK_PATTERN = /\b([0-9]{4,8})\b/;
+const KEYWORD_PATTERN =
+  /\b(?:(?:verification|verify|security|one[- ]?time|login|log-?in|sign[- ]?in|access|confirmation|auth(?:entication|orization)?|2fa|two[- ]factor)\s+(?:code|pin|passcode|password|otp)|passcode|otp|pin\s+code|code|kode|c[oó]digo|codice)\b/gi;
 
-export function extractVerificationCode(text: string): string | null {
-  for (const pattern of KEYWORD_PATTERNS) {
-    const match = text.match(pattern);
-    if (match?.[1]) {
-      return match[1].trim();
-    }
+/** How far after a keyword we look for the token. */
+const WINDOW_CHARS = 80;
+
+const TOKEN_SCAN = /[A-Za-z0-9][A-Za-z0-9 -]*[A-Za-z0-9]|[A-Za-z0-9]/g;
+
+function isYearLike(digits: string) {
+  return /^(19|20)\d{2}$/.test(digits);
+}
+
+function precededByRejectedSymbol(text: string, index: number) {
+  const before = text.slice(Math.max(0, index - 2), index);
+  return /[#$€£+%]$/.test(before) || /&#$/.test(before);
+}
+
+function normalizeDigits(token: string) {
+  return token.replace(/[ -]/g, "");
+}
+
+/** Returns a plausible code at the start of `chunk`, or null. */
+function codeFromChunk(chunk: string): string | null {
+  const grouped = chunk.match(/^(\d{3,4})[ -](\d{3,4})$/);
+  if (grouped) {
+    return `${grouped[1]}${grouped[2]}`;
   }
 
-  const fallback = text.match(FALLBACK_PATTERN);
-  return fallback?.[1] ?? null;
+  if (/^\d+$/.test(chunk)) {
+    if (chunk.length < 4 || chunk.length > 8) return null;
+    if (isYearLike(chunk)) return null;
+    return chunk;
+  }
+
+  if (
+    /^[A-Z0-9]{5,10}$/.test(chunk) &&
+    /\d/.test(chunk) &&
+    /[A-Z]/.test(chunk)
+  ) {
+    return chunk;
+  }
+
+  return null;
+}
+
+function scanWindow(
+  window: string,
+  fullText: string,
+  offset: number,
+): string | null {
+  const re = new RegExp(TOKEN_SCAN.source, "g");
+  let match: RegExpExecArray | null = re.exec(window);
+  while (match) {
+    const start = offset + match.index;
+    if (!precededByRejectedSymbol(fullText, start)) {
+      // A token run can be a sentence fragment ("is valid for 10 minutes");
+      // try each word-ish piece inside it in order.
+      const pieces = match[0].split(
+        /(?<=\d)[ -](?=\D)|(?<=\D)[ -](?=\d)|(?<=\D)[ -](?=\D)/,
+      );
+      for (const piece of pieces) {
+        const trimmed = piece.trim();
+        if (!trimmed) continue;
+        // Re-split grouped digit pairs like "123 456" or "123-456" kept intact.
+        const code = codeFromChunk(trimmed);
+        if (code) return code;
+        // Fallback: split into single tokens.
+        for (const single of trimmed.split(/[ -]/)) {
+          const singleCode = codeFromChunk(single);
+          if (singleCode) return singleCode;
+        }
+      }
+    }
+    match = re.exec(window);
+  }
+  return null;
+}
+
+export function extractVerificationCode(text: string): string | null {
+  const keywordRe = new RegExp(KEYWORD_PATTERN.source, "gi");
+  let keyword: RegExpExecArray | null = keywordRe.exec(text);
+  while (keyword) {
+    const start = keyword.index + keyword[0].length;
+    const window = text.slice(start, start + WINDOW_CHARS);
+    const code = scanWindow(window, text, start);
+    if (code) {
+      return code;
+    }
+    keyword = keywordRe.exec(text);
+  }
+
+  return fallbackCode(text);
+}
+
+/**
+ * Without a keyword we only trust the most common OTP shape — a single,
+ * unambiguous 6-digit token (optionally grouped 3-3). Zip codes, phone
+ * fragments, order numbers and years are deliberately not guessed.
+ */
+function fallbackCode(text: string): string | null {
+  const sixDigit = new Set<string>();
+
+  for (const match of text.matchAll(/\b(\d{3}[ -]\d{3}|\d{6})\b/g)) {
+    if (precededByRejectedSymbol(text, match.index ?? 0)) continue;
+    const digits = normalizeDigits(match[1] ?? "");
+    if (isYearLike(digits)) continue;
+    sixDigit.add(digits);
+  }
+
+  return sixDigit.size === 1 ? ([...sixDigit][0] ?? null) : null;
 }

--- a/src/server/email/parse.ts
+++ b/src/server/email/parse.ts
@@ -75,9 +75,48 @@ export function parseAuthenticationResults(
   return result;
 }
 
-function stripHtml(html: string): string {
-  return html
-    .replace(/<[^>]+>/g, " ")
+const NAMED_ENTITIES: Record<string, string> = {
+  nbsp: " ",
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  "#39": "'",
+};
+
+export function decodeHtmlEntities(value: string): string {
+  return value.replace(
+    /&(#x[0-9a-f]+|#\d+|[a-z]+);/gi,
+    (whole, entity: string) => {
+      const lower = entity.toLowerCase();
+      if (lower.startsWith("#x")) {
+        const codePoint = Number.parseInt(lower.slice(2), 16);
+        return Number.isNaN(codePoint)
+          ? whole
+          : String.fromCodePoint(codePoint);
+      }
+      if (lower.startsWith("#")) {
+        const codePoint = Number.parseInt(lower.slice(1), 10);
+        return Number.isNaN(codePoint)
+          ? whole
+          : String.fromCodePoint(codePoint);
+      }
+      return NAMED_ENTITIES[lower] ?? whole;
+    },
+  );
+}
+
+/**
+ * Turns HTML into plain text good enough for code extraction: style/script
+ * blocks and comments are removed entirely (CSS colours like #123456 must not
+ * look like codes), tags become spaces, entities are decoded.
+ */
+export function stripHtml(html: string): string {
+  const withoutBlocks = html
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/<(style|script|head|title)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, " ");
+  return decodeHtmlEntities(withoutBlocks.replace(/<[^>]+>/g, " "))
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/test/extract-code.test.ts
+++ b/test/extract-code.test.ts
@@ -1,23 +1,52 @@
 import { describe, expect, it } from "vitest";
 
 import { extractVerificationCode } from "../src/server/domain/extract-code";
+import { stripHtml } from "../src/server/email/parse";
 
 describe("extractVerificationCode", () => {
-  it("extracts keyword-based codes", () => {
-    expect(extractVerificationCode("Your verification code is 654321")).toBe(
-      "654321",
-    );
-  });
+  const cases: Array<[string, string | null]> = [
+    // keyword-anchored
+    ["Your verification code is 654321", "654321"],
+    ["Your verification code is valid for 10 minutes: 482913", "482913"],
+    ["Your verification code will expire soon.\n\n482913", "482913"],
+    ["Enter the security code below to continue\n\n771122", "771122"],
+    ["Your code: 123-456", "123456"],
+    ["Your code is 123 456", "123456"],
+    ["Ihr Code lautet 123456", "123456"],
+    ["Tu código de verificación es 998877", "998877"],
+    ["OTP: 4821", "4821"],
+    ["Your one-time passcode is 7K3PQ2", "7K3PQ2"],
+    ["Sign-in code\n\n445566\n\nThis code expires in 5 minutes.", "445566"],
+    ["Use this PIN code 2468 to unlock", "2468"],
+    // conservative fallback without a keyword
+    ["Use 112233 to finish signing in", "112233"],
+    ["Welcome back, there is nothing to verify here.", null],
+    ["© 2024 Netflix, Inc. 100 Winchester Circle, Los Gatos, CA 95032", null],
+    ["Order #123456 has shipped. Track it at 555 0100 ext 4433", null],
+    ["Two codes 111111 and 222222 are both in here", null],
+    // rejections around keywords
+    ["Your code is valid until 2026. Thanks!", null],
+    ["Promo code SUMMER applies; nothing numeric", null],
+  ];
 
-  it("falls back to a standalone numeric code", () => {
-    expect(extractVerificationCode("Use 112233 to finish signing in")).toBe(
-      "112233",
-    );
-  });
+  for (const [input, expected] of cases) {
+    it(`${JSON.stringify(input.slice(0, 60))} → ${JSON.stringify(expected)}`, () => {
+      expect(extractVerificationCode(input)).toBe(expected);
+    });
+  }
+});
 
-  it("returns null when no code-like value is present", () => {
-    expect(
-      extractVerificationCode("Welcome back, there is nothing to verify here."),
-    ).toBeNull();
+describe("stripHtml", () => {
+  it("drops style/script blocks, decodes entities and keeps the code", () => {
+    const html =
+      "<html><head><style>.btn{color:#123456;width:600px}</style></head>" +
+      "<body><p>Hello&nbsp;there, your code is&#160;<b>778899</b> &amp; expires soon.</p>" +
+      "<script>var x = 999999;</script></body></html>";
+
+    const text = stripHtml(html);
+    expect(text).not.toContain("123456");
+    expect(text).not.toContain("999999");
+    expect(text).toContain("Hello there, your code is 778899 & expires soon.");
+    expect(extractVerificationCode(text)).toBe("778899");
   });
 });


### PR DESCRIPTION
## Summary

Closes #98.

The extractor returned plain words (`valid`, `will`, `below`), footer years (`2024`), CSS hex colours from unstripped `<style>` blocks and zip codes as "codes", and missed `123-456` / `123 456` — displayed in a 3 rem banner with a copy button.

- **Keyword-anchored**: scans an 80-char window after a code keyword (verification/security/login/sign-in/2FA code, passcode, OTP, PIN code, and `code`/`kode`/`código`/`codice`) for the first plausible token: digits (optionally grouped `123-456`/`123 456` → normalised), or an uppercase alphanumeric token containing a digit (`7K3PQ2`); rejects years (`19xx/20xx`) and tokens preceded by `#`, `$`, `&#`.
- **Fallback without a keyword** is deliberately conservative: only a single, unambiguous 6-digit token; zip/phone/order numbers and multi-candidate bodies yield `null`.
- `stripHtml` now removes `<style>/<script>/<head>/<title>` blocks and comments and decodes HTML entities (`&nbsp;`, `&#160;`, `&amp;` …).

## Tests

Table-driven `test/extract-code.test.ts` with every case from the review (all previously wrong) plus German/Spanish, alphanumeric, grouped digits, ZIP/year/order-number rejections, ambiguity → null; `stripHtml` case with CSS colour + entities + script.

`npm run ci` green: 182 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)