### PR TITLE
fix: JSON error responses everywhere, UNIQUE violations as 409, atomic quarantine release

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { cors } from "hono/cors";
 import { authForEnv } from "./server/auth/auth";
 import { loadAuthSession } from "./server/auth/middleware";
 import { handleIncomingEmail } from "./server/email/handler";
+import { handleApiError } from "./server/http/errors";
 import { purgeExpiredMessages } from "./server/jobs/retention";
 import { adminRoutes } from "./server/routes/admin";
 import { healthRoutes } from "./server/routes/health";
@@ -78,6 +79,9 @@ app.route("/api/setup", setupRoutes);
 app.get("*", async (c) => {
   return c.env.ASSETS.fetch(c.req.raw);
 });
+
+app.notFound((c) => c.json({ error: "Not found" }, 404));
+app.onError(handleApiError);
 
 const worker: ExportedHandler<Env> = {
   fetch(request, env, ctx) {

--- a/src/server/db/errors.ts
+++ b/src/server/db/errors.ts
@@ -1,0 +1,54 @@
+/**
+ * Drizzle wraps D1 errors (DrizzleQueryError → cause → D1_ERROR → cause …).
+ * Walk the chain to the innermost Error.
+ */
+export function unwrapDatabaseError(error: unknown): unknown {
+  if (!(error instanceof Error)) {
+    return error;
+  }
+
+  let current: Error = error;
+  const seen = new Set<Error>();
+
+  while (current.cause instanceof Error && !seen.has(current)) {
+    seen.add(current);
+    current = current.cause;
+  }
+
+  return current;
+}
+
+function messagesInChain(error: unknown): string[] {
+  const messages: string[] = [];
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    const message = (current as { message?: unknown }).message;
+    if (typeof message === "string") {
+      messages.push(message);
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+
+  return messages;
+}
+
+/** True when any error in the chain is a SQLite UNIQUE constraint violation. */
+export function isUniqueViolation(error: unknown): boolean {
+  return messagesInChain(error).some((message) =>
+    /UNIQUE constraint failed/i.test(message),
+  );
+}
+
+/** Columns named in the first UNIQUE violation message, e.g. "households.slug". */
+export function uniqueViolationTarget(error: unknown): string | null {
+  for (const message of messagesInChain(error)) {
+    const match = message.match(/UNIQUE constraint failed: ([^\s(:]+)/i);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+  return null;
+}

--- a/src/server/db/repositories/messages.ts
+++ b/src/server/db/repositories/messages.ts
@@ -1,6 +1,11 @@
-import { sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 import { dbForDatabase } from "../client";
+import { unwrapDatabaseError } from "../errors";
+import {
+  messages as messagesTable,
+  quarantineMessages as quarantineTable,
+} from "../schema";
 import type {
   ClassificationResult,
   InboxMessageRow,
@@ -48,20 +53,6 @@ function isDuplicateMessageError(
       `UNIQUE constraint failed: ${tableName}.household_id, ${tableName}.message_id`,
     )
   );
-}
-
-function unwrapDatabaseError(error: unknown): unknown {
-  if (!(error instanceof Error)) {
-    return error;
-  }
-
-  let current: unknown = error;
-
-  while (current instanceof Error && current.cause instanceof Error) {
-    current = current.cause;
-  }
-
-  return current;
 }
 
 export async function insertMessage(
@@ -264,6 +255,7 @@ type QuarantineMessageRecord = {
   raw_size: number;
   received_at: string;
   delete_after: string;
+  date_header: string | null;
   reviewed_at: string | null;
 };
 
@@ -275,7 +267,7 @@ async function findQuarantineMessageRecord(
   return dbForDatabase(db).get<QuarantineMessageRecord>(sql`
     SELECT id, household_id, message_id, envelope_from, envelope_to, from_header, subject,
             text_body, extracted_code, quarantine_reason, raw_size,
-            received_at, delete_after, reviewed_at
+            received_at, delete_after, date_header, reviewed_at
     FROM quarantine_messages
     WHERE household_id = ${householdId} AND id = ${messageId}
     LIMIT 1
@@ -308,18 +300,42 @@ export async function reviewQuarantineMessage(
       );
     }
 
-    await database.run(sql`
-      INSERT INTO messages (
-        id, household_id, message_id, provider_id, envelope_from, envelope_to, from_header, subject,
-        text_body, extracted_code, status, classification_reason, raw_size, received_at, delete_after
-      ) VALUES (
-        ${crypto.randomUUID()}, ${record.household_id}, ${record.message_id}, ${review.providerId}, ${record.envelope_from},
-        ${record.envelope_to}, ${record.from_header}, ${record.subject}, ${record.text_body},
-        ${record.extracted_code}, ${"new"},
-        ${`Released from quarantine by owner review. Original reason: ${record.quarantine_reason}`},
-        ${record.raw_size}, ${record.received_at}, ${record.delete_after}
-      )
-    `);
+    // Insert the released copy and mark the quarantine row reviewed in one
+    // atomic batch. If a message with the same Message-ID already exists in
+    // this household (e.g. a duplicate delivery that was classified after a
+    // rule change), keep the existing row instead of failing.
+    await database.batch([
+      database
+        .insert(messagesTable)
+        .values({
+          id: crypto.randomUUID(),
+          householdId: record.household_id,
+          messageId: record.message_id,
+          providerId: review.providerId,
+          envelopeFrom: record.envelope_from,
+          envelopeTo: record.envelope_to,
+          fromHeader: record.from_header,
+          subject: record.subject,
+          textBody: record.text_body,
+          extractedCode: record.extracted_code,
+          status: "new",
+          classificationReason: `Released from quarantine by owner review. Original reason: ${record.quarantine_reason}`,
+          rawSize: record.raw_size,
+          dateHeader: record.date_header,
+          receivedAt: record.received_at,
+          deleteAfter: record.delete_after,
+        })
+        .onConflictDoNothing(),
+      database
+        .update(quarantineTable)
+        .set({ reviewedAt })
+        .where(
+          and(
+            eq(quarantineTable.householdId, householdId),
+            eq(quarantineTable.id, messageId),
+          ),
+        ),
+    ]);
 
     const result = await database.get<InboxMessageRow>(sql`
       SELECT messages.id, households.slug AS household_slug, providers.provider_key, providers.display_name AS provider_display_name,
@@ -334,6 +350,7 @@ export async function reviewQuarantineMessage(
     `);
 
     releasedMessage = result ?? null;
+    return { reviewedAt, releasedMessage };
   }
 
   await database.run(sql`

--- a/src/server/http/errors.ts
+++ b/src/server/http/errors.ts
@@ -1,0 +1,45 @@
+import type { Context } from "hono";
+import { HTTPException } from "hono/http-exception";
+
+import { isUniqueViolation, uniqueViolationTarget } from "../db/errors";
+
+/**
+ * Last-resort error handler for the API: every failure becomes a JSON
+ * `{ error }` body (the client expects that shape), UNIQUE violations map to
+ * 409 instead of 500, and unexpected errors are logged with request context.
+ */
+export function handleApiError(error: unknown, c: Context): Response {
+  if (error instanceof HTTPException) {
+    return c.json({ error: error.message || "Request failed" }, error.status);
+  }
+
+  if (isUniqueViolation(error)) {
+    const target = uniqueViolationTarget(error);
+    return c.json(
+      {
+        error: target
+          ? `A record with the same ${describeUniqueTarget(target)} already exists`
+          : "A record with the same values already exists",
+      },
+      409,
+    );
+  }
+
+  console.error(
+    JSON.stringify({
+      event: "unhandled_error",
+      method: c.req.method,
+      path: c.req.path,
+      ray: c.req.header("cf-ray") ?? null,
+      error: error instanceof Error ? error.message : String(error),
+    }),
+  );
+
+  return c.json({ error: "Internal error" }, 500);
+}
+
+function describeUniqueTarget(target: string): string {
+  // "households.slug" → "slug"; "sender_rules.household_id, …" → first column
+  const column = target.split(".").at(-1) ?? target;
+  return column.replace(/_/g, " ");
+}

--- a/src/server/routes/setup.ts
+++ b/src/server/routes/setup.ts
@@ -2,6 +2,7 @@ import { isAPIError } from "better-auth/api";
 import { Hono } from "hono";
 
 import { provisioningAuthForEnv } from "../auth/auth";
+import { isUniqueViolation } from "../db/errors";
 import {
   createHousehold,
   listHouseholdsForUser,
@@ -44,23 +45,6 @@ function mapInstallationStatus(
     status: row.status,
     ownerEmail: row.owner_email,
   };
-}
-
-function isUniqueConstraintError(error: unknown): boolean {
-  const seen = new Set<unknown>();
-  let current: unknown = error;
-  while (current && typeof current === "object" && !seen.has(current)) {
-    seen.add(current);
-    const message = (current as { message?: unknown }).message;
-    if (
-      typeof message === "string" &&
-      /UNIQUE constraint failed/.test(message)
-    ) {
-      return true;
-    }
-    current = (current as { cause?: unknown }).cause;
-  }
-  return false;
 }
 
 function normalizeSlug(value: string | undefined) {
@@ -263,7 +247,7 @@ setupRoutes.post("/complete", rateLimit(RATE_LIMITS.setup), async (c) => {
 
     await resetInstallationSetup(c.env.DB);
 
-    if (isUniqueConstraintError(error)) {
+    if (isUniqueViolation(error)) {
       return c.json(
         { error: "A household with that slug already exists" },
         409,

--- a/test/db-errors.test.ts
+++ b/test/db-errors.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isUniqueViolation,
+  uniqueViolationTarget,
+  unwrapDatabaseError,
+} from "../src/server/db/errors";
+
+describe("database error helpers", () => {
+  it("recognises UNIQUE violations anywhere in the cause chain", () => {
+    const inner = new Error(
+      "D1_ERROR: UNIQUE constraint failed: households.slug: SQLITE_CONSTRAINT",
+    );
+    const wrapped = new Error("Failed query: insert …", { cause: inner });
+
+    expect(isUniqueViolation(wrapped)).toBe(true);
+    expect(uniqueViolationTarget(wrapped)).toBe("households.slug");
+    expect(unwrapDatabaseError(wrapped)).toBe(inner);
+    expect(isUniqueViolation(new Error("database unavailable"))).toBe(false);
+    expect(isUniqueViolation("nope")).toBe(false);
+  });
+});

--- a/test/integration/error-handling.test.ts
+++ b/test/integration/error-handling.test.ts
@@ -1,0 +1,153 @@
+import { SELF } from "cloudflare:test";
+import { provisioningAuthForEnv } from "@server/auth/auth";
+import { createHousehold } from "@server/db/repositories/households";
+import {
+  insertMessage,
+  insertQuarantineMessage,
+  listMessagesForProvider,
+  listQuarantineMessages,
+  reviewQuarantineMessage,
+} from "@server/db/repositories/messages";
+import { createProvider } from "@server/db/repositories/provider-rules";
+import type { ParsedIncomingEmail } from "@server/db/types";
+import { describe, expect, it } from "vitest";
+
+import { count, db, insertHousehold, testEnv } from "./helpers";
+
+async function ownerSession() {
+  const result = await provisioningAuthForEnv(testEnv()).api.signUpEmail({
+    body: {
+      email: "owner@example.com",
+      name: "Owner",
+      password: "averylongpassword123",
+    },
+    returnHeaders: true,
+  });
+  const cookie = result.headers
+    .getSetCookie()
+    .map((entry: string) => entry.split(";")[0])
+    .join("; ");
+  await createHousehold(db, {
+    slug: "casa",
+    displayName: "Casa",
+    ownerUserId: result.response.user.id,
+  });
+  return cookie;
+}
+
+function parsedEmail(messageId: string): ParsedIncomingEmail {
+  return {
+    envelopeFrom: "info@netflix.com",
+    envelopeTo: "casa@example.com",
+    householdSlug: "casa",
+    fromHeader: "Netflix <info@netflix.com>",
+    subject: "Code",
+    messageId,
+    dateHeader: null,
+    textBody: "Your verification code is 123456",
+    rawSize: 100,
+  };
+}
+
+describe("API error handling", () => {
+  it("returns JSON 409 for a duplicate sender rule instead of a text 500", async () => {
+    const cookie = await ownerSession();
+    const household = (await db
+      .prepare("SELECT id FROM households WHERE slug = 'casa'")
+      .first<{ id: string }>()) as { id: string };
+    const provider = await createProvider(
+      db,
+      household.id,
+      "netflix",
+      "Netflix",
+    );
+    const body = JSON.stringify({
+      providerId: provider.id,
+      matchType: "domain",
+      matchValue: "netflix.com",
+    });
+    const post = () =>
+      SELF.fetch("http://localhost:8787/api/admin/casa/provider-rules", {
+        method: "POST",
+        headers: { cookie, "content-type": "application/json" },
+        body,
+      });
+
+    expect((await post()).status).toBe(201);
+    const duplicate = await post();
+    expect(duplicate.status).toBe(409);
+    expect(duplicate.headers.get("content-type")).toMatch(/application\/json/);
+    await expect(duplicate.json()).resolves.toMatchObject({
+      error: expect.stringMatching(/already exists/),
+    });
+  });
+
+  it("answers unknown API routes with JSON 404", async () => {
+    const response = await SELF.fetch(
+      "http://localhost:8787/api/does-not-exist",
+      {
+        method: "POST",
+      },
+    );
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Not found" });
+  });
+});
+
+describe("quarantine release", () => {
+  it("is atomic and tolerates an already-classified copy of the same Message-ID", async () => {
+    const household = await insertHousehold({ slug: "casa" });
+    const provider = await createProvider(
+      db,
+      household.id,
+      "netflix",
+      "Netflix",
+    );
+    const matched = {
+      kind: "matched" as const,
+      householdId: household.id,
+      householdSlug: "casa",
+      providerId: provider.id,
+      providerKey: "netflix",
+      code: "123456",
+      reason: "matched",
+    };
+
+    // Same Message-ID stored once as a classified message and once quarantined.
+    await insertMessage(
+      db,
+      parsedEmail("<dup@test>"),
+      household.id,
+      provider.id,
+      matched,
+    );
+    const quarantined = await insertQuarantineMessage(
+      db,
+      parsedEmail("<dup@test>"),
+      household.id,
+      {
+        kind: "quarantine",
+        householdId: household.id,
+        reason: "no rule",
+        code: null,
+      },
+    );
+
+    const result = await reviewQuarantineMessage(
+      db,
+      household.id,
+      quarantined.id,
+      {
+        action: "release",
+        providerId: provider.id,
+      },
+    );
+
+    expect(result?.releasedMessage).toMatchObject({ provider_key: "netflix" });
+    expect(await count("messages")).toBe(1);
+    expect(await listQuarantineMessages(db, household.id)).toHaveLength(0);
+    expect(
+      await listMessagesForProvider(db, household.id, "netflix"),
+    ).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #101.

- `src/server/db/errors.ts`: shared `unwrapDatabaseError` / `isUniqueViolation` / `uniqueViolationTarget` (walks the Drizzle → D1 cause chain); `messages.ts` and `setup.ts` reuse them.
- `src/server/http/errors.ts` + `app.onError` / `app.notFound`: every unhandled error becomes a JSON `{ error }` body (what `fetchJson` expects); **UNIQUE violations → 409** with a readable message (duplicate sender rule, slug/provider-key races); `HTTPException`s keep their status; unexpected errors are logged as `unhandled_error` with method/path/`cf-ray`. Unknown API routes → JSON 404.
- Quarantine **release** now inserts the released copy and marks the quarantine row reviewed in one atomic batch, and tolerates an already-classified copy of the same Message-ID (`onConflictDoNothing`) instead of 500-ing and leaving the row unreviewed.

## Tests
- Unit: error helpers recognise UNIQUE violations anywhere in the cause chain and extract the target.
- D1 (via `SELF`): duplicate `POST /provider-rules` → JSON 409; unknown API route → JSON 404; release with a pre-existing classified duplicate → released, single message row, quarantine cleared.

`npm run ci` green: 197 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)