### PR TITLE
fix: harden the setup secret (no oracle after lock, constant-time compare, no owner email in status)

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Add as **encrypted secrets**:
 | Secret | Purpose |
 | --- | --- |
 | `AUTH_SECRET` | Random string used by Better Auth to sign sessions (generate with `openssl rand -base64 32`) |
-| `SETUP_SECRET` | One-time setup passphrase you choose for the initial owner account creation |
+| `SETUP_SECRET` | One-time setup passphrase you choose for the initial owner account creation. Delete it after `/setup` succeeds |
 
 Repeat for the preview Worker (`mi-casa-su-casa-preview`) if you want setup to work in preview environments. Use the preview URL for `APP_URL` in that Worker.
 
@@ -305,6 +305,7 @@ After the first successful deploy:
 1. Visit `https://<your-production-url>/setup`
 2. Enter the `OWNER_EMAIL` and `SETUP_SECRET` you configured
 3. The initial owner account is created and the `/setup` route locks permanently
+4. Remove `SETUP_SECRET` from the Worker's secrets in the Cloudflare dashboard — it was only needed once. The route stays locked (it answers 409 for any secret after setup), so keeping the secret around only adds risk
 
 You're done. Invite family members through the app.
 

--- a/docs/ci-cd-architecture.md
+++ b/docs/ci-cd-architecture.md
@@ -134,7 +134,7 @@ Add as **encrypted secrets**:
 | Secret | Purpose |
 | --- | --- |
 | `AUTH_SECRET` | Random string used by Better Auth to sign sessions (generate with `openssl rand -base64 32`) |
-| `SETUP_SECRET` | One-time setup passphrase for initial owner account creation |
+| `SETUP_SECRET` | One-time setup passphrase for initial owner account creation — delete it from the Worker after `/setup` succeeds |
 
 Repeat for both production (`mi-casa-su-casa`) and preview (`mi-casa-su-casa-preview`) Workers. Use the appropriate URL for `APP_URL` in each.
 

--- a/src/server/routes/setup.ts
+++ b/src/server/routes/setup.ts
@@ -14,6 +14,7 @@ import {
   resetInstallationSetup,
 } from "../db/repositories/installation-state";
 import { deleteUserById, findUserByEmail } from "../db/repositories/users";
