### PR TITLE
ci: make production migrations/deploys uninterruptible and consistent with the docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -11,9 +11,11 @@ permissions:
   contents: read
   pull-requests: write
 
+# A superseded push may cancel validation, but never a migration/deploy that
+# has already started against the shared preview database.
 concurrency:
   group: preview-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   deploy-preview:
@@ -80,7 +82,14 @@ jobs:
         if: env.HAS_CLOUDFLARE_API_TOKEN == 'true' && env.HAS_CLOUDFLARE_ACCOUNT_ID == 'true' && env.HAS_D1_DATABASE_ID_PREVIEW == 'true'
         env:
           D1_DATABASE_ID_PREVIEW: ${{ secrets.D1_DATABASE_ID_PREVIEW }}
-        run: sed -i 's/PLACEHOLDER_PREVIEW_D1_DATABASE_ID/'"$D1_DATABASE_ID_PREVIEW"'/' wrangler.jsonc
+        run: |
+          set -euo pipefail
+          grep -q PLACEHOLDER_PREVIEW_D1_DATABASE_ID wrangler.jsonc || {
+            echo "::error::wrangler.jsonc no longer contains PLACEHOLDER_PREVIEW_D1_DATABASE_ID"; exit 1; }
+          sed -i 's/PLACEHOLDER_PREVIEW_D1_DATABASE_ID/'"${D1_DATABASE_ID_PREVIEW}"'/' wrangler.jsonc
+          if grep -q PLACEHOLDER_PREVIEW_D1_DATABASE_ID wrangler.jsonc; then
+            echo "::error::Placeholder injection failed"; exit 1
+          fi
 
       - name: Apply preview D1 migrations
         if: env.HAS_CLOUDFLARE_API_TOKEN == 'true' && env.HAS_CLOUDFLARE_ACCOUNT_ID == 'true' && env.HAS_D1_DATABASE_ID_PREVIEW == 'true'

--- a/.github/workflows/production-d1-migrate.yml
+++ b/.github/workflows/production-d1-migrate.yml
@@ -1,5 +1,8 @@
 name: Production D1 Migrate
 
+# Manual/recovery path: normally migrations are applied by "Production Deploy"
+# on every push to main. Use this to re-apply or inspect migrations for a
+# specific ref (e.g. after a failed deploy) behind the protected environment.
 on:
   workflow_dispatch:
     inputs:
@@ -15,7 +18,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: production-d1-migrate
+  group: production-d1
   cancel-in-progress: false
 
 jobs:
@@ -39,14 +42,29 @@ jobs:
         run: npm ci
 
       - name: Record migration request
+        env:
+          MIGRATE_REF: ${{ inputs.ref }}
+          MIGRATE_REASON: ${{ inputs.reason }}
         run: |
-          echo "Running production migrations for ref: ${{ inputs.ref }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "Reason: ${{ inputs.reason }}" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "Running production migrations for ref: ${MIGRATE_REF}"
+            echo "Reason: ${MIGRATE_REASON}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Inject production D1 database ID into Wrangler config
         env:
           D1_DATABASE_ID_PRODUCTION: ${{ secrets.D1_DATABASE_ID_PRODUCTION }}
-        run: sed -i 's/PLACEHOLDER_PRODUCTION_D1_DATABASE_ID/'"$D1_DATABASE_ID_PRODUCTION"'/' wrangler.jsonc
+        run: |
+          set -euo pipefail
+          if [ -z "${D1_DATABASE_ID_PRODUCTION}" ]; then
+            echo "::error::Secret D1_DATABASE_ID_PRODUCTION is not set"; exit 1
+          fi
+          grep -q PLACEHOLDER_PRODUCTION_D1_DATABASE_ID wrangler.jsonc || {
+            echo "::error::wrangler.jsonc no longer contains PLACEHOLDER_PRODUCTION_D1_DATABASE_ID"; exit 1; }
+          sed -i 's/PLACEHOLDER_PRODUCTION_D1_DATABASE_ID/'"${D1_DATABASE_ID_PRODUCTION}"'/' wrangler.jsonc
+          if grep -q PLACEHOLDER_PRODUCTION_D1_DATABASE_ID wrangler.jsonc; then
+            echo "::error::Placeholder injection failed"; exit 1
+          fi
 
       - name: Apply production D1 migrations
         env:

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -8,13 +8,19 @@ on:
 permissions:
   contents: read
 
