### PR TITLE
fix: let existing users accept household invitations

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -124,6 +124,19 @@ const INITIAL_RULE_FORM_STATE: SenderRuleFormState = {
   matchValue: "",
 };
 
+const PENDING_INVITE_KEY = "pendingInviteToken";
+
+// Declared at module level so it is not remounted on every App render.
+function InviteRoute({ onAccepted }: { onAccepted: (slug: string) => void }) {
+  const { token } = useParams<{ token: string }>();
+
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <InvitePage token={token} onAcceptSuccess={onAccepted} />;
+}
+
 export function App() {
   const {
     data: session,
@@ -152,6 +165,7 @@ export function App() {
       ? routeSegments[0]
       : null;
 
+  const isInvitePath = routeSegments[0] === "invite";
   const activeView = getActiveView(location.pathname);
   const [households, setHouseholds] = useState<HouseholdSummary[]>([]);
   const [isLoadingHouseholds, setIsLoadingHouseholds] = useState(false);
@@ -309,25 +323,11 @@ export function App() {
     setViewError(null);
   };
 
-  function InviteRoute() {
-    const { token } = useParams<{ token: string }>();
-
-    if (!token) {
-      return <Navigate to="/login" replace />;
-    }
-
-    return (
-      <InvitePage
-        token={token}
-        onAcceptSuccess={(householdSlug) => {
-          navigate(buildHouseholdPath(householdSlug, "/inbox"), {
-            replace: true,
-          });
-          void refetch();
-        }}
-      />
-    );
-  }
+  const handleInviteAccepted = (householdSlug: string) => {
+    sessionStorage.removeItem(PENDING_INVITE_KEY);
+    navigate(buildHouseholdPath(householdSlug, "/inbox"), { replace: true });
+    void refetch();
+  };
 
   useEffect(() => {
     if (!isAuthenticated) {
@@ -375,7 +375,13 @@ export function App() {
       return;
     }
 
-    if (activeView === "settings") {
+    if (activeView === "settings" || isInvitePath) {
+      return;
+    }
+
+    const pendingInvite = sessionStorage.getItem(PENDING_INVITE_KEY);
+    if (pendingInvite) {
+      navigate(`/invite/${pendingInvite}`, { replace: true });
       return;
     }
 
@@ -395,6 +401,7 @@ export function App() {
     defaultHousehold,
     households,
     isAuthenticated,
+    isInvitePath,
     isLoadingHouseholds,
     navigate,
     routeSlug,
@@ -1788,7 +1795,10 @@ export function App() {
   if (!isAuthenticated) {
     return (
       <Routes>
-        <Route path="/invite/:token" element={<InviteRoute />} />
+        <Route
+          path="/invite/:token"
+          element={<InviteRoute onAccepted={handleInviteAccepted} />}
+        />
         <Route
           path="/setup"
           element={
@@ -1863,6 +1873,10 @@ export function App() {
       onLogout={handleLogout}
     >
       <Routes>
+        <Route
+          path="/invite/:token"
+          element={<InviteRoute onAccepted={handleInviteAccepted} />}
+        />
         <Route
           path="/"
           element={

--- a/src/client/components/InvitePage.tsx
+++ b/src/client/components/InvitePage.tsx
@@ -8,7 +8,11 @@ import {
 } from "@mui/material";
 import { type FormEvent, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import type { InvitationAcceptanceState, InvitationSummary } from "../types";
+import type {
+  InvitationAcceptanceState,
+  InvitationLookupResponse,
+  InvitationSummary,
+} from "../types";
 import { fetchJson } from "../utils";
 import { PublicEntryShell } from "./PublicEntryShell";
 
@@ -20,6 +24,9 @@ interface InvitePageProps {
 export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
   const navigate = useNavigate();
   const [invitation, setInvitation] = useState<InvitationSummary | null>(null);
+  const [accountExists, setAccountExists] = useState(false);
+  const [viewer, setViewer] =
+    useState<InvitationLookupResponse["viewer"]>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isAccepting, setIsAccepting] = useState(false);
@@ -33,13 +40,15 @@ export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
 
     async function loadInvitation() {
       try {
-        const response = await fetchJson<{ invitation: InvitationSummary }>(
+        const response = await fetchJson<InvitationLookupResponse>(
           `/api/invitations/${token}`,
         );
 
         if (cancelled) return;
 
         setInvitation(response.invitation);
+        setAccountExists(response.accountExists);
+        setViewer(response.viewer);
       } catch (err) {
         if (!cancelled) {
           setError(
@@ -60,6 +69,32 @@ export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
     };
   }, [token]);
 
+  async function submitAcceptance(body: Record<string, string>) {
+    setError(null);
+    setIsAccepting(true);
+
+    try {
+      const response = await fetchJson<{ household?: { slug: string } | null }>(
+        `/api/invitations/${token}/accept`,
+        { method: "POST", body: JSON.stringify(body) },
+      );
+
+      if (!response.household?.slug) {
+        throw new Error("Invitation accepted but no household was returned");
+      }
+
+      onAcceptSuccess(response.household.slug);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Unable to accept invitation";
+      if (/already exists/i.test(message)) {
+        setAccountExists(true);
+      }
+      setError(message);
+      setIsAccepting(false);
+    }
+  }
+
   async function handleAccept(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
@@ -70,32 +105,15 @@ export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
       return;
     }
 
-    setError(null);
-    setIsAccepting(true);
+    await submitAcceptance({
+      name: formState.name,
+      password: formState.password,
+    });
+  }
 
-    try {
-      const response = await fetchJson<{ household?: { slug: string } | null }>(
-        `/api/invitations/${token}/accept`,
-        {
-          method: "POST",
-          body: JSON.stringify({
-            name: formState.name,
-            password: formState.password,
-          }),
-        },
-      );
-
-      if (!response.household?.slug) {
-        throw new Error("Invitation accepted but no household was returned");
-      }
-
-      onAcceptSuccess(response.household.slug);
-    } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Unable to accept invitation",
-      );
-      setIsAccepting(false);
-    }
+  function goToSignIn() {
+    sessionStorage.setItem("pendingInviteToken", token);
+    navigate("/login");
   }
 
   if (isLoading) {
@@ -142,6 +160,92 @@ export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
 
   if (!invitation) {
     return null;
+  }
+
+  if (viewer?.emailMatches) {
+    return (
+      <PublicEntryShell
+        eyebrow="Mi Casa Su Casa"
+        title="Accept invitation"
+        description={
+          <>
+            You are signed in as <strong>{viewer.email}</strong> and have been
+            invited to join as a <strong>{invitation.role}</strong>.
+          </>
+        }
+      >
+        {error && (
+          <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
+            {error}
+          </Alert>
+        )}
+        <Button
+          fullWidth
+          variant="contained"
+          size="large"
+          disabled={isAccepting}
+          onClick={() => void submitAcceptance({})}
+          sx={{ py: 1.5 }}
+        >
+          {isAccepting ? "Accepting…" : `Accept as ${viewer.email}`}
+        </Button>
+      </PublicEntryShell>
+    );
+  }
+
+  if (viewer && !viewer.emailMatches) {
+    return (
+      <PublicEntryShell
+        eyebrow="Mi Casa Su Casa"
+        title="This invitation is for a different account"
+        description={
+          <>
+            The invitation was sent to <strong>{invitation.email}</strong>, but
+            you are signed in as <strong>{viewer.email}</strong>. Sign out and
+            open the link again with the invited account.
+          </>
+        }
+      >
+        <Button
+          variant="outlined"
+          fullWidth
+          onClick={() => navigate("/settings")}
+        >
+          Go to account settings
+        </Button>
+      </PublicEntryShell>
+    );
+  }
+
+  if (accountExists) {
+    return (
+      <PublicEntryShell
+        eyebrow="Mi Casa Su Casa"
+        title="Sign in to accept"
+        description={
+          <>
+            An account already exists for <strong>{invitation.email}</strong>.
+            Sign in with it and you will be brought back here to accept the
+            invitation.
+          </>
+        }
+      >
+        {error && (
+          <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
+            {error}
+          </Alert>
+        )}
+        <Button
+          fullWidth
+          variant="contained"
+          size="large"
+          onClick={goToSignIn}
+          sx={{ py: 1.5 }}
+        >
+          Sign in to accept
+        </Button>
+      </PublicEntryShell>
+    );
   }
 
   return (

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -230,3 +230,9 @@ export type InvitationDeliveryResponse = {
   emailSent: boolean;
   emailError?: string;
 };
+
+export type InvitationLookupResponse = {
+  invitation: InvitationSummary;
+  accountExists: boolean;
+  viewer: { email: string; emailMatches: boolean } | null;
+};

--- a/src/server/db/repositories/invitations.ts
+++ b/src/server/db/repositories/invitations.ts
@@ -246,6 +246,18 @@ export async function acceptInvitation(
       })
       .where(eq(householdInvitations.id, input.invitationId)),
   ]);
+
+  // Carry the invitation's provider scope over to the new membership.
+  // Idempotent (INSERT OR IGNORE), so a retry after a failure here is safe.
+  await database.run(sql`
+    INSERT OR IGNORE INTO household_member_provider_access (id, household_membership_id, provider_id)
+    SELECT lower(hex(randomblob(16))), household_memberships.id, household_invitation_provider_access.provider_id
+    FROM household_invitation_provider_access
+    INNER JOIN household_memberships
+      ON household_memberships.household_id = ${input.householdId}
+     AND household_memberships.user_id = ${input.acceptedByUserId}
+    WHERE household_invitation_provider_access.invitation_id = ${input.invitationId}
+  `);
 }
 
 export async function refreshExpiredInvitations(db: D1Database) {

--- a/src/server/routes/invitations.ts
+++ b/src/server/routes/invitations.ts
@@ -45,27 +45,36 @@ invitationRoutes.get("/:token", async (c) => {
     return c.json({ error: "Invitation not found or no longer valid" }, 404);
   }
 
-  return c.json({ invitation: withoutToken(invitation) });
+  const currentUser = c.get("user");
+  const accountExists = Boolean(
+    await findUserByEmail(c.env.DB, invitation.email),
+  );
+
+  return c.json({
+    invitation: withoutToken(invitation),
+    // Lets the invite page pick the right flow: create an account, sign in
+    // first, or accept as the signed-in user.
+    accountExists,
+    viewer: currentUser
+      ? {
+          email: currentUser.email,
+          emailMatches:
+            currentUser.email.toLowerCase() === invitation.email.toLowerCase(),
+        }
+      : null,
+  });
 });
 
 invitationRoutes.post("/:token/accept", async (c) => {
   await refreshExpiredInvitations(c.env.DB);
 
-  let payload: AcceptInvitationPayload;
+  let payload: AcceptInvitationPayload = {};
 
   try {
-    payload = await c.req.json<AcceptInvitationPayload>();
+    const raw = await c.req.text();
+    payload = raw.trim() ? (JSON.parse(raw) as AcceptInvitationPayload) : {};
   } catch {
     return c.json({ error: "Invalid JSON body" }, 400);
-  }
-
-  if (!payload.name || !payload.password || payload.password.length < 12) {
-    return c.json(
-      {
-        error: "name and a password with at least 12 characters are required",
-      },
-      400,
-    );
   }
 
   const tokenHash = await hashInvitationToken(c.req.param("token"));
@@ -77,6 +86,19 @@ invitationRoutes.post("/:token/accept", async (c) => {
 
   const auth = provisioningAuthForEnv(c.env);
   const currentUser = c.get("user");
+
+  // A signed-in user accepts with their existing account: no password, no
+  // name required.
+  if (!currentUser) {
+    if (!payload.name || !payload.password || payload.password.length < 12) {
+      return c.json(
+        {
+          error: "name and a password with at least 12 characters are required",
+        },
+        400,
+      );
+    }
+  }
 
   if (currentUser) {
     if (currentUser.email.toLowerCase() !== invitation.email.toLowerCase()) {
@@ -103,7 +125,7 @@ invitationRoutes.post("/:token/accept", async (c) => {
         member: {
           id: currentUser.id,
           email: currentUser.email,
-          name: payload.name.trim(),
+          name: currentUser.name,
           role: invitation.role,
         },
         household,
@@ -111,6 +133,9 @@ invitationRoutes.post("/:token/accept", async (c) => {
       200,
     );
   }
+
+  const name = payload.name?.trim() ?? "";
+  const password = payload.password ?? "";
 
   // An account for the invited address already exists (e.g. an earlier
   // attempt was interrupted after sign-up, or the person already has an
@@ -133,8 +158,8 @@ invitationRoutes.post("/:token/accept", async (c) => {
     const signUpResult = await auth.api.signUpEmail({
       body: {
         email: invitation.email,
-        name: payload.name.trim(),
-        password: payload.password,
+        name,
+        password,
       },
       headers: new Headers(c.req.raw.headers),
       returnHeaders: true,

--- a/test/integration/invitation-accept.test.ts
+++ b/test/integration/invitation-accept.test.ts
@@ -1,30 +1,54 @@
 import { SELF } from "cloudflare:test";
+import { provisioningAuthForEnv } from "@server/auth/auth";
 import { createHousehold } from "@server/db/repositories/households";
 import { createHouseholdInvitation } from "@server/db/repositories/invitations";
+import { createProvider } from "@server/db/repositories/provider-rules";
 import { hashInvitationToken } from "@server/security/tokens";
 import { describe, expect, it } from "vitest";
 
-import { count, createTestUser, db } from "./helpers";
+import { count, createTestUser, db, testEnv } from "./helpers";
 
-async function seedInvitation(email = "kid@example.com") {
+async function seedInvitation(email = "kid@example.com", withProvider = false) {
   const owner = await createTestUser({ email: "owner@example.com" });
   const household = await createHousehold(db, {
     slug: "casa",
     displayName: "Casa",
     ownerUserId: owner.id,
   });
+  const householdId = household?.id ?? "";
+  const providerIds: string[] = [];
+  if (withProvider) {
+    const provider = await createProvider(
+      db,
+      householdId,
+      "netflix",
+      "Netflix",
+    );
+    providerIds.push(provider.id);
+  }
   const token = "invite-token-1";
   await createHouseholdInvitation(db, {
-    householdId: household?.id ?? "",
+    householdId,
     email,
     name: "Kid",
     role: "member",
     tokenHash: await hashInvitationToken(token),
     invitedByUserId: owner.id,
     expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
-    providerIds: [],
+    providerIds,
   });
-  return { token, householdId: household?.id ?? "" };
+  return { token, householdId };
+}
+
+async function signUpWithCookie(email: string) {
+  const result = await provisioningAuthForEnv(testEnv()).api.signUpEmail({
+    body: { email, name: "Existing", password: "averylongpassword123" },
+    returnHeaders: true,
+  });
+  return result.headers
+    .getSetCookie()
+    .map((entry: string) => entry.split(";")[0])
+    .join("; ");
 }
 
 async function postAccept(token: string, body: unknown) {
@@ -76,5 +100,82 @@ describe("invitation acceptance (end-to-end against D1)", () => {
     });
     expect(response.status).toBe(404);
     expect(await count("user")).toBe(1);
+  });
+
+  it("lets a signed-in user with the invited email accept without a password and copies provider access", async () => {
+    const { token, householdId } = await seedInvitation(
+      "kid@example.com",
+      true,
+    );
+    const cookie = await signUpWithCookie("kid@example.com");
+
+    const lookup = await SELF.fetch(
+      `http://localhost:8787/api/invitations/${token}`,
+      {
+        headers: { cookie },
+      },
+    );
+    await expect(lookup.json()).resolves.toMatchObject({
+      accountExists: true,
+      viewer: { email: "kid@example.com", emailMatches: true },
+    });
+
+    const response = await SELF.fetch(
+      `http://localhost:8787/api/invitations/${token}/accept`,
+      {
+        method: "POST",
+        headers: { cookie, "content-type": "application/json" },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      member: { email: "kid@example.com", role: "member" },
+      household: { slug: "casa" },
+    });
+    expect(
+      await count(
+        "household_memberships",
+        "household_id = ?1 AND role = 'member'",
+        householdId,
+      ),
+    ).toBe(1);
+    expect(await count("household_member_provider_access")).toBe(1);
+    expect(await count("household_invitations", "status = 'accepted'")).toBe(1);
+  });
+
+  it("refuses acceptance by a signed-in user with a different email", async () => {
+    const { token } = await seedInvitation("kid@example.com");
+    const cookie = await signUpWithCookie("someone-else@example.com");
+
+    const lookup = await SELF.fetch(
+      `http://localhost:8787/api/invitations/${token}`,
+      {
+        headers: { cookie },
+      },
+    );
+    await expect(lookup.json()).resolves.toMatchObject({
+      viewer: { email: "someone-else@example.com", emailMatches: false },
+    });
+
+    const response = await SELF.fetch(
+      `http://localhost:8787/api/invitations/${token}/accept`,
+      { method: "POST", headers: { cookie } },
+    );
+    expect(response.status).toBe(403);
+    expect(await count("household_invitations", "status = 'pending'")).toBe(1);
+  });
+
+  it("reports accountExists to anonymous visitors so the page can send them to sign in", async () => {
+    const { token } = await seedInvitation("kid@example.com");
+    await createTestUser({ email: "kid@example.com" });
+
+    const lookup = await SELF.fetch(
+      `http://localhost:8787/api/invitations/${token}`,
+    );
+    await expect(lookup.json()).resolves.toMatchObject({
+      accountExists: true,
+      viewer: null,
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #96.

Multi-household is a headline feature, but a signed-in user clicking `/invite/<token>` was redirected to their inbox, and a signed-out user who already had an account hit `User already exists` with no way forward.

**Server**
- `GET /api/invitations/:token` returns `accountExists` and `viewer: { email, emailMatches } | null` so the page can choose the right flow.
- `POST …/accept`: a signed-in user with the invited email accepts **without a password or name** (body may be empty); the invited **provider scope is copied** onto the new membership (`household_invitation_provider_access` → `household_member_provider_access`, idempotent).
- Existing-account-without-session → `409 ACCOUNT_EXISTS` (from #127), surfaced in the UI.

**Client**
- Invite page branches: *Accept as `<email>`* when signed in with the invited account; *Sign in to accept* when an account exists (remembers the token in `sessionStorage`, returns to the invite after login); a clear message when signed in as someone else; otherwise the create-account form.
- `/invite/:token` is routed in the authenticated tree as well; `InviteRoute` is now a module-level component (no remount on every `App` render — part of #111); the household redirect skips invite paths and honours a pending invite after login.

## Tests (real D1 via `SELF`)
- Signed-in invited user: lookup flags → accept with empty body → 200, membership + **provider access copied**, invitation accepted.
- Signed-in as a different email → 403, invitation stays pending.
- Anonymous visitor with an existing account → `accountExists: true, viewer: null`.
- Existing happy path / unknown token cases still pass.

`npm run ci` green: 190 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)