### PR TITLE
feat: complete the password reset flow (forgot + reset pages, session revocation)

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -17,6 +17,7 @@ import {
   useParams,
 } from "react-router-dom";
 import { CreateHouseholdPage } from "./components/CreateHouseholdPage";
+import { ForgotPasswordPage } from "./components/ForgotPasswordPage";
 import { HouseholdSettingsView } from "./components/HouseholdSettingsView";
 import { InboxView } from "./components/InboxView";
 import { InvitePage } from "./components/InvitePage";
@@ -25,6 +26,7 @@ import { LoginPage } from "./components/LoginPage";
 import { MembersView } from "./components/MembersView";
 import { ProvidersRulesView } from "./components/ProvidersRulesView";
 import { QuarantineView } from "./components/QuarantineView";
+import { ResetPasswordPage } from "./components/ResetPasswordPage";
 import { SettingsView } from "./components/SettingsView";
 import { SetupPage } from "./components/SetupPage";
 import type {
@@ -139,7 +141,14 @@ export function App() {
   const routeSegments = location.pathname.split("/").filter(Boolean);
   const routeSlug =
     routeSegments[0] &&
-    !["login", "setup", "invite", "settings"].includes(routeSegments[0])
+    ![
+      "login",
+      "setup",
+      "invite",
+      "settings",
+      "forgot-password",
+      "reset-password",
+    ].includes(routeSegments[0])
       ? routeSegments[0]
       : null;
 
@@ -1809,6 +1818,8 @@ export function App() {
             />
           }
         />
+        <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+        <Route path="/reset-password" element={<ResetPasswordPage />} />
         <Route
           path="*"
           element={

--- a/src/client/components/ForgotPasswordPage.tsx
+++ b/src/client/components/ForgotPasswordPage.tsx
@@ -1,0 +1,86 @@
+import { Alert, Box, Button, Link as MuiLink, TextField } from "@mui/material";
+import { authClient } from "@server/auth/client";
+import { type FormEvent, useState } from "react";
+import { Link as RouterLink } from "react-router-dom";
+import { PublicEntryShell } from "./PublicEntryShell";
+
+export function ForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    const { error: requestError } = await authClient.requestPasswordReset({
+      email: email.trim(),
+      redirectTo: `${window.location.origin}/reset-password`,
+    });
+
+    setIsSubmitting(false);
+
+    if (requestError) {
+      setError(requestError.message ?? "Unable to request a password reset.");
+      return;
+    }
+
+    setSubmitted(true);
+  };
+
+  return (
+    <PublicEntryShell
+      eyebrow="Mi Casa Su Casa"
+      title="Forgot your password?"
+      description="Enter the email address of your household account. If it exists, we will send a link to choose a new password."
+    >
+      {submitted ? (
+        <Alert severity="success" sx={{ borderRadius: 2, mb: 3 }}>
+          If an account exists for {email.trim()}, a reset link is on its way.
+          The link is valid for one hour.
+        </Alert>
+      ) : (
+        <Box component="form" onSubmit={handleSubmit} noValidate>
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            id="email"
+            label="Email Address"
+            name="email"
+            autoComplete="email"
+            autoFocus
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            sx={{ mb: 3 }}
+          />
+
+          {error && (
+            <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
+              {error}
+            </Alert>
+          )}
+
+          <Button
+            type="submit"
+            fullWidth
+            variant="contained"
+            size="large"
+            disabled={isSubmitting || !email.trim()}
+            sx={{ py: 1.5 }}
+          >
+            {isSubmitting ? "Sending…" : "Send reset link"}
+          </Button>
+        </Box>
+      )}
+
+      <Box sx={{ mt: 3, textAlign: "center" }}>
+        <MuiLink component={RouterLink} to="/login" underline="hover">
+          Back to sign in
+        </MuiLink>
+      </Box>
+    </PublicEntryShell>
+  );
+}

--- a/src/client/components/LoginPage.tsx
+++ b/src/client/components/LoginPage.tsx
@@ -1,6 +1,7 @@
-import { Alert, Box, Button, TextField } from "@mui/material";
+import { Alert, Box, Button, Link as MuiLink, TextField } from "@mui/material";
 import { authClient } from "@server/auth/client";
 import { type FormEvent, useState } from "react";
+import { Link as RouterLink } from "react-router-dom";
 import type { LoginState, SetupStatus } from "../types";
 import { PublicEntryShell } from "./PublicEntryShell";
 
@@ -109,6 +110,16 @@ export function LoginPage({
         >
           {isLoggingIn ? "Signing in…" : "Sign in"}
         </Button>
+
+        <Box sx={{ mt: 2, textAlign: "center" }}>
+          <MuiLink
+            component={RouterLink}
+            to="/forgot-password"
+            underline="hover"
+          >
+            Forgot your password?
+          </MuiLink>
+        </Box>
       </Box>
     </PublicEntryShell>
   );

--- a/src/client/components/ResetPasswordPage.tsx
+++ b/src/client/components/ResetPasswordPage.tsx
@@ -1,0 +1,136 @@
+import { Alert, Box, Button, Link as MuiLink, TextField } from "@mui/material";
+import { authClient } from "@server/auth/client";
+import { type FormEvent, useState } from "react";
+import { Link as RouterLink, useSearchParams } from "react-router-dom";
+import { PublicEntryShell } from "./PublicEntryShell";
+
+const MIN_PASSWORD_LENGTH = 12;
+
+export function ResetPasswordPage() {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token");
+  const linkError = searchParams.get("error");
+
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+
+    if (!token) {
+      setError("This reset link is missing its token. Request a new one.");
+      return;
+    }
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError("The two passwords do not match.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    const { error: resetError } = await authClient.resetPassword({
+      newPassword: password,
+      token,
+    });
+    setIsSubmitting(false);
+
+    if (resetError) {
+      setError(
+        resetError.message ??
+          "Unable to reset the password. The link may have expired.",
+      );
+      return;
+    }
+
+    setDone(true);
+  };
+
+  const invalidLink = !token || linkError === "INVALID_TOKEN";
+
+  return (
+    <PublicEntryShell
+      eyebrow="Mi Casa Su Casa"
+      title="Choose a new password"
+      description="Pick a new password for your household account. For safety, every other signed-in device is signed out when it changes."
+    >
+      {done ? (
+        <Alert severity="success" sx={{ borderRadius: 2, mb: 3 }}>
+          Your password has been updated. You can sign in with it now.
+        </Alert>
+      ) : invalidLink ? (
+        <Alert severity="error" sx={{ borderRadius: 2, mb: 3 }}>
+          This password reset link is invalid or has expired. Request a new link
+          and try again.
+        </Alert>
+      ) : (
+        <Box component="form" onSubmit={handleSubmit} noValidate>
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            type="password"
+            id="new-password"
+            label="New password"
+            autoComplete="new-password"
+            autoFocus
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            helperText={`At least ${MIN_PASSWORD_LENGTH} characters`}
+          />
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            type="password"
+            id="confirm-password"
+            label="Confirm new password"
+            autoComplete="new-password"
+            value={confirmPassword}
+            onChange={(event) => setConfirmPassword(event.target.value)}
+            sx={{ mb: 3 }}
+          />
+
+          {error && (
+            <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
+              {error}
+            </Alert>
+          )}
+
+          <Button
+            type="submit"
+            fullWidth
+            variant="contained"
+            size="large"
+            disabled={isSubmitting}
+            sx={{ py: 1.5 }}
+          >
+            {isSubmitting ? "Updating…" : "Update password"}
+          </Button>
+        </Box>
+      )}
+
+      <Box sx={{ mt: 3, textAlign: "center" }}>
+        {invalidLink && !done ? (
+          <MuiLink
+            component={RouterLink}
+            to="/forgot-password"
+            underline="hover"
+          >
+            Request a new reset link
+          </MuiLink>
+        ) : (
+          <MuiLink component={RouterLink} to="/login" underline="hover">
+            Back to sign in
+          </MuiLink>
+        )}
+      </Box>
+    </PublicEntryShell>
+  );
+}