+import { secretsEqual } from "../security/compare";
 import { RATE_LIMITS, rateLimit } from "../security/rate-limit";
 
 type SetupPayload = {
@@ -38,12 +39,12 @@ function mapInstallationStatus(
   const isConfigured = Boolean(env.OWNER_EMAIL && env.SETUP_SECRET);
   const needsSetup = isConfigured && row.status !== "complete";
 
+  // Deliberately no owner email here: this endpoint is public.
   return {
     needsSetup,
     setupLocked: row.status === "complete",
     isConfigured,
     status: row.status,
-    ownerEmail: row.owner_email,
   };
 }
 
@@ -57,6 +58,14 @@ setupRoutes.get("/status", async (c) => {
 });
 
 setupRoutes.post("/complete", rateLimit(RATE_LIMITS.setup), async (c) => {
+  // Once setup is complete, every call gets the same answer regardless of
+  // the supplied secret, so the endpoint cannot be used as a secret oracle.
+  const state = await getInstallationState(c.env.DB);
+
+  if (state.status === "complete") {
+    return c.json({ error: "Setup has already been completed" }, 409);
+  }
+
   if (!c.env.OWNER_EMAIL || !c.env.SETUP_SECRET) {
     return c.json(
       {
@@ -95,7 +104,7 @@ setupRoutes.post("/complete", rateLimit(RATE_LIMITS.setup), async (c) => {
   const requestedEmail = normalizeEmail(payload.email);
   const ownerEmail = normalizeEmail(c.env.OWNER_EMAIL);
 
-  if (payload.setupSecret !== c.env.SETUP_SECRET) {
+  if (!(await secretsEqual(payload.setupSecret, c.env.SETUP_SECRET))) {
     return c.json({ error: "Invalid setup secret" }, 403);
   }
 
@@ -117,12 +126,6 @@ setupRoutes.post("/complete", rateLimit(RATE_LIMITS.setup), async (c) => {
       },
       400,
     );
-  }
-
-  const state = await getInstallationState(c.env.DB);
-
-  if (state.status === "complete") {
-    return c.json({ error: "Setup has already been completed" }, 409);
   }
 
   const claimed = await beginInstallationSetup(c.env.DB);

--- a/src/server/security/compare.ts
+++ b/src/server/security/compare.ts
@@ -1,0 +1,19 @@
+/**
+ * Constant-time comparison of two secrets. Both values are hashed first so
+ * the comparison always runs over equal-length buffers and neither the
+ * length nor the position of the first difference leaks through timing.
+ */
+export async function secretsEqual(a: string, b: string): Promise<boolean> {
+  const [da, db] = await Promise.all([digest(a), digest(b)]);
+  let diff = 0;
+  for (let i = 0; i < da.length; i += 1) {
+    diff |= (da[i] ?? 0) ^ (db[i] ?? 0);
+  }
+  return diff === 0;
+}
+
+async function digest(value: string): Promise<Uint8Array> {
+  return new Uint8Array(
+    await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value)),
+  );
+}

--- a/test/integration/setup-route.test.ts
+++ b/test/integration/setup-route.test.ts
@@ -66,4 +66,27 @@ describe("first-run setup (end-to-end against D1)", () => {
     expect(await count("user")).toBe(0);
     expect(await count("households")).toBe(0);
   });
+
+  it("never reveals the owner email publicly and answers identically to any secret once locked", async () => {
+    const before = await (
+      await SELF.fetch("http://localhost:8787/api/setup/status")
+    ).json();
+    expect(before).not.toHaveProperty("ownerEmail");
+
+    expect((await postSetup(setupPayload)).status).toBe(201);
+
+    const after = await (
+      await SELF.fetch("http://localhost:8787/api/setup/status")
+    ).json();
+    expect(after).not.toHaveProperty("ownerEmail");
+
+    const withRightSecret = await postSetup(setupPayload);
+    const withWrongSecret = await postSetup({
+      ...setupPayload,
+      setupSecret: "nope",
+    });
+    expect(withRightSecret.status).toBe(409);
+    expect(withWrongSecret.status).toBe(409);
+    expect(await withRightSecret.text()).toBe(await withWrongSecret.text());
+  });
 });

--- a/test/secrets-compare.test.ts
+++ b/test/secrets-compare.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { secretsEqual } from "../src/server/security/compare";
+
+describe("secretsEqual", () => {
+  it("compares secrets regardless of length differences", async () => {
+    await expect(secretsEqual("correct horse", "correct horse")).resolves.toBe(
+      true,
+    );
+    await expect(secretsEqual("correct horse", "correct horsf")).resolves.toBe(
+      false,
+    );
+    await expect(secretsEqual("short", "a much longer secret")).resolves.toBe(
+      false,
+    );
+    await expect(secretsEqual("", "")).resolves.toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #108.

- `POST /api/setup/complete` now checks the installation state **first** and answers `409` identically for any secret once setup is complete — the endpoint can no longer be used as a secret oracle after lock (it was 403 vs 409 before). The secret is compared in constant time over SHA-256 digests (`security/compare.ts`), so length and first-difference position don't leak through timing.
- `GET /api/setup/status` no longer returns `ownerEmail` to anonymous callers (the client never used it).
- README / docs: delete `SETUP_SECRET` from the Worker after `/setup` succeeds.

## Tests
- Unit: `secretsEqual` (equal, near-miss, different length, empty).
- D1 (`SELF`): status has no `ownerEmail` before/after; after setup, right and wrong secrets get byte-identical 409 responses.

`npm run ci` green: 204 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)