### PR TITLE
fix: compare invitation expiry in ISO time and reject expired invitations on lookup/accept

### DIFF
--- a/src/server/db/repositories/invitations.ts
+++ b/src/server/db/repositories/invitations.ts
@@ -260,7 +260,27 @@ export async function acceptInvitation(
   `);
 }
 
-export async function refreshExpiredInvitations(db: D1Database) {
+/** True when the invitation's expiry (ISO-8601 UTC) is in the past. */
+export function isInvitationExpired(
+  invitation: Pick<InvitationRecord, "expiresAt">,
+  now: Date = new Date(),
+): boolean {
+  const expiresAt = new Date(invitation.expiresAt).getTime();
+  return Number.isNaN(expiresAt) || expiresAt <= now.getTime();
+}
+
+/**
+ * Marks pending invitations whose expiry has passed as expired.
+ *
+ * `expires_at` is written by the app as ISO-8601 UTC ("…T10:00:00.000Z").
+ * SQLite's CURRENT_TIMESTAMP is "YYYY-MM-DD HH:MM:SS"; comparing the two
+ * lexically is wrong ('T' sorts after ' '), so the comparison value must be
+ * an ISO string produced in JS.
+ */
+export async function refreshExpiredInvitations(
+  db: D1Database,
+  now: Date = new Date(),
+) {
   await dbForDatabase(db)
     .update(householdInvitations)
     .set({
@@ -270,7 +290,7 @@ export async function refreshExpiredInvitations(db: D1Database) {
     .where(
       and(
         eq(householdInvitations.status, "pending"),
-        sql`${householdInvitations.expiresAt} < CURRENT_TIMESTAMP`,
+        sql`${householdInvitations.expiresAt} <= ${now.toISOString()}`,
       ),
     );
 }

--- a/src/server/routes/invitations.ts
+++ b/src/server/routes/invitations.ts
@@ -7,6 +7,7 @@ import { getHouseholdById } from "../db/repositories/households";
 import {
   acceptInvitation,
   getInvitationByTokenHash,
+  isInvitationExpired,
   refreshExpiredInvitations,
 } from "../db/repositories/invitations";
 import { deleteUserById, findUserByEmail } from "../db/repositories/users";
@@ -43,6 +44,10 @@ invitationRoutes.get("/:token", async (c) => {
 
   if (!invitation || invitation.status !== "pending") {
     return c.json({ error: "Invitation not found or no longer valid" }, 404);
+  }
+
+  if (isInvitationExpired(invitation)) {
+    return c.json({ error: "This invitation has expired" }, 410);
   }
 
   const currentUser = c.get("user");
@@ -82,6 +87,10 @@ invitationRoutes.post("/:token/accept", async (c) => {
 
   if (!invitation || invitation.status !== "pending") {
     return c.json({ error: "Invitation not found or no longer valid" }, 404);
+  }
+
+  if (isInvitationExpired(invitation)) {
+    return c.json({ error: "This invitation has expired" }, 410);
   }
 
   const auth = provisioningAuthForEnv(c.env);

--- a/test/inbox-routes.test.ts
+++ b/test/inbox-routes.test.ts
@@ -977,7 +977,7 @@ describe("worker routes", () => {
         status: "pending",
         invitedByUserId: "owner-home",
         acceptedByUserId: null,
-        expiresAt: "2026-05-31T12:00:00.000Z",
+        expiresAt: "2099-05-31T12:00:00.000Z",
         acceptedAt: null,
         cancelledAt: null,
         createdAt: "2026-05-10T12:00:00.000Z",

--- a/test/integration/invitation-expiry.test.ts
+++ b/test/integration/invitation-expiry.test.ts
@@ -1,0 +1,83 @@
+import { SELF } from "cloudflare:test";
+import { createHousehold } from "@server/db/repositories/households";
+import {
+  createHouseholdInvitation,
+  getInvitationByTokenHash,
+  isInvitationExpired,
+  refreshExpiredInvitations,
+} from "@server/db/repositories/invitations";
+import { hashInvitationToken } from "@server/security/tokens";
+import { describe, expect, it } from "vitest";
+
+import { count, createTestUser, db } from "./helpers";
+
+async function seed(expiresAt: Date, token = "tok") {
+  const owner = await createTestUser({ email: "owner@example.com" });
+  const household = await createHousehold(db, {
+    slug: "casa",
+    displayName: "Casa",
+    ownerUserId: owner.id,
+  });
+  await createHouseholdInvitation(db, {
+    householdId: household?.id ?? "",
+    email: "kid@example.com",
+    name: "Kid",
+    role: "member",
+    tokenHash: await hashInvitationToken(token),
+    invitedByUserId: owner.id,
+    expiresAt: expiresAt.toISOString(),
+    providerIds: [],
+  });
+  return token;
+}
+
+describe("invitation expiry", () => {
+  it("treats an invitation that expired earlier today as expired (not tomorrow)", async () => {
+    // The old comparison against CURRENT_TIMESTAMP kept same-day ISO values
+    // 'pending' until the next calendar day.
+    const now = new Date("2026-08-20T19:00:00.000Z");
+    const token = await seed(new Date("2026-08-20T10:00:00.000Z"));
+
+    const invitation = await getInvitationByTokenHash(
+      db,
+      await hashInvitationToken(token),
+    );
+    expect(invitation && isInvitationExpired(invitation, now)).toBe(true);
+
+    await refreshExpiredInvitations(db, now);
+    expect(await count("household_invitations", "status = 'expired'")).toBe(1);
+  });
+
+  it("keeps a future invitation pending", async () => {
+    const now = new Date("2026-08-20T19:00:00.000Z");
+    const token = await seed(new Date("2026-08-21T10:00:00.000Z"));
+
+    await refreshExpiredInvitations(db, now);
+    const invitation = await getInvitationByTokenHash(
+      db,
+      await hashInvitationToken(token),
+    );
+    expect(invitation?.status).toBe("pending");
+    expect(invitation && isInvitationExpired(invitation, now)).toBe(false);
+  });
+
+  it("refuses to show or accept an expired invitation over the API", async () => {
+    const token = await seed(new Date(Date.now() - 60_000));
+
+    const lookup = await SELF.fetch(
+      `http://localhost:8787/api/invitations/${token}`,
+    );
+    expect([404, 410]).toContain(lookup.status);
+
+    const accept = await SELF.fetch(
+      `http://localhost:8787/api/invitations/${token}/accept`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "Kid", password: "averylongpassword123" }),
+      },
+    );
+    expect([404, 410]).toContain(accept.status);
+    expect(await count("user", "email = 'kid@example.com'")).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #102.

`expires_at` is written as ISO-8601 UTC (`2026-08-27T10:00:00.000Z`) but `refreshExpiredInvitations` compared it lexically with SQLite's `CURRENT_TIMESTAMP` (`2026-08-27 19:00:00`); since `'T'` > `' '`, a same-day value always sorted *after* now, so invitations that expired at 10:00 stayed `pending` until the next calendar day. The accept route never checked expiry at all.

- `refreshExpiredInvitations(db, now = new Date())` compares against a JS ISO string (documented convention: `expires_at` is app-written ISO; never compare with `CURRENT_TIMESTAMP`).
- New `isInvitationExpired(invitation, now)`; `GET /api/invitations/:token` and `POST …/accept` return **410** for an expired token even if the refresh has not run.

Timestamp formats elsewhere (`created_at` defaults) are left as-is; this was the only cross-format comparison in the codebase.

## Tests (real D1)
- An invitation that expired earlier **today** is expired now (the old lexical bug), and `refreshExpiredInvitations` marks it; a future one stays pending.
- Expired token → lookup/accept refused over the API, no account created.
- Route-test fixture moved to a far-future expiry.

`npm run ci` green: 200 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)