--- a/src/server/auth/auth.ts
+++ b/src/server/auth/auth.ts
@@ -36,6 +36,7 @@ function createAuth(env: Env, options: { disableSignUp: boolean }) {
       disableSignUp: options.disableSignUp,
       minPasswordLength: 12,
       maxPasswordLength: 128,
+      revokeSessionsOnPasswordReset: true,
       sendResetPassword: async ({ user, url }) => {
         try {
           await sendPasswordResetEmail(env, {

--- a/test/integration/password-reset.test.ts
+++ b/test/integration/password-reset.test.ts
@@ -1,0 +1,97 @@
+import { SELF } from "cloudflare:test";
+import { authForEnv, provisioningAuthForEnv } from "@server/auth/auth";
+import { describe, expect, it } from "vitest";
+
+import { count, db, testEnv } from "./helpers";
+
+describe("password reset (end-to-end against D1)", () => {
+  it("emails a reset link, accepts the new password, revokes other sessions", async () => {
+    const sent: string[] = [];
+    const env = testEnv({
+      EMAIL: {
+        send: async (message: { text?: string }) => {
+          sent.push(message.text ?? "");
+          return { messageId: "m" };
+        },
+      } as unknown as Env["EMAIL"],
+    });
+
+    // Owner signs up, then signs in on a "second device".
+    await provisioningAuthForEnv(env).api.signUpEmail({
+      body: {
+        email: "owner@example.com",
+        name: "Owner",
+        password: "old-password-123456",
+      },
+    });
+    await authForEnv(env).api.signInEmail({
+      body: { email: "owner@example.com", password: "old-password-123456" },
+    });
+    expect(await count("session")).toBe(2);
+
+    // Request a reset through the worker (what the Forgot page does).
+    const request = await SELF.fetch(
+      "http://localhost:8787/api/auth/request-password-reset",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:8787",
+        },
+        body: JSON.stringify({
+          email: "owner@example.com",
+          redirectTo: "http://localhost:8787/reset-password",
+        }),
+      },
+    );
+    expect(request.status).toBe(200);
+    // The worker-served instance uses the real EMAIL binding, so resolve the
+    // token from the verification table instead of the outbound mail.
+    const tokenFromEmail = sent
+      .map((text) => text.match(/reset-password\/([A-Za-z0-9_-]+)/)?.[1])
+      .find(Boolean);
+
+    const verification = await db
+      .prepare(
+        "SELECT identifier FROM verification WHERE identifier LIKE 'reset-password:%' ORDER BY createdAt DESC LIMIT 1",
+      )
+      .first<{ identifier: string }>();
+    const token =
+      tokenFromEmail ?? verification?.identifier.replace("reset-password:", "");
+    expect(token).toBeTruthy();
+
+    // Following the emailed link redirects to the SPA with the token.
+    const follow = await SELF.fetch(
+      `http://localhost:8787/api/auth/reset-password/${token}?callbackURL=http://localhost:8787/reset-password`,
+      { redirect: "manual" },
+    );
+    expect(follow.status).toBeGreaterThanOrEqual(300);
+    expect(follow.headers.get("location")).toContain(`token=${token}`);
+
+    // The reset page posts the new password.
+    const reset = await SELF.fetch(
+      "http://localhost:8787/api/auth/reset-password",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:8787",
+        },
+        body: JSON.stringify({ newPassword: "new-password-654321", token }),
+      },
+    );
+    expect(reset.status).toBe(200);
+
+    // Other sessions are revoked; the new password works, the old one does not.
+    expect(await count("session")).toBe(0);
+    await expect(
+      authForEnv(env).api.signInEmail({
+        body: { email: "owner@example.com", password: "old-password-123456" },
+      }),
+    ).rejects.toThrow();
+    const signedIn = await authForEnv(env).api.signInEmail({
+      body: { email: "owner@example.com", password: "new-password-654321" },
+    });
+    expect(signedIn.user.email).toBe("owner@example.com");
+  });
+});

--- a/test/password-reset-pages.test.tsx
+++ b/test/password-reset-pages.test.tsx
@@ -1,0 +1,58 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import { ForgotPasswordPage } from "../src/client/components/ForgotPasswordPage";
+import { LoginPage } from "../src/client/components/LoginPage";
+import { ResetPasswordPage } from "../src/client/components/ResetPasswordPage";
+
+describe("password reset pages", () => {
+  it("login page links to the forgot-password flow", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter initialEntries={["/login"]}>
+        <LoginPage
+          setupStatus={null}
+          setupError={null}
+          onLoginSuccess={() => {}}
+        />
+      </MemoryRouter>,
+    );
+    expect(html).toContain('href="/forgot-password"');
+    expect(html).toContain("Forgot your password?");
+  });
+
+  it("forgot-password page asks for an email and links back to sign in", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter initialEntries={["/forgot-password"]}>
+        <ForgotPasswordPage />
+      </MemoryRouter>,
+    );
+    expect(html).toContain("Send reset link");
+    expect(html).toContain('href="/login"');
+  });
+
+  it("reset page shows the new-password form when a token is present", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter initialEntries={["/reset-password?token=abc"]}>
+        <ResetPasswordPage />
+      </MemoryRouter>,
+    );
+    expect(html).toContain("New password");
+    expect(html).toContain("Update password");
+  });
+
+  it("reset page explains invalid or missing tokens and offers a new link", () => {
+    for (const entry of [
+      "/reset-password",
+      "/reset-password?error=INVALID_TOKEN",
+    ]) {
+      const html = renderToStaticMarkup(
+        <MemoryRouter initialEntries={[entry]}>
+          <ResetPasswordPage />
+        </MemoryRouter>,
+      );
+      expect(html).toContain("invalid or has expired");
+      expect(html).toContain('href="/forgot-password"');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #94.

Reset links pointed at `/reset-password`, which did not exist (the SPA's catch-all dropped the token), and the only way to request a reset was from inside account settings — so nobody could recover a forgotten password.

- **`/forgot-password`** page (`authClient.requestPasswordReset`, enumeration-safe confirmation) linked from the login page ("Forgot your password?").
- **`/reset-password`** page reads `token` (or `error=INVALID_TOKEN`) from the URL, validates length + confirmation, calls `authClient.resetPassword`, and offers a new-link path when the token is invalid/expired.
- Both routes registered in the public router and excluded from household-slug resolution.
- `emailAndPassword.revokeSessionsOnPasswordReset: true` — every other device is signed out when the password changes.

## Tests

- `test/password-reset-pages.test.tsx`: login links to forgot; forgot page form + back link; reset page shows the form with a token and the invalid-link message (+ new-link CTA) without one / with `INVALID_TOKEN`.
- `test/integration/password-reset.test.ts` (real D1 via `SELF`): request reset → follow emailed link (redirect carries the token) → post new password → **other sessions revoked**, old password rejected, new password signs in.

`npm run ci` green: 187 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)