### PR TITLE
feat: working two-factor authentication (enrolment with QR + backup codes, sign-in challenge)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,12 @@
         "@mui/icons-material": "^9.3.1",
         "@mui/material": "^9.3.1",
         "@mui/x-data-grid": "^9.11.0",
+        "@types/qrcode": "^1.5.6",
         "better-auth": "1.7.1",
         "drizzle-orm": "^0.45.2",
         "hono": "4.13.3",
         "postal-mime": "3.0.0",
+        "qrcode": "^1.5.4",
         "react": "19.2.8",
         "react-dom": "19.2.8",
         "react-router-dom": "^7.18.2"
@@ -3015,7 +3017,6 @@
       "version": "26.2.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
       "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -3032,6 +3033,15 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "license": "MIT"
+    },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.2.18",
@@ -3773,6 +3783,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -3826,6 +3845,24 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/concurrently": {
       "version": "10.0.5",
@@ -3919,6 +3956,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/defu": {
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
@@ -3934,6 +3980,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -4236,6 +4288,19 @@
       "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
       "license": "MIT"
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4264,7 +4329,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -4367,6 +4431,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jose": {
@@ -4688,6 +4761,18 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4791,6 +4876,42 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4819,6 +4940,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-parse": {
@@ -4867,6 +4997,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/postal-mime": {
@@ -4937,6 +5076,145 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/qrcode/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react": {
@@ -5031,6 +5309,21 @@
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "license": "Apache-2.0"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/reselect": {
       "version": "5.2.0",
@@ -5146,6 +5439,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-cookie-parser": {
       "version": "3.1.2",
@@ -5483,7 +5782,6 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -5672,6 +5970,12 @@
           "optional": false
         }
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -58,10 +58,12 @@
     "@mui/icons-material": "^9.3.1",
     "@mui/material": "^9.3.1",
     "@mui/x-data-grid": "^9.11.0",
+    "@types/qrcode": "^1.5.6",
     "better-auth": "1.7.1",
     "drizzle-orm": "^0.45.2",
     "hono": "4.13.3",
     "postal-mime": "3.0.0",
+    "qrcode": "1.5.4",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-router-dom": "^7.18.2"

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -7,6 +7,7 @@ import {
   Typography,
 } from "@mui/material";
 import { authClient } from "@server/auth/client";
