### PR TITLE
feat: security headers (CSP, HSTS, X-Frame-Options, nosniff, Referrer/Permissions-Policy) on all responses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { secureHeaders } from "hono/secure-headers";
 
 import { authForEnv } from "./server/auth/auth";
 import { loadAuthSession } from "./server/auth/middleware";
@@ -21,6 +22,40 @@ import {
 } from "./server/security/origin";
 
 const app = new Hono<{ Bindings: Env }>();
+
+// Security headers for every response (API and static assets alike — all
+// requests pass through the Worker, see run_worker_first in wrangler.jsonc).
+// The inbox shows one-time codes, so framing is denied outright. Emotion/MUI
+// inject inline <style> elements, hence 'unsafe-inline' for styles only; the
+// QR code for 2FA enrolment is a data: image.
+app.use(
+  "*",
+  secureHeaders({
+    contentSecurityPolicy: {
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'"],
+      styleSrc: ["'self'", "'unsafe-inline'"],
+      imgSrc: ["'self'", "data:", "https:"],
+      fontSrc: ["'self'", "data:"],
+      connectSrc: ["'self'"],
+      frameAncestors: ["'none'"],
+      baseUri: ["'self'"],
+      formAction: ["'self'"],
+      objectSrc: ["'none'"],
+      upgradeInsecureRequests: [],
+    },
+    strictTransportSecurity: "max-age=63072000; includeSubDomains",
+    xFrameOptions: "DENY",
+    referrerPolicy: "no-referrer",
+    crossOriginEmbedderPolicy: false,
+    permissionsPolicy: {
+      camera: [],
+      microphone: [],
+      geolocation: [],
+      payment: [],
+    },
+  }),
+);
 
 // The SPA is same-origin; credentialed CORS is only granted to APP_URL (and
 // localhost during development). Anything else gets no CORS headers at all.

--- a/test/inbox-routes.test.ts
+++ b/test/inbox-routes.test.ts
@@ -1580,3 +1580,24 @@ describe("cross-origin protections", () => {
     expect(curlLike.status).toBe(201);
   });
 });
+
+describe("security headers", () => {
+  it("sets CSP, frame, sniffing, referrer and HSTS headers on API and SPA responses", async () => {
+    for (const path of ["/api/setup/status", "/", "/casa/inbox"]) {
+      const response = await invokeWorker(path);
+      const csp = response.headers.get("content-security-policy") ?? "";
+      expect(csp, path).toContain("default-src 'self'");
+      expect(csp, path).toContain("frame-ancestors 'none'");
+      expect(csp, path).toContain("img-src 'self' data: https:");
+      expect(csp, path).toContain("script-src 'self'");
+      expect(response.headers.get("x-frame-options"), path).toBe("DENY");
+      expect(response.headers.get("x-content-type-options"), path).toBe(
+        "nosniff",
+      );
+      expect(response.headers.get("referrer-policy"), path).toBe("no-referrer");
+      expect(response.headers.get("strict-transport-security"), path).toContain(
+        "max-age=",
+      );
+    }
+  });
+});

--- a/test/integration/security-headers.test.ts
+++ b/test/integration/security-headers.test.ts
@@ -1,0 +1,15 @@
+import { SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+describe("security headers (workerd)", () => {
+  it("are present on live API responses", async () => {
+    const response = await SELF.fetch("http://localhost:8787/api/health/live");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-security-policy")).toContain(
+      "frame-ancestors 'none'",
+    );
+    expect(response.headers.get("x-frame-options")).toBe("DENY");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(response.headers.get("permissions-policy")).toContain("camera=()");
+  });
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,7 +13,9 @@
     "directory": "./dist/client",
     "binding": "ASSETS",
     "not_found_handling": "single-page-application",
-    "run_worker_first": ["/api/*"]
+    // Every request goes through the Worker so security headers (CSP, HSTS,
+    // X-Frame-Options, …) are applied to the SPA and its assets, not only /api.
+    "run_worker_first": true
   },
   // Local development uses a local D1 file database — the database_id below is ignored.
   "d1_databases": [


### PR DESCRIPTION
## Summary

Closes #99.

The inbox displays one-time codes; there were no security headers on API or SPA responses, and because `run_worker_first` was `["/api/*"]` the Worker could not add any to static assets.

- `wrangler.jsonc`: `run_worker_first: true` — every request passes through the Worker (SPA fallback still via `ASSETS.fetch`), so headers apply to the app shell and assets too.
- `src/index.ts`: `hono/secure-headers` on `*` with a CSP (`default-src/script-src/connect-src 'self'`, `style-src 'self' 'unsafe-inline'` for Emotion/MUI, `img-src 'self' data: https:` for the 2FA QR, `frame-ancestors 'none'`, `object-src 'none'`, `base-uri`/`form-action 'self'`, `upgrade-insecure-requests`), HSTS 2 years incl. subdomains, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`, `Permissions-Policy` denying camera/microphone/geolocation/payment.

## Tests
- Route test: headers present on `/api/*`, `/` and `/casa/inbox` (SPA fallback path through the Worker).
- workerd: live API response carries CSP/XFO/nosniff/Permissions-Policy.
- `wrangler deploy --dry-run --env production` OK with `run_worker_first: true`.

`npm run ci` green: 202 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)