+# Migrations and deploys must never be interrupted half-way (schema N+1 with
+# worker N live). Queue runs instead of cancelling, and share the group with the
+# manual "Production D1 Migrate" workflow so two migration runs never overlap.
 concurrency:
-  group: production-deploy
-  cancel-in-progress: true
+  group: production-d1
+  cancel-in-progress: false
 
 jobs:
   deploy-production:
     runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: ${{ vars.CLOUDFLARE_PRODUCTION_URL }}
 
     steps:
       - uses: actions/checkout@v6
@@ -33,8 +39,21 @@ jobs:
       - name: Inject production D1 database ID into Wrangler config
         env:
           D1_DATABASE_ID_PRODUCTION: ${{ secrets.D1_DATABASE_ID_PRODUCTION }}
-        run: sed -i 's/PLACEHOLDER_PRODUCTION_D1_DATABASE_ID/'"$D1_DATABASE_ID_PRODUCTION"'/' wrangler.jsonc
+        run: |
+          set -euo pipefail
+          if [ -z "${D1_DATABASE_ID_PRODUCTION}" ]; then
+            echo "::error::Secret D1_DATABASE_ID_PRODUCTION is not set"; exit 1
+          fi
+          grep -q PLACEHOLDER_PRODUCTION_D1_DATABASE_ID wrangler.jsonc || {
+            echo "::error::wrangler.jsonc no longer contains PLACEHOLDER_PRODUCTION_D1_DATABASE_ID"; exit 1; }
+          sed -i 's/PLACEHOLDER_PRODUCTION_D1_DATABASE_ID/'"${D1_DATABASE_ID_PRODUCTION}"'/' wrangler.jsonc
+          if grep -q PLACEHOLDER_PRODUCTION_D1_DATABASE_ID wrangler.jsonc; then
+            echo "::error::Placeholder injection failed"; exit 1
+          fi
 
+      # Schema changes are applied right before the matching code ships.
+      # Migrations must therefore be expand/contract-safe: the previous worker
+      # version keeps running against the new schema for a few seconds.
       - name: Apply production D1 migrations
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ The repository now includes a Cloudflare-focused CI/CD baseline for issue #8:
 
 - `CI` validates pull requests and pushes to `main`
 - `Preview Deploy` deploys pull requests to a preview Worker and preview D1 database
-- `Production Deploy` automatically deploys Worker code from `main`
-- `Production D1 Migrate` is a separate, manually approved workflow for production schema changes
+- `Production Deploy` applies pending D1 migrations and deploys the Worker from `main` (queued, never cancelled mid-run)
+- `Production D1 Migrate` is a manual recovery workflow behind a protected environment
 
 See [`docs/ci-cd-architecture.md`](./docs/ci-cd-architecture.md) for the required GitHub secrets, Cloudflare setup, repository variables, environment protection rules, and the production migration workflow.
 

--- a/docs/ci-cd-architecture.md
+++ b/docs/ci-cd-architecture.md
@@ -44,31 +44,25 @@ Fork pull requests do not get preview deploys by default because GitHub does not
 
 File: `.github/workflows/production-deploy.yml`
 
-Runs automatically on pushes to `main`.
+Runs automatically on pushes to `main`, in the `production` GitHub environment (add required reviewers there if you want a manual gate).
 
 Flow:
 
 1. install dependencies
 2. run `npm run ci`