+import QRCode from "qrcode";
 import { type FormEvent, useCallback, useEffect, useState } from "react";
 import {
   Navigate,
@@ -29,6 +30,7 @@ import { QuarantineView } from "./components/QuarantineView";
 import { ResetPasswordPage } from "./components/ResetPasswordPage";
 import { SettingsView } from "./components/SettingsView";
 import { SetupPage } from "./components/SetupPage";
+import { TwoFactorPage } from "./components/TwoFactorPage";
 import type {
   AccountProfile,
   AccountSession,
@@ -54,6 +56,7 @@ import type {
   SenderRule,
   SenderRuleFormState,
   SetupStatus,
+  TwoFactorSetup,
 } from "./types";
 import {
   buildHouseholdApiPath,
@@ -161,6 +164,7 @@ export function App() {
       "settings",
       "forgot-password",
       "reset-password",
+      "two-factor",
     ].includes(routeSegments[0])
       ? routeSegments[0]
       : null;
@@ -614,6 +618,10 @@ export function App() {
     }
   }
 
+  const [twoFactorSetup, setTwoFactorSetup] = useState<TwoFactorSetup | null>(
+    null,
+  );
+
   async function handleEnable2FA(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setIsSavingSettings(true);
@@ -621,20 +629,38 @@ export function App() {
     setViewError(null);
 
     try {
-      const { error } = await authClient.twoFactor.enable({
+      const { data, error } = await authClient.twoFactor.enable({
         password: settingsFormState.twoFactorPassword,
       });
 
-      if (error) {
-        throw new Error(error.message || "Failed to enable 2FA");
+      if (error || !data || !("totpURI" in data)) {
+        throw new Error(error?.message || "Failed to start 2FA setup");
       }
 
+      // Enabling only creates the secret; it becomes active once a code from
+      // the authenticator app is verified.
+      let qrDataUrl: string | null = null;
+      try {
+        qrDataUrl = await QRCode.toDataURL(data.totpURI, { margin: 1 });
+      } catch {
+        qrDataUrl = null;
+      }
+      const secret = new URL(data.totpURI).searchParams.get("secret") ?? null;
+
+      setTwoFactorSetup({
+        totpURI: data.totpURI,
+        qrDataUrl,
+        secret,
+        backupCodes: data.backupCodes,
+      });
       setSettingsFormState((current) => ({
         ...current,
         twoFactorPassword: "",
+        twoFactorCode: "",
       }));
-      setStatusMessage("Two-factor authentication enabled.");
-      await refreshSettings();
+      setStatusMessage(
+        "Scan the QR code and enter a code to finish enabling two-factor authentication.",
+      );
     } catch (error) {
       setViewError(
         error instanceof Error ? error.message : "Unable to enable 2FA",
@@ -642,6 +668,42 @@ export function App() {
     } finally {
       setIsSavingSettings(false);
     }
+  }
+
+  async function handleVerify2FA(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsSavingSettings(true);
+    setStatusMessage(null);
+    setViewError(null);
+
+    try {
+      const { error } = await authClient.twoFactor.verifyTotp({
+        code: settingsFormState.twoFactorCode.trim(),
+      });
+
+      if (error) {
+        throw new Error(
+          error.message || "That code was not accepted. Try the next one.",
+        );
+      }
+
+      setTwoFactorSetup(null);
+      setSettingsFormState((current) => ({ ...current, twoFactorCode: "" }));
+      setStatusMessage("Two-factor authentication enabled.");
+      await refreshSettings();
+    } catch (error) {
+      setViewError(
+        error instanceof Error ? error.message : "Unable to verify the code",
+      );
+    } finally {
+      setIsSavingSettings(false);
+    }
+  }
+
+  function handleCancel2FASetup() {
+    setTwoFactorSetup(null);
+    setSettingsFormState((current) => ({ ...current, twoFactorCode: "" }));
+    setStatusMessage(null);
   }
 
   async function handleDisable2FA(): Promise<boolean> {
@@ -1831,6 +1893,17 @@ export function App() {
         <Route path="/forgot-password" element={<ForgotPasswordPage />} />
         <Route path="/reset-password" element={<ResetPasswordPage />} />
         <Route
+          path="/two-factor"
+          element={
+            <TwoFactorPage
+              onVerified={() => {
+                void refetch();
+                navigate("/", { replace: true });
+              }}
+            />
+          }
+        />
+        <Route
           path="*"
           element={
             <Navigate
@@ -1919,6 +1992,9 @@ export function App() {
               onRequestPasswordReset={handleRequestPasswordReset}
               onEnable2FA={handleEnable2FA}
               onDisable2FA={handleDisable2FA}
+              twoFactorSetup={twoFactorSetup}
+              onVerify2FA={handleVerify2FA}
+              onCancel2FASetup={handleCancel2FASetup}
               onAddPasskey={handleAddPasskey}
               onRevokeSession={handleRevokeSession}
               onRevokeOtherSessions={handleRevokeOtherSessions}

--- a/src/client/components/LoginPage.tsx
+++ b/src/client/components/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { Alert, Box, Button, Link as MuiLink, TextField } from "@mui/material";
 import { authClient } from "@server/auth/client";
 import { type FormEvent, useState } from "react";
-import { Link as RouterLink } from "react-router-dom";
+import { Link as RouterLink, useNavigate } from "react-router-dom";
 import type { LoginState, SetupStatus } from "../types";
 import { PublicEntryShell } from "./PublicEntryShell";
 
@@ -16,6 +16,7 @@ export function LoginPage({
   setupError,
   onLoginSuccess,
 }: LoginPageProps) {
+  const navigate = useNavigate();
   const [loginState, setLoginState] = useState<LoginState>({
     email: "",
     password: "",
@@ -28,7 +29,7 @@ export function LoginPage({
     setLoginError(null);
     setIsLoggingIn(true);
 
-    const { error } = await authClient.signIn.email({
+    const { data, error } = await authClient.signIn.email({
       email: loginState.email,
       password: loginState.password,
       rememberMe: true,
@@ -42,6 +43,14 @@ export function LoginPage({
     }
 
     setLoginState({ email: "", password: "" });
+
+    // Accounts with two-factor enabled get no session yet; finish on the
+    // challenge page.
+    if (data && "twoFactorRedirect" in data && data.twoFactorRedirect) {
+      navigate("/two-factor");
+      return;
+    }
+
     onLoginSuccess();
   };
 

--- a/src/client/components/SettingsView.tsx
+++ b/src/client/components/SettingsView.tsx
@@ -20,6 +20,7 @@ import type {
   AccountProfile,
   AccountSession,
   AccountSettingsFormState,
+  TwoFactorSetup,
 } from "../types";
 import { ConfirmDialog } from "./ConfirmDialog";
 
@@ -35,6 +36,9 @@ interface SettingsViewProps {
   onRequestPasswordReset: (e: FormEvent<HTMLFormElement>) => void;
   onEnable2FA: (e: FormEvent<HTMLFormElement>) => void;
   onDisable2FA: () => Promise<boolean>;
+  twoFactorSetup: TwoFactorSetup | null;
+  onVerify2FA: (e: FormEvent<HTMLFormElement>) => void;
+  onCancel2FASetup: () => void;
   onAddPasskey: (e: FormEvent<HTMLFormElement>) => void;
   onRevokeSession: (sessionId: string) => Promise<boolean>;
   onRevokeOtherSessions: () => Promise<boolean>;
@@ -53,6 +57,9 @@ export function SettingsView({
   onRequestPasswordReset,
   onEnable2FA,
   onDisable2FA,
+  twoFactorSetup,
+  onVerify2FA,
+  onCancel2FASetup,
   onAddPasskey,
   onRevokeSession,
   onRevokeOtherSessions,
@@ -258,7 +265,83 @@ export function SettingsView({
         <CardHeader title="Two-Factor Authentication" />
         <Divider />
         <CardContent>
-          {profile.twoFactorEnabled ? (
+          {twoFactorSetup ? (
+            <Box component="form" onSubmit={onVerify2FA}>
+              <Typography variant="body1" sx={{ mb: 2 }}>
+                Scan the QR code with your authenticator app (or enter the key
+                manually), save the backup codes somewhere safe, then enter the
+                current 6-digit code to finish enabling two-factor
+                authentication.
+              </Typography>
+              <Stack spacing={2}>
+                {twoFactorSetup.qrDataUrl ? (
+                  <Box>
+                    <img
+                      src={twoFactorSetup.qrDataUrl}
+                      alt="Authenticator QR code"
+                      width={192}
+                      height={192}
+                      style={{ display: "block", borderRadius: 8 }}
+                    />
+                  </Box>
+                ) : null}
+                {twoFactorSetup.secret ? (
+                  <Typography
+                    variant="body2"
+                    sx={{ fontFamily: "monospace", wordBreak: "break-all" }}
+                  >
+                    Manual key: {twoFactorSetup.secret}
+                  </Typography>
+                ) : null}
+                <Box>
+                  <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                    Backup codes (each works once)
+                  </Typography>
+                  <Box
+                    component="ul"
+                    sx={{
+                      m: 0,
+                      pl: 2,
+                      columns: 2,
+                      fontFamily: "monospace",
+                    }}
+                  >
+                    {twoFactorSetup.backupCodes.map((backupCode) => (
+                      <li key={backupCode}>{backupCode}</li>
+                    ))}
+                  </Box>
+                </Box>
+                <TextField
+                  fullWidth
+                  label="Code from your authenticator app"
+                  inputMode="numeric"
+                  autoComplete="one-time-code"
+                  value={formState.twoFactorCode}
+                  onChange={(e) =>
+                    onFormChange({ twoFactorCode: e.target.value })
+                  }
+                  required
+                />
+                <Stack direction="row" spacing={1}>
+                  <Button
+                    type="submit"
+                    variant="contained"
+                    disabled={isSaving || formState.twoFactorCode.trim() === ""}
+                  >
+                    Verify and enable
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="text"
+                    disabled={isSaving}
+                    onClick={onCancel2FASetup}
+                  >
+                    Cancel
+                  </Button>
+                </Stack>
+              </Stack>
+            </Box>
+          ) : profile.twoFactorEnabled ? (
             <Box
               component="form"
               onSubmit={(e) => {

--- a/src/client/components/TwoFactorPage.tsx
+++ b/src/client/components/TwoFactorPage.tsx
@@ -1,0 +1,133 @@
+import {
+  Alert,
+  Box,
+  Button,
+  FormControlLabel,
+  Link as MuiLink,
+  Switch,
+  TextField,
+} from "@mui/material";
+import { authClient } from "@server/auth/client";
+import { type FormEvent, useState } from "react";
+import { Link as RouterLink } from "react-router-dom";
+import { PublicEntryShell } from "./PublicEntryShell";
+
+interface TwoFactorPageProps {
+  onVerified: () => void;
+}
+
+export function TwoFactorPage({ onVerified }: TwoFactorPageProps) {
+  const [useBackupCode, setUseBackupCode] = useState(false);
+  const [code, setCode] = useState("");
+  const [trustDevice, setTrustDevice] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    const trimmed = code.trim();
+    const result = useBackupCode
+      ? await authClient.twoFactor.verifyBackupCode({
+          code: trimmed,
+          trustDevice,
+        })
+      : await authClient.twoFactor.verifyTotp({ code: trimmed, trustDevice });
+
+    setIsSubmitting(false);
+
+    if (result.error) {
+      setError(
+        result.error.message ??
+          (useBackupCode
+            ? "That backup code was not accepted."
+            : "That code was not accepted. Codes change every 30 seconds."),
+      );
+      return;
+    }
+
+    onVerified();
+  };
+
+  return (
+    <PublicEntryShell
+      eyebrow="Mi Casa Su Casa"
+      title="Two-factor authentication"
+      description={
+        useBackupCode
+          ? "Enter one of the backup codes you saved when you enabled two-factor authentication. Each code works once."
+          : "Enter the 6-digit code from your authenticator app to finish signing in."
+      }
+    >
+      <Box component="form" onSubmit={handleSubmit} noValidate>
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          id="two-factor-code"
+          label={useBackupCode ? "Backup code" : "Authenticator code"}
+          autoComplete="one-time-code"
+          inputMode={useBackupCode ? "text" : "numeric"}
+          autoFocus
+          value={code}
+          onChange={(event) => setCode(event.target.value)}
+        />
+        <FormControlLabel
+          control={
+            <Switch
+              checked={trustDevice}
+              onChange={(event) => setTrustDevice(event.target.checked)}
+            />
+          }
+          label="Trust this device for 30 days"
+          sx={{ mb: 2 }}
+        />
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        <Button
+          type="submit"
+          fullWidth
+          variant="contained"
+          size="large"
+          disabled={isSubmitting || !code.trim()}
+          sx={{ py: 1.5 }}
+        >
+          {isSubmitting ? "Verifying…" : "Verify"}
+        </Button>
+      </Box>
+
+      <Box
+        sx={{
+          mt: 3,
+          display: "flex",
+          justifyContent: "space-between",
+          flexWrap: "wrap",
+          gap: 1,
+        }}
+      >
+        <MuiLink
+          component="button"
+          type="button"
+          underline="hover"
+          onClick={() => {
+            setUseBackupCode((current) => !current);
+            setCode("");
+            setError(null);
+          }}
+        >
+          {useBackupCode ? "Use an authenticator code" : "Use a backup code"}
+        </MuiLink>
+        <MuiLink component={RouterLink} to="/login" underline="hover">
+          Back to sign in
+        </MuiLink>
+      </Box>
+    </PublicEntryShell>
+  );
+}

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -236,3 +236,10 @@ export type InvitationLookupResponse = {
   accountExists: boolean;
   viewer: { email: string; emailMatches: boolean } | null;
 };
+
+export type TwoFactorSetup = {
+  totpURI: string;
+  qrDataUrl: string | null;
+  secret: string | null;
+  backupCodes: string[];
+};

--- a/src/server/auth/client.ts
+++ b/src/server/auth/client.ts
@@ -7,7 +7,10 @@ export const authClient = createAuthClient({
     adminClient(),
     passkeyClient(),
     twoFactorClient({
-      twoFactorPage: "/",
+      twoFactorPage: "/two-factor",
+      // The login page inspects `twoFactorRedirect` itself and navigates with
+      // the router, so the plugin must not hard-redirect the window.
+      onTwoFactorRedirect() {},
     }),
   ],
   sessionOptions: {

--- a/test/integration/two-factor.test.ts
+++ b/test/integration/two-factor.test.ts
@@ -1,0 +1,156 @@
+import { SELF } from "cloudflare:test";
+import { provisioningAuthForEnv } from "@server/auth/auth";
+import { describe, expect, it } from "vitest";
+
+import { count, testEnv } from "./helpers";
+
+const BASE32 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+function base32Decode(input: string): Uint8Array {
+  const clean = input.replace(/=+$/, "").toUpperCase();
+  let bits = 0;
+  let value = 0;
+  const out: number[] = [];
+  for (const char of clean) {
+    const index = BASE32.indexOf(char);
+    if (index === -1) continue;
+    value = (value << 5) | index;
+    bits += 5;
+    if (bits >= 8) {
+      out.push((value >>> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+  }
+  return new Uint8Array(out);
+}
+
+/** RFC 6238 TOTP (SHA-1, 6 digits, 30 s) — what authenticator apps produce. */
+async function totp(secretBase32: string, now = Date.now()): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    base32Decode(secretBase32) as unknown as BufferSource,
+    { name: "HMAC", hash: "SHA-1" },
+    false,
+    ["sign"],
+  );
+  const counter = Math.floor(now / 1000 / 30);
+  const message = new Uint8Array(8);
+  new DataView(message.buffer).setBigUint64(0, BigInt(counter));
+  const hmac = new Uint8Array(
+    await crypto.subtle.sign("HMAC", key, message as unknown as BufferSource),
+  );
+  const offset = (hmac[hmac.length - 1] ?? 0) & 0x0f;
+  const binary =
+    (((hmac[offset] ?? 0) & 0x7f) << 24) |
+    (((hmac[offset + 1] ?? 0) & 0xff) << 16) |
+    (((hmac[offset + 2] ?? 0) & 0xff) << 8) |
+    ((hmac[offset + 3] ?? 0) & 0xff);
+  return String(binary % 1_000_000).padStart(6, "0");
+}
+
+function cookiesFrom(response: Response) {
+  return response.headers
+    .getSetCookie()
+    .map((entry) => entry.split(";")[0])
+    .filter((pair) => !pair.endsWith("="))
+    .join("; ");
+}
+
+async function post(path: string, body: unknown, cookie = "") {
+  return SELF.fetch(`http://localhost:8787${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      origin: "http://localhost:8787",
+      ...(cookie ? { cookie } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("two-factor authentication (end-to-end against D1)", () => {
+  it("enrols with a verified TOTP, then requires the code (or a backup code) at sign-in", async () => {
+    const password = "averylongpassword123";
+    const signUp = await provisioningAuthForEnv(testEnv()).api.signUpEmail({
+      body: { email: "owner@example.com", name: "Owner", password },
+      returnHeaders: true,
+    });
+    const sessionCookie = signUp.headers
+      .getSetCookie()
+      .map((entry) => entry.split(";")[0])
+      .join("; ");
+
+    // 1. Enable: returns the TOTP URI + backup codes but is NOT active yet.
+    const enable = await post(
+      "/api/auth/two-factor/enable",
+      { password },
+      sessionCookie,
+    );
+    expect(enable.status).toBe(200);
+    const enabled = await enable.json<{
+      totpURI: string;
+      backupCodes: string[];
+    }>();
+    const secret = new URL(enabled.totpURI).searchParams.get("secret");
+    expect(secret).toBeTruthy();
+    expect(enabled.backupCodes.length).toBeGreaterThan(0);
+    expect(await count("user", "twoFactorEnabled = 1")).toBe(0);
+
+    // 2. Verify a real code → active.
+    const verify = await post(
+      "/api/auth/two-factor/verify-totp",
+      { code: await totp(secret as string) },
+      sessionCookie,
+    );
+    expect(verify.status).toBe(200);
+    expect(await count("user", "twoFactorEnabled = 1")).toBe(1);
+
+    // 3. Fresh sign-in: no session, twoFactorRedirect instead.
+    const signIn = await post("/api/auth/sign-in/email", {
+      email: "owner@example.com",
+      password,
+    });
+    expect(signIn.status).toBe(200);
+    await expect(signIn.json()).resolves.toMatchObject({
+      twoFactorRedirect: true,
+    });
+    const pendingCookie = cookiesFrom(signIn);
+    expect(pendingCookie).toMatch(/two_factor/);
+
+    // Wrong code is refused; the right TOTP completes the sign-in.
+    const wrong = await post(
+      "/api/auth/two-factor/verify-totp",
+      { code: "000000" },
+      pendingCookie,
+    );
+    expect(wrong.status).toBeGreaterThanOrEqual(400);
+
+    const right = await post(
+      "/api/auth/two-factor/verify-totp",
+      { code: await totp(secret as string) },
+      pendingCookie,
+    );
+    expect(right.status).toBe(200);
+    const signedInCookie = cookiesFrom(right);
+    expect(signedInCookie).toMatch(/session_token/);
+
+    const settings = await SELF.fetch("http://localhost:8787/api/settings", {
+      headers: { cookie: signedInCookie },
+    });
+    expect(settings.status).toBe(200);
+
+    // 4. Backup codes also complete a challenge, once.
+    const signInAgain = await post("/api/auth/sign-in/email", {
+      email: "owner@example.com",
+      password,
+    });
+    const pendingAgain = cookiesFrom(signInAgain);
+    const backup = await post(
+      "/api/auth/two-factor/verify-backup-code",
+      { code: enabled.backupCodes[0] },
+      pendingAgain,
+    );
+    expect(backup.status).toBe(200);
+    expect(cookiesFrom(backup)).toMatch(/session_token/);
+  });
+});

--- a/test/settings-view.test.tsx
+++ b/test/settings-view.test.tsx
@@ -47,6 +47,9 @@ describe("SettingsView", () => {
         onRequestPasswordReset={vi.fn()}
         onEnable2FA={vi.fn()}
         onDisable2FA={vi.fn()}
+        twoFactorSetup={null}
+        onVerify2FA={vi.fn()}
+        onCancel2FASetup={vi.fn()}
         onAddPasskey={vi.fn()}
         onRevokeSession={vi.fn()}
         onRevokeOtherSessions={vi.fn()}
@@ -99,6 +102,9 @@ describe("SettingsView", () => {
         onRequestPasswordReset={vi.fn()}
         onEnable2FA={vi.fn()}
         onDisable2FA={vi.fn()}
+        twoFactorSetup={null}
+        onVerify2FA={vi.fn()}
+        onCancel2FASetup={vi.fn()}
         onAddPasskey={vi.fn()}
         onRevokeSession={vi.fn()}
         onRevokeOtherSessions={vi.fn()}
@@ -108,5 +114,60 @@ describe("SettingsView", () => {
 
     expect(html).toContain("Disable 2FA");
     expect(html).not.toContain("Enable 2FA");
+  });
+
+  it("shows the enrolment step (QR, manual key, backup codes, verify) while 2FA setup is pending", () => {
+    const html = renderToStaticMarkup(
+      <SettingsView
+        profile={{
+          id: "user-1",
+          email: "member@example.com",
+          name: "Member Person",
+          image: null,
+          role: "user",
+          twoFactorEnabled: false,
+          households: [],
+        }}
+        sessions={[]}
+        isLoading={false}
+        error={null}
+        formState={{
+          name: "Member Person",
+          image: "",
+          currentPassword: "",
+          newPassword: "",
+          forgotPasswordEmail: "",
+          twoFactorPassword: "",
+          twoFactorCode: "",
+          twoFactorBackupCode: "",
+          passkeyName: "",
+        }}
+        onFormChange={vi.fn()}
+        onUpdateProfile={vi.fn()}
+        onChangePassword={vi.fn()}
+        onRequestPasswordReset={vi.fn()}
+        onEnable2FA={vi.fn()}
+        onDisable2FA={vi.fn()}
+        twoFactorSetup={{
+          totpURI:
+            "otpauth://totp/Mi%20Casa:member@example.com?secret=JBSWY3DPEHPK3PXP",
+          qrDataUrl: "data:image/png;base64,AAAA",
+          secret: "JBSWY3DPEHPK3PXP",
+          backupCodes: ["aaaa-bbbb", "cccc-dddd"],
+        }}
+        onVerify2FA={vi.fn()}
+        onCancel2FASetup={vi.fn()}
+        onAddPasskey={vi.fn()}
+        onRevokeSession={vi.fn()}
+        onRevokeOtherSessions={vi.fn()}
+        isSaving={false}
+      />,
+    );
+
+    expect(html).toContain("Authenticator QR code");
+    expect(html).toContain("JBSWY3DPEHPK3PXP");
+    expect(html).toContain("aaaa-bbbb");
+    expect(html).toContain("Verify and enable");
+    expect(html).not.toContain(">Enable 2FA<");
   });
 });

--- a/test/two-factor-page.test.tsx
+++ b/test/two-factor-page.test.tsx
@@ -1,0 +1,19 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { TwoFactorPage } from "../src/client/components/TwoFactorPage";
+
+describe("TwoFactorPage", () => {
+  it("asks for the authenticator code, offers backup codes and a way back", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter initialEntries={["/two-factor"]}>
+        <TwoFactorPage onVerified={vi.fn()} />
+      </MemoryRouter>,
+    );
+    expect(html).toContain("Authenticator code");
+    expect(html).toContain("Use a backup code");
+    expect(html).toContain("Trust this device");
+    expect(html).toContain('href="/login"');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #95.

"Enable 2FA" called `twoFactor.enable` and immediately showed "enabled", but Better Auth only activates 2FA after a code is verified — so `twoFactorEnabled` stayed `false` (false sense of security), and a user who *did* get 2FA active had no challenge page at login (lockout).

- **Settings enrolment step**: enable → QR code (`qrcode`), manual key, backup codes, then **Verify and enable** (`twoFactor.verifyTotp`) before it is active; cancel path.
- **`/two-factor` challenge page**: authenticator code or backup code, "trust this device" toggle; the login page navigates there when sign-in returns `twoFactorRedirect`; the auth client's hard window redirect is disabled in favour of router navigation.
- Route exclusions updated for `two-factor`.

## Tests

- Component: challenge page renders code/backup/trust controls; settings enrolment step renders QR, manual key, backup codes and the verify button (and hides the old "Enable 2FA").
- **`test/integration/two-factor.test.ts`** (real D1 via `SELF`, with an RFC 6238 TOTP computed in the test from the returned secret): enable → not active → verify TOTP → active → fresh sign-in returns `twoFactorRedirect` with no session → wrong code rejected → right code issues the session → settings reachable → a backup code also completes a challenge.

`npm run ci` green: 193 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)