### PR TITLE
fix: one household role vocabulary, role on created households, real inbox address instead of placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Add as **plaintext variables**:
 | --- | --- |
 | `APP_URL` | Full URL of this deployment (e.g. `https://mi-casa-su-casa.example.com`) |
 | `OWNER_EMAIL` | Email address for the initial owner account |
+| `EMAIL_DOMAIN` | Domain of the household inbox addresses (`<slug>@EMAIL_DOMAIN`, e.g. `home.yourdomain.com`). Display only — shown to owners in household settings |
 | `OUTBOUND_EMAIL_FROM` | Sender address for invitation and password-reset emails — must be on a domain enabled for sending in Cloudflare Email Routing. The Worker refuses API requests (503 `misconfigured`) until this, `APP_URL` and `AUTH_SECRET` are set |
 
 Add as **encrypted secrets**:

--- a/docs/ci-cd-architecture.md
+++ b/docs/ci-cd-architecture.md
@@ -127,6 +127,7 @@ Add as **plaintext variables**:
 | --- | --- |
 | `APP_URL` | Full URL of this deployment (e.g. `https://mi-casa-su-casa.example.com`) |
 | `OWNER_EMAIL` | Email address for the initial owner account |
+| `EMAIL_DOMAIN` | Domain of the household inbox addresses (`<slug>@EMAIL_DOMAIN`, e.g. `home.yourdomain.com`). Display only — shown to owners in household settings |
 | `OUTBOUND_EMAIL_FROM` | Sender address for invitation and password-reset emails — must be on a domain enabled for sending in Cloudflare Email Routing. The Worker refuses API requests (503 `misconfigured`) until this, `APP_URL` and `AUTH_SECRET` are set |
 
 Add as **encrypted secrets**:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
       "SETUP_SECRET": {
         "description": "One-time secret required to complete the `/setup` first-run flow. Pick any strong passphrase — it is only used once."
       },
+      "EMAIL_DOMAIN": {
+        "description": "Domain of the household inbox addresses (households receive mail at <slug>@EMAIL_DOMAIN). Used to display the address in household settings."
+      },
       "OUTBOUND_EMAIL_FROM": {
         "description": "Sender address for invitation and password-reset emails. Must be an address on a domain you have enabled for sending in Cloudflare Email Routing."
       }

