### PR TITLE
fix: household creation policy, reserved slugs, segment-based view detection

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -68,22 +68,15 @@ import {
 type ViewType = "inbox" | "quarantine" | "members" | "providers" | "settings";
 
 function getActiveView(pathname: string): ViewType {
-  if (pathname === "/settings" || pathname.endsWith("/settings")) {
-    return "settings";
-  }
+  // Match on path segments (/:slug/:view), not substrings, so a household slug
+  // that happens to contain a view name does not change the active view.
+  const segments = pathname.split("/").filter(Boolean);
+  const view = segments.length === 1 ? segments[0] : segments[1];
 
-  if (pathname.includes("/quarantine")) {
-    return "quarantine";
-  }
-
-  if (pathname.includes("/members")) {
-    return "members";
-  }
-
-  if (pathname.includes("/providers")) {
-    return "providers";
-  }
-
+  if (view === "settings") return "settings";
+  if (view === "quarantine") return "quarantine";
+  if (view === "members") return "members";
+  if (view === "providers") return "providers";
   return "inbox";
 }
 
@@ -165,11 +158,13 @@ export function App() {
       "forgot-password",
       "reset-password",
       "two-factor",
+      "new-household",
     ].includes(routeSegments[0])
       ? routeSegments[0]
       : null;
 
-  const isInvitePath = routeSegments[0] === "invite";
+  const isInvitePath =
+    routeSegments[0] === "invite" || routeSegments[0] === "new-household";
   const activeView = getActiveView(location.pathname);
   const [households, setHouseholds] = useState<HouseholdSummary[]>([]);
   const [isLoadingHouseholds, setIsLoadingHouseholds] = useState(false);
@@ -1825,7 +1820,7 @@ export function App() {
 
   function handleCreateHousehold() {
     setViewError(null);
-    setStatusMessage("Household creation walkthrough coming soon.");
+    navigate("/new-household");
   }
 
   if (
@@ -1949,6 +1944,22 @@ export function App() {
         <Route
           path="/invite/:token"
           element={<InviteRoute onAccepted={handleInviteAccepted} />}
+        />
+        <Route
+          path="/new-household"
+          element={
+            <CreateHouseholdPage
+              onCreated={(household) => {
+                setHouseholds((current) => [...current, household]);
+                setStatusMessage(
+                  `Household "${household.displayName}" created.`,
+                );
+                navigate(buildHouseholdPath(household.slug, "/inbox"), {
+                  replace: true,
+                });
+              }}
+            />
+          }
         />
         <Route
           path="/"

--- a/src/client/components/CreateHouseholdPage.tsx
+++ b/src/client/components/CreateHouseholdPage.tsx
@@ -67,7 +67,7 @@ export function CreateHouseholdPage({ onCreated }: CreateHouseholdPageProps) {
           required
           fullWidth
           label="Household slug"
-          helperText="Lowercase letters, numbers, and hyphens only. This cannot be changed later."
+          helperText="2–40 lowercase letters, numbers, and hyphens; also the inbound address local part (slug@your-domain). Cannot be changed later."
           value={formState.slug}
           onChange={(e) =>
             setFormState((current) => ({

--- a/src/client/components/Layout.tsx
+++ b/src/client/components/Layout.tsx
@@ -55,22 +55,15 @@ interface LayoutProps {
 }
 
 function getActiveView(pathname: string) {
-  if (pathname === "/settings" || pathname.endsWith("/settings")) {
-    return "settings";
-  }
+  // Match on path segments (/:slug/:view), not substrings, so a household slug
+  // that happens to contain a view name does not change the active view.
+  const segments = pathname.split("/").filter(Boolean);
+  const view = segments.length === 1 ? segments[0] : segments[1];
 
-  if (pathname.includes("/quarantine")) {
-    return "quarantine";
-  }
-
-  if (pathname.includes("/members")) {
-    return "members";
-  }
-
-  if (pathname.includes("/providers")) {
-    return "providers";
-  }
-
+  if (view === "settings") return "settings";
+  if (view === "quarantine") return "quarantine";
+  if (view === "members") return "members";
+  if (view === "providers") return "providers";
   return "inbox";
 }
 

--- a/src/server/domain/household-slug.ts
+++ b/src/server/domain/household-slug.ts
@@ -1,0 +1,74 @@
+/**
+ * Household slugs double as URL path segments and inbound email local parts,
+ * so they must not collide with app routes or look like system mailboxes.
+ */
+export const RESERVED_HOUSEHOLD_SLUGS = new Set([
+  "api",
+  "admin",
+  "assets",
+  "cdn-cgi",
+  "favicon.ico",
+  "forgot-password",
+  "health",
+  "households",
+  "household",
+  "inbox",
+  "invite",
+  "invitations",
+  "login",
+  "logout",
+  "members",
+  "new-household",
+  "postmaster",
+  "providers",
+  "quarantine",
+  "reset-password",
+  "settings",
+  "setup",
+  "static",
+  "two-factor",
+  "abuse",
+  "noreply",
+  "no-reply",
+  "hostmaster",
+  "webmaster",
+]);
+
+export const HOUSEHOLD_SLUG_MIN_LENGTH = 2;
+export const HOUSEHOLD_SLUG_MAX_LENGTH = 40;
+const SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+
+export type SlugValidation = { ok: true } | { ok: false; error: string };
+
+export function normalizeHouseholdSlug(value: string | undefined | null) {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+export function validateHouseholdSlug(slug: string): SlugValidation {
+  if (!slug) {
+    return { ok: false, error: "slug is required" };
+  }
+  if (
+    slug.length < HOUSEHOLD_SLUG_MIN_LENGTH ||
+    slug.length > HOUSEHOLD_SLUG_MAX_LENGTH
+  ) {
+    return {
+      ok: false,
+      error: `slug must be between ${HOUSEHOLD_SLUG_MIN_LENGTH} and ${HOUSEHOLD_SLUG_MAX_LENGTH} characters`,
+    };
+  }
+  if (!SLUG_PATTERN.test(slug)) {
+    return {
+      ok: false,
+      error:
+        "slug may only contain lowercase letters, numbers, and hyphens, and must start and end with a letter or number",
+    };
+  }
+  if (RESERVED_HOUSEHOLD_SLUGS.has(slug)) {
+    return {
+      ok: false,
+      error: `"${slug}" is reserved and cannot be used as a household slug`,
+    };
+  }
+  return { ok: true };
+}

--- a/src/server/routes/households.ts
+++ b/src/server/routes/households.ts
@@ -9,6 +9,11 @@ import {
   getHouseholdBySlug,
   listHouseholdsForUser,
 } from "../db/repositories/households";
+import { getInstallationState } from "../db/repositories/installation-state";
+import {
+  normalizeHouseholdSlug,
+  validateHouseholdSlug,
+} from "../domain/household-slug";
 import { RATE_LIMITS, rateLimit } from "../security/rate-limit";
 
 type CreateHouseholdPayload = {
@@ -16,8 +21,25 @@ type CreateHouseholdPayload = {
   displayName?: string;
 };
 
-function normalizeSlug(value: string | undefined) {
-  return value?.trim().toLowerCase() ?? "";
+/**
+ * Who may create households: the installation owner and app-level admins
+ * always; anyone else only when they belong to no household yet (so a user
+ * whose only household was removed can recover). Invited members cannot
+ * mint extra households or squat inbound addresses.
+ */
+async function mayCreateHousehold(
+  db: D1Database,
+  user: { id: string; role: string },
+): Promise<boolean> {
+  if (user.role === "admin") {
+    return true;
+  }
+  const installation = await getInstallationState(db);
+  if (installation.owner_user_id === user.id) {
+    return true;
+  }
+  const memberships = await listHouseholdsForUser(db, user.id);
+  return memberships.length === 0;
 }
 
 function normalizeDisplayName(value: string | undefined) {
@@ -56,21 +78,29 @@ householdRoutes.post("/", rateLimit(RATE_LIMITS.householdCreate), async (c) => {
     return c.json({ error: "Invalid JSON body" }, 400);
   }
 
-  const slug = normalizeSlug(payload.slug);
+  const slug = normalizeHouseholdSlug(payload.slug);
   const displayName = normalizeDisplayName(payload.displayName);
+  const slugCheck = validateHouseholdSlug(slug);
 
-  if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
+  if (!slugCheck.ok) {
+    return c.json({ error: slugCheck.error }, 400);
+  }
+
+  if (!displayName || displayName.length > 80) {
     return c.json(
-      {
-        error:
-          "slug is required and may only contain lowercase letters, numbers, and hyphens",
-      },
+      { error: "displayName is required (max 80 characters)" },
       400,
     );
   }
 
-  if (!displayName) {
-    return c.json({ error: "displayName is required" }, 400);
+  if (!(await mayCreateHousehold(c.env.DB, user))) {
+    return c.json(
+      {
+        error:
+          "Only the installation owner can create additional households. Ask them to create it and invite you.",
+      },
+      403,
+    );
   }
 
   const existing = await getHouseholdBySlug(c.env.DB, slug);

--- a/src/server/routes/setup.ts
+++ b/src/server/routes/setup.ts
@@ -14,6 +14,10 @@ import {
   resetInstallationSetup,
 } from "../db/repositories/installation-state";
 import { deleteUserById, findUserByEmail } from "../db/repositories/users";
+import {
+  normalizeHouseholdSlug,
+  validateHouseholdSlug,
+} from "../domain/household-slug";
 import { secretsEqual } from "../security/compare";
 import { RATE_LIMITS, rateLimit } from "../security/rate-limit";
 
@@ -46,10 +50,6 @@ function mapInstallationStatus(
     isConfigured,
     status: row.status,
   };
-}
-
-function normalizeSlug(value: string | undefined) {
-  return value?.trim().toLowerCase() ?? "";
 }
 
 setupRoutes.get("/status", async (c) => {
@@ -116,16 +116,11 @@ setupRoutes.post("/complete", rateLimit(RATE_LIMITS.setup), async (c) => {
     return c.json({ error: "Password must be at least 12 characters" }, 400);
   }
 
-  const householdSlug = normalizeSlug(payload.householdSlug);
+  const householdSlug = normalizeHouseholdSlug(payload.householdSlug);
+  const slugCheck = validateHouseholdSlug(householdSlug);
 
-  if (!/^[a-z0-9-]+$/.test(householdSlug)) {
-    return c.json(
-      {
-        error:
-          "householdSlug may only contain lowercase letters, numbers, and hyphens",
-      },
-      400,
-    );
+  if (!slugCheck.ok) {
+    return c.json({ error: `householdSlug: ${slugCheck.error}` }, 400);
   }
 
   const claimed = await beginInstallationSetup(c.env.DB);

--- a/test/household-slug.test.ts
+++ b/test/household-slug.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeHouseholdSlug,
+  validateHouseholdSlug,
+} from "../src/server/domain/household-slug";
+
+describe("household slug validation", () => {
+  it("accepts ordinary slugs", () => {
+    for (const slug of ["casa", "smith-family", "home2", "ab"]) {
+      expect(validateHouseholdSlug(slug)).toEqual({ ok: true });
+    }
+  });
+
+  it("rejects reserved, malformed and oversized slugs", () => {
+    for (const slug of [
+      "members",
+      "settings",
+      "api",
+      "invite",
+      "two-factor",
+      "postmaster",
+      "-casa",
+      "casa-",
+      "Casa",
+      "ca sa",
+      "a",
+      "x".repeat(41),
+      "",
+    ]) {
+      expect(validateHouseholdSlug(slug).ok, slug).toBe(false);
+    }
+  });
+
+  it("normalises case and whitespace", () => {
+    expect(normalizeHouseholdSlug("  Casa ")).toBe("casa");
+  });
+});

--- a/test/integration/household-creation.test.ts
+++ b/test/integration/household-creation.test.ts
@@ -1,0 +1,87 @@
+import { SELF } from "cloudflare:test";
+import { provisioningAuthForEnv } from "@server/auth/auth";
+import {
+  addUserToHousehold,
+  createHousehold,
+} from "@server/db/repositories/households";
+import { completeInstallationSetup } from "@server/db/repositories/installation-state";
+import { describe, expect, it } from "vitest";
+
+import { count, db, testEnv } from "./helpers";
+
+async function signUp(email: string) {
+  const result = await provisioningAuthForEnv(testEnv()).api.signUpEmail({
+    body: { email, name: email, password: "averylongpassword123" },
+    returnHeaders: true,
+  });
+  const cookie = result.headers
+    .getSetCookie()
+    .map((entry: string) => entry.split(";")[0])
+    .join("; ");
+  return { id: result.response.user.id, cookie };
+}
+
+async function create(cookie: string, slug: string) {
+  return SELF.fetch("http://localhost:8787/api/households", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ slug, displayName: `Household ${slug}` }),
+  });
+}
+
+describe("household creation policy", () => {
+  it("lets the installation owner create more households but not an invited member", async () => {
+    const owner = await signUp("owner@example.com");
+    const member = await signUp("member@example.com");
+    const first = await createHousehold(db, {
+      slug: "casa",
+      displayName: "Casa",
+      ownerUserId: owner.id,
+    });
+    await completeInstallationSetup(db, owner.id, "owner@example.com");
+    await addUserToHousehold(db, {
+      householdId: first?.id ?? "",
+      userId: member.id,
+      role: "member",
+    });
+
+    const ownerCreate = await create(owner.cookie, "cabin");
+    expect(ownerCreate.status).toBe(201);
+    await expect(ownerCreate.json()).resolves.toMatchObject({
+      household: { slug: "cabin", role: "owner" },
+    });
+
+    const memberCreate = await create(member.cookie, "mine");
+    expect(memberCreate.status).toBe(403);
+    expect(await count("households")).toBe(2);
+  });
+
+  it("lets a user with no household create their first one", async () => {
+    const user = await signUp("solo@example.com");
+    expect((await create(user.cookie, "solo")).status).toBe(201);
+    expect((await create(user.cookie, "solo-two")).status).toBe(403);
+  });
+
+  it("rejects reserved or malformed slugs at creation and at setup", async () => {
+    const user = await signUp("solo@example.com");
+    for (const slug of ["members", "settings", "api", "-bad", "x"]) {
+      const response = await create(user.cookie, slug);
+      expect(response.status, slug).toBe(400);
+    }
+    expect(await count("households")).toBe(0);
+
+    const setup = await SELF.fetch("http://localhost:8787/api/setup/complete", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "owner@example.com",
+        name: "Owner",
+        password: "averylongpassword123",
+        householdName: "X",
+        householdSlug: "invite",
+        setupSecret: "test-setup-secret",
+      }),
+    });
+    expect(setup.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #112.

- **Policy**: `POST /api/households` now allows the installation owner (`app_installation.owner_user_id`) and app-level admins to create additional households; any other user may only create their **first** one. Invited members can no longer mint households or squat inbound addresses. Clear 403 message.
- **Slugs**: `src/server/domain/household-slug.ts` — 2–40 chars, `[a-z0-9-]`, no leading/trailing hyphen, and a reserved list (`api`, `settings`, `members`, `invite`, `two-factor`, `new-household`, `postmaster`, `noreply`, …). Used by both `/setup` and household creation; display name capped at 80.
- **Client**: `getActiveView` (App + Layout) matches `/:slug/:view` **segments**, not substrings; the sidebar's "Create new household" opens a real `/new-household` page (server enforces the policy) instead of a "coming soon" toast; route exclusions updated.

## Tests
- Unit: slug validator accept/reject matrix.
- D1 (`SELF`): installation owner creates a second household (role `owner` in the response) while an invited member gets 403; a household-less user can create one but not two; reserved/malformed slugs rejected at creation and at setup.

`npm run ci` green: 211 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)