-3. deploy Worker code with `npm run deploy:production`
+3. inject the production D1 id (fails loudly if the secret or placeholder is missing)
+4. **apply production D1 migrations** (`npm run db:apply:production`)
+5. deploy the Worker (`npm run deploy:production`)
 
-This keeps application deployments automatic when `main` is green.
+Migrations are applied immediately before the matching code ships, so they must be **expand/contract-safe**: the previous Worker version keeps running for a few seconds against the new schema. Add columns/tables before code depends on them; only drop or rename once no deployed code references them. Migrations are append-only.
+
+The workflow uses `concurrency: { group: production-d1, cancel-in-progress: false }`: a second push queues instead of cancelling a migration or deploy half-way, and it shares the group with `Production D1 Migrate`, so two migration runs can never overlap.
 
 ### 4. `Production D1 Migrate`
 
 File: `.github/workflows/production-d1-migrate.yml`
 
-Runs only through `workflow_dispatch` and targets the protected GitHub environment `production-migrations`.
-
-Flow:
-
-1. choose the git ref to migrate
-2. require environment approval in GitHub
-3. install dependencies
-4. run `npm run db:apply:production`
-5. list production migrations afterward for audit visibility
-
-This is the explicit production schema step required by issue #8.
+Manual recovery path (`workflow_dispatch`) behind the protected `production-migrations` environment. Normal releases do **not** need it — `Production Deploy` applies migrations. Use it to re-apply migrations for a specific ref after a failed deploy, or to list the applied migrations for an audit. It shares the `production-d1` concurrency group.
 
 ## Wrangler environment model
 
@@ -160,18 +154,15 @@ Recommended settings:
 
 ## D1 rollout guidance
 
-Production app deploys and production D1 migrations are intentionally separate.
+Merging to `main` applies pending migrations and then deploys the Worker, in that order, in one queued run.
 
-Use this operating model:
+For schema changes, always use expand/contract rollouts:
 
-1. merge to `main`
-2. let `Production Deploy` ship the Worker code automatically
-3. review the release and run `Production D1 Migrate` when a schema change is intended
+- additive columns/tables/indexes in one PR, with code that tolerates both shapes
+- backfills as idempotent statements
+- cleanup and destructive changes (drop/rename) only in a later PR, after compatible code is live
 
-For schema changes, prefer backward-compatible rollouts:
-
-- additive columns/tables before code depends on them
-- cleanup and destructive changes only after compatible code is already live
+If a migration fails, the Worker is **not** deployed; fix forward with a new migration and re-run via a new push or `Production D1 Migrate`.
 
 ## Local commands
 


### PR DESCRIPTION
## Summary

Closes #89.

The docs said production migrations were approval-gated, but `Production Deploy` applied them on every push with `cancel-in-progress: true` (a second push could cancel between "schema migrated" and "worker deployed", or mid-migration), there was no shared concurrency with the manual migrate workflow, and that workflow interpolated `${{ inputs.reason }}` straight into a shell step.

Decision: keep **migrate-then-deploy on push** (this is how the repo is actually operated), and make it safe and honest:

- `production-deploy.yml`: `concurrency: { group: production-d1, cancel-in-progress: false }` (queued, shared with the manual workflow), GitHub `environment: production` (add required reviewers there if you ever want a gate), injection step fails loudly if the secret or placeholder is missing / replacement didn't happen.
- `production-d1-migrate.yml`: repositioned as the manual recovery path, same concurrency group, inputs passed via `env:` (no script injection), guarded injection.
- `preview-deploy.yml`: `cancel-in-progress: false` (a cancelled run mid-migration would poison the shared preview DB), guarded injection.
- `ci.yml`: `permissions: contents: read`.
- `docs/ci-cd-architecture.md` + README now describe the real flow and the expand/contract rules it requires.

No code changes; `npm run ci` unaffected (193 tests). YAML parsed OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)