--- a/src/client/components/HouseholdSettingsView.tsx
+++ b/src/client/components/HouseholdSettingsView.tsx
@@ -83,7 +83,11 @@ export function HouseholdSettingsView({
               <TextField
                 fullWidth
                 label="Household email address"
-                value={household.emailAddress}
+                value={
+                  household.emailAddress ??
+                  "Not configured — set EMAIL_DOMAIN on the Worker"
+                }
+                helperText="Give this address to the services that send verification codes."
                 disabled
               />
               <TextField
@@ -94,12 +98,6 @@ export function HouseholdSettingsView({
                   onFormChange({ displayName: event.target.value })
                 }
                 required
-              />
-              <TextField
-                fullWidth
-                label="Subscription plan"
-                value={household.subscriptionPlan}
-                disabled
               />
               <Box>
                 <Button

--- a/src/client/components/MembersView.tsx
+++ b/src/client/components/MembersView.tsx
@@ -298,12 +298,12 @@ export function MembersView({
                     label="Role"
                     onChange={(e) =>
                       onMemberFormChange({
-                        role: e.target.value as "member" | "admin",
+                        role: e.target.value as "member" | "owner",
                       })
                     }
                   >
                     <MenuItem value="member">Member</MenuItem>
-                    <MenuItem value="admin">Owner</MenuItem>
+                    <MenuItem value="owner">Owner</MenuItem>
                   </Select>
                 </FormControl>
               </Box>
@@ -383,12 +383,12 @@ export function MembersView({
                     label="Role"
                     onChange={(e) =>
                       onInvitationFormChange({
-                        role: e.target.value as "member" | "admin",
+                        role: e.target.value as "member" | "owner",
                       })
                     }
                   >
                     <MenuItem value="member">Member</MenuItem>
-                    <MenuItem value="admin">Owner</MenuItem>
+                    <MenuItem value="owner">Owner</MenuItem>
                   </Select>
                 </FormControl>
                 <FormControl
@@ -514,10 +514,10 @@ export function MembersView({
                           <Chip
                             size="small"
                             label={
-                              invitation.role === "admin" ? "Owner" : "Member"
+                              invitation.role === "owner" ? "Owner" : "Member"
                             }
                             color={
-                              invitation.role === "admin"
+                              invitation.role === "owner"
                                 ? "primary"
                                 : "default"
                             }
@@ -622,7 +622,7 @@ export function MembersView({
                             horizontal: "right",
                           }}
                           badgeContent={
-                            member.role === "admin" ? (
+                            member.role === "owner" ? (
                               <Tooltip title="Household Owner" placement="top">
                                 <AdminPanelSettingsOutlined
                                   sx={{
@@ -661,8 +661,8 @@ export function MembersView({
 
                     <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
                       <Chip
-                        label={member.role === "admin" ? "Owner" : "Member"}
-                        color={member.role === "admin" ? "primary" : "default"}
+                        label={member.role === "owner" ? "Owner" : "Member"}
+                        color={member.role === "owner" ? "primary" : "default"}
                         size="small"
                         sx={{ fontWeight: "bold" }}
                       />
@@ -799,7 +799,7 @@ export function MembersView({
                             horizontal: "right",
                           }}
                           badgeContent={
-                            member.role === "admin" ? (
+                            member.role === "owner" ? (
                               <Tooltip title="Household Owner" placement="top">
                                 <AdminPanelSettingsOutlined
                                   sx={{
@@ -835,8 +835,8 @@ export function MembersView({
                     </TableCell>
                     <TableCell>
                       <Chip
-                        label={member.role === "admin" ? "Owner" : "Member"}
-                        color={member.role === "admin" ? "primary" : "default"}
+                        label={member.role === "owner" ? "Owner" : "Member"}
+                        color={member.role === "owner" ? "primary" : "default"}
                         size="small"
                         sx={{ fontWeight: "bold" }}
                       />
@@ -1009,12 +1009,12 @@ export function MembersView({
                       onChange={(e) =>
                         onRoleChange(
                           selectedMember.id,
-                          e.target.value as "admin" | "member",
+                          e.target.value as "owner" | "member",
                         )
                       }
                     >
                       <MenuItem value="member">Member</MenuItem>
-                      <MenuItem value="admin">Owner</MenuItem>
+                      <MenuItem value="owner">Owner</MenuItem>
                     </Select>
                   </FormControl>
                 </Card>

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -106,13 +106,13 @@ export type SenderRuleFormState = {
 export type MemberFormState = {
   email: string;
   name: string;
-  role: "member" | "admin";
+  role: "member" | "owner";
 };
 
 export type InvitationFormState = {
   email: string;
   name: string;
-  role: "member" | "admin";
+  role: "member" | "owner";
   providerIds: string[];
 };
 
@@ -120,7 +120,7 @@ export type InvitationSummary = {
   id: string;
   email: string;
   name: string;
-  role: "member" | "admin";
+  role: "member" | "owner";
   status: "pending" | "accepted" | "cancelled" | "expired";
   invitedByUserId: string;
   acceptedByUserId: string | null;
@@ -172,9 +172,9 @@ export type AccountSettingsFormState = {
 
 export type HouseholdSettings = {
   slug: string;
-  emailAddress: string;
+  /** <slug>@EMAIL_DOMAIN, or null until the operator configures EMAIL_DOMAIN. */
+  emailAddress: string | null;
   displayName: string;
-  subscriptionPlan: string;
 };
 
 export type HouseholdSettingsResponse = {

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -23,6 +23,8 @@ interface Env {
   ENVIRONMENT: string;
   NODE_ENV?: string;
   OUTBOUND_EMAIL_FROM: string;
+  /** Domain of the inbound addresses (<slug>@EMAIL_DOMAIN); optional, display only. */
+  EMAIL_DOMAIN?: string;
   OWNER_EMAIL?: string;
   SETUP_SECRET?: string;
 }

--- a/src/server/routes/admin.ts
+++ b/src/server/routes/admin.ts
@@ -119,6 +119,7 @@ type SenderRulePayload = {
 type InvitationPayload = {
   email?: string;
   name?: string;
+  /** "owner" | "member"; the legacy value "admin" is accepted as "owner". */
   role?: InvitationRole | "admin";
   providerIds?: string[];
 };
@@ -131,6 +132,29 @@ export const adminRoutes = new Hono<{
   Bindings: Env;
   Variables: AppVariables;
 }>();
+
+/**
+ * Household roles are "owner" | "member" everywhere. The UI used to send
+ * "admin" for owners; keep accepting it so old clients don't break.
+ */
+function normalizeHouseholdRole(value: unknown): "owner" | "member" | null {
+  if (value === "owner" || value === "admin") return "owner";
+  if (value === "member") return "member";
+  return null;
+}
+
+function householdSettingsPayload(
+  env: Env,
+  settings: { slug: string; displayName: string },
+) {
+  const domain = env.EMAIL_DOMAIN?.trim();
+  return {
+    slug: settings.slug,
+    displayName: settings.displayName,
+    // The address providers must send codes to; null until EMAIL_DOMAIN is set.
+    emailAddress: domain ? `${settings.slug}@${domain}` : null,
+  };
+}
 
 function normalizeProviderKey(value: string | undefined) {
   return value?.trim().toLowerCase() ?? "";
@@ -176,14 +200,7 @@ adminRoutes.get("/:slug/settings", async (c) => {
     return c.json({ error: "Household not found" }, 404);
   }
 
-  return c.json({
-    household: {
-      slug: settings.slug,
-      emailAddress: `${settings.slug}@DOMAIN`,
-      displayName: settings.displayName,
-      subscriptionPlan: "Free Plan",
-    },
-  });
+  return c.json({ household: householdSettingsPayload(c.env, settings) });
 });
 
 adminRoutes.patch("/:slug/settings", async (c) => {
@@ -217,14 +234,7 @@ adminRoutes.patch("/:slug/settings", async (c) => {
     return c.json({ error: "Household not found" }, 404);
   }
 
-  return c.json({
-    household: {
-      slug: settings.slug,
-      emailAddress: `${settings.slug}@DOMAIN`,
-      displayName: settings.displayName,
-      subscriptionPlan: "Free Plan",
-    },
-  });
+  return c.json({ household: householdSettingsPayload(c.env, settings) });
 });
 
 adminRoutes.get("/:slug/providers", async (c) => {
@@ -477,7 +487,7 @@ adminRoutes.get("/:slug/members", async (c) => {
   return c.json({
     members: members.map((member) => ({
       ...member,
-      role: member.householdRole === "owner" ? "admin" : "member",
+      role: member.householdRole,
       providerAccess: accessByUserId.get(member.id) ?? [],
     })),
     providers,
@@ -505,8 +515,7 @@ adminRoutes.post("/:slug/invitations", async (c) => {
 
   const email = normalizeEmail(payload.email);
   const name = normalizeDisplayName(payload.name);
-  const role: InvitationRole =
-    payload.role === "owner" || payload.role === "admin" ? "owner" : "member";
+  const role: InvitationRole = normalizeHouseholdRole(payload.role) ?? "member";
   const providerIds = Array.isArray(payload.providerIds)
     ? payload.providerIds.filter((providerId) => Boolean(providerId))
     : [];
@@ -681,7 +690,7 @@ adminRoutes.post("/:slug/members", async (c) => {
     Date.now() + 1000 * 60 * 60 * 24 * 7,
   ).toISOString();
   const invitationRole: InvitationRole =
-    payload.role === "admin" ? "owner" : "member";
+    normalizeHouseholdRole(payload.role) ?? "member";
 
   const invitationId = await createHouseholdInvitation(c.env.DB, {
     householdId: household.id,
@@ -733,8 +742,10 @@ adminRoutes.patch("/:slug/members/:userId/role", async (c) => {
     return c.json({ error: "Invalid JSON body" }, 400);
   }
 
-  if (payload.role !== "admin" && payload.role !== "member") {
-    return c.json({ error: "role must be admin or member" }, 400);
+  const nextRole = normalizeHouseholdRole(payload.role);
+
+  if (!nextRole) {
+    return c.json({ error: "role must be owner or member" }, 400);
   }
 
   const household = c.get("household");
@@ -756,7 +767,7 @@ adminRoutes.patch("/:slug/members/:userId/role", async (c) => {
   await updateHouseholdMembershipRole(c.env.DB, {
     householdId: household.id,
     userId,
-    role: payload.role === "admin" ? "owner" : "member",
+    role: nextRole,
   });
 
   return c.json({ ok: true });

--- a/src/server/routes/households.ts
+++ b/src/server/routes/households.ts
@@ -85,5 +85,10 @@ householdRoutes.post("/", rateLimit(RATE_LIMITS.householdCreate), async (c) => {
     ownerUserId: user.id,
   });
 
-  return c.json({ household }, 201);
+  if (!household) {
+    return c.json({ error: "Unable to create household" }, 500);
+  }
+
+  // Same shape as /api/households/me entries so the client can use it directly.
+  return c.json({ household: { ...household, role: "owner" as const } }, 201);
 });

--- a/test/household-settings-view.test.tsx
+++ b/test/household-settings-view.test.tsx
@@ -4,14 +4,13 @@ import { describe, expect, it, vi } from "vitest";
 import { HouseholdSettingsView } from "../src/client/components/HouseholdSettingsView";
 
 describe("HouseholdSettingsView", () => {
-  it("renders readonly slug, email, plan, and editable household name", () => {
+  it("renders readonly slug, inbox address, and editable household name", () => {
     const html = renderToStaticMarkup(
       <HouseholdSettingsView
         household={{
           slug: "home",
-          emailAddress: "home@DOMAIN",
+          emailAddress: "home@example.com",
           displayName: "Home",
-          subscriptionPlan: "Free Plan",
         }}
         isLoading={false}
         error={null}
@@ -29,10 +28,25 @@ describe("HouseholdSettingsView", () => {
     expect(html).toContain("Household slug");
     expect(html).toContain("home");
     expect(html).toContain("Household email address");
-    expect(html).toContain("home@DOMAIN");
+    expect(html).toContain("home@example.com");
     expect(html).toContain("Household name");
-    expect(html).toContain("Subscription plan");
-    expect(html).toContain("Free Plan");
+    expect(html).not.toContain("Subscription plan");
     expect(html).toContain("Save Household Name");
+  });
+
+  it("explains how to get an inbox address when EMAIL_DOMAIN is not configured", () => {
+    const html = renderToStaticMarkup(
+      <HouseholdSettingsView
+        household={{ slug: "home", emailAddress: null, displayName: "Home" }}
+        isLoading={false}
+        error={null}
+        formState={{ displayName: "Home" }}
+        onFormChange={vi.fn()}
+        onSave={vi.fn()}
+        isSaving={false}
+      />,
+    );
+    expect(html).toContain("Not configured");
+    expect(html).toContain("EMAIL_DOMAIN");
   });
 });

--- a/test/inbox-routes.test.ts
+++ b/test/inbox-routes.test.ts
@@ -829,6 +829,7 @@ function createEnv(db: D1Database, overrides?: Partial<Env>): Env {
     EMAIL: email,
     ENVIRONMENT: "test",
     OUTBOUND_EMAIL_FROM: "noreply@example.com",
+    EMAIL_DOMAIN: "example.com",
     OWNER_EMAIL: "owner@example.com",
     SETUP_SECRET: "setup-secret",
     ...overrides,
@@ -1122,7 +1123,7 @@ describe("worker routes", () => {
           email: "owner@example.com",
           name: "Home Owner",
           householdRole: "owner",
-          role: "admin",
+          role: "owner",
           createdAt: "2026-05-10T12:00:00.000Z",
           updatedAt: "2026-05-10T12:00:00.000Z",
           providerAccess: [],
@@ -1165,9 +1166,8 @@ describe("worker routes", () => {
     await expect(response.json()).resolves.toEqual({
       household: {
         slug: "home",
-        emailAddress: "home@DOMAIN",
         displayName: "Home",
-        subscriptionPlan: "Free Plan",
+        emailAddress: "home@example.com",
       },
     });
   });
@@ -1187,9 +1187,8 @@ describe("worker routes", () => {
     await expect(response.json()).resolves.toEqual({
       household: {
         slug: "home",
-        emailAddress: "home@DOMAIN",
         displayName: "Renamed Home",
-        subscriptionPlan: "Free Plan",
+        emailAddress: "home@example.com",
       },
     });
     expect(

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -37,7 +37,8 @@
     "APP_URL": "http://localhost:8787",
     "ENVIRONMENT": "development",
     "OWNER_EMAIL": "owner@example.com",
-    "OUTBOUND_EMAIL_FROM": "noreply@example.com"
+    "OUTBOUND_EMAIL_FROM": "noreply@example.com",
+    "EMAIL_DOMAIN": "example.com"
   },
   "env": {
     "preview": {


### PR DESCRIPTION
## Summary

Closes #104.

- **Roles**: `owner | member` everywhere. The members API no longer maps owners to `"admin"`; invitations / "create member" / role-change accept `owner|member` (the legacy `"admin"` is still accepted as `owner` so nothing old breaks); client types, selects and chips updated — owner invitations no longer render as "Member".
- **`POST /api/households`** returns `{ …household, role: "owner" }` (same shape as `/api/households/me`), so the creator is treated as owner immediately instead of after a reload.
- **Household settings**: `emailAddress` is `<slug>@EMAIL_DOMAIN` (new optional `EMAIL_DOMAIN` var — display only, documented, placeholder in dev vars) or `null` with a "Not configured — set EMAIL_DOMAIN" hint; the fake `subscriptionPlan: "Free Plan"` is removed from API, types and UI.

## Tests
- Route tests expect `owner` roles and `home@example.com`; settings view tests cover configured and unconfigured `EMAIL_DOMAIN`; the old `home@DOMAIN` / `Free Plan` assertions are gone.

`npm run ci` green: 205 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)