### PR TITLE
feat: structured logging helper, failed-request logging, operations runbook for alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ They cover:
 
 If your editor supports `.http` or REST client files, you can run these requests directly against the local dev server.
 
+### Operations
+
+Logging, health endpoints and the recommended alert set are described in [`docs/operations.md`](./docs/operations.md).
+
 ### Health endpoints
 
 - `GET /api/health/live` — liveness check

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,46 @@
+# Operations: observability and alerting
+
+Mi Casa Su Casa runs as one Cloudflare Worker. Everything it reports goes to **Workers Logs** (enabled in `wrangler.jsonc` → `observability.logs`) as single-line JSON, and to Cloudflare's built-in Worker metrics.
+
+## Log events
+
+Every line is `{"event": "<name>", "level": "info|warn|error", ...fields}`. Bodies and verification codes are never logged.
+
+| Event | Level | When | Key fields |
+| --- | --- | --- | --- |
+| `api_request_failed` | warn / error | any `/api/*` response ≥ 400 (5xx = error) | `ray`, `method`, `path`, `status`, `durationMs` |
+| `unhandled_error` | error | an exception reached the global handler (response is a JSON 500) | `ray`, `method`, `path`, `error` |
+| `env_misconfigured` | error | a request hit a Worker missing required config (503) | `problems[]` |
+| `email_stored` / `email_quarantined` | info | inbound mail processed | `from`, `to`, `messageId`, `householdId`, `providerKey`, `codeFound`, `truncated` |
+| `email_rejected` | info | mail refused (`unknown_recipient`, `too_large`, `quarantine_full`) | `reason`, `from`, `to` |
+| `email_parse_failed` / `email_ingest_failed` | error | parsing or storage failed (ingest failures are re-thrown so the sender retries) | `from`, `to`, `messageId`, `error` |
+| `invitation_email_failed` / `password_reset_email_failed` | error | outbound email could not be sent | `invitationId` / `userId`, `error` |
+| `retention_completed` / `retention_failed` | info / error | daily cron result | `messagesPurged`, `quarantinePurged`, `batches`, `durationMs` |
+| `setup_failed`, `setup_orphan_user_removed`, `setup_recovered_existing_owner`, `setup_cleanup_failed` | error / warn | first-run setup recovery paths | `userId`, `error` |
+| `invitation_accept_failed` | error | membership step failed after sign-up (account rolled back) | `invitationId`, `error` |
+| `member_removed`, `member_left` | info | membership changes | `householdId`, `userId`, `byUserId` |
+| `audit_write_failed` | error | an audit row could not be written (the action itself succeeded) | `action`, `error` |
+
+Owner/admin actions are additionally stored in the `audit_events` table and exposed to owners at `GET /api/admin/:slug/audit`.
+
+### Useful Workers Logs queries
+
+- Ingestion problems: `event:"email_ingest_failed" OR event:"email_parse_failed" OR event:"email_rejected"`
+- Anything the Worker could not handle: `level:"error"`
+- One request end-to-end: filter by `ray` (the `cf-ray` header the client received)
+
+## Health endpoints
+
+- `GET /api/health/live` — always 200 while the Worker runs.
+- `GET /api/health/ready` — 503 with `problems[]` when required config is missing; otherwise 200 with `setupConfigured` and `retention: { lastRunAt, stale }` (`stale` is true until the first cron run and whenever the last run is older than 48 h).
+
+## Minimum alert set
+
+1. **Cloudflare Notifications → Workers** — enable *Error rate* (and *CPU / request limits* if on the free plan) for the production Worker.
+2. **Cloudflare Notifications → Cron Triggers** — *Failed cron trigger* for the production Worker (the retention job re-throws on failure so it registers).
+3. **External uptime monitor** (any provider) on `https://<APP_URL>/api/health/ready`, alerting on non-200 **and** on `retention.stale == true` if the monitor supports body assertions.
+4. **Workers Logs alert / Logpush rule** on `event:"email_ingest_failed"`, `event:"env_misconfigured"` and `event:"unhandled_error"`. Without Logpush, check the Logs tab after any report of a missing code.
+
+## Rate limiting and abuse
+
+Brute-force limits are enforced in D1 (see README → Security notes). Repeated `api_request_failed` lines with `status: 429` for the same `ray` prefix / path indicate someone probing sign-in, setup or invitation endpoints; consider adding a Cloudflare WAF rate-limiting rule in front of `/api/auth/*` and `/api/setup/*`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { settingsRoutes } from "./server/routes/settings";
 import { setupRoutes } from "./server/routes/setup";
 import { createAppContext } from "./server/runtime/context";
 import { assertValidEnv, validateEnv } from "./server/runtime/env";
+import { logEvent, logFailedApiRequests } from "./server/runtime/log";
 import {
   corsOriginFor,
   rejectCrossSiteMutations,
@@ -69,6 +70,7 @@ app.use(
   }),
 );
 app.use("/api/*", rejectCrossSiteMutations);
+app.use("/api/*", logFailedApiRequests);
 
 // Fail fast (and loudly) when required configuration is missing, instead of
 // letting auth/email silently degrade. Liveness stays available.
@@ -80,12 +82,9 @@ app.use("/api/*", async (c, next) => {
   const validation = validateEnv(c.env);
 
   if (!validation.ok) {
-    console.error(
-      JSON.stringify({
-        event: "env_misconfigured",
-        problems: validation.problems,
-      }),
-    );
+    logEvent("error", "env_misconfigured", {
+      problems: validation.problems,
+    });
     return c.json(
       { error: "misconfigured", problems: validation.problems },
       503,
@@ -110,6 +109,9 @@ app.route("/api/admin", adminRoutes);
 app.route("/api/invitations", invitationRoutes);
 app.route("/api/settings", settingsRoutes);
 app.route("/api/setup", setupRoutes);
+
+// Unknown API paths must never fall through to the SPA/asset handler.
+app.all("/api/*", (c) => c.json({ error: "Not found" }, 404));
 
 app.get("*", async (c) => {
   return c.env.ASSETS.fetch(c.req.raw);

--- a/src/server/auth/auth.ts
+++ b/src/server/auth/auth.ts
@@ -6,6 +6,7 @@ import { twoFactor } from "better-auth/plugins";
 import { dbForEnv } from "../db/client";
 import * as schema from "../db/schema";
 import { sendPasswordResetEmail } from "../email/sender";
+import { logEvent } from "../runtime/log";
 
 function getRpId(url: string) {
   // APP_URL is validated at the edge (see runtime/env.ts); a bad value here
@@ -45,13 +46,10 @@ function createAuth(env: Env, options: { disableSignUp: boolean }) {
             resetUrl: url,
           });
         } catch (error) {
-          console.error(
-            JSON.stringify({
-              event: "password_reset_email_failed",
-              userId: user.id,
-              error: error instanceof Error ? error.message : String(error),
-            }),
-          );
+          logEvent("error", "password_reset_email_failed", {
+            userId: user.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
           throw error;
         }
       },

--- a/src/server/db/repositories/audit.ts
+++ b/src/server/db/repositories/audit.ts
@@ -1,5 +1,5 @@
 import { desc, eq, sql } from "drizzle-orm";
-
+import { logEvent } from "../../runtime/log";
 import { dbForDatabase } from "../client";
 import { auditEvents } from "../schema";
 
@@ -34,13 +34,10 @@ export async function recordAuditEvent(
         createdAt: sql`CURRENT_TIMESTAMP`,
       });
   } catch (error) {
-    console.error(
-      JSON.stringify({
-        event: "audit_write_failed",
-        action: input.action,
-        error: error instanceof Error ? error.message : String(error),
-      }),
-    );
+    logEvent("error", "audit_write_failed", {
+      action: input.action,
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
 }
 

--- a/src/server/email/handler.ts
+++ b/src/server/email/handler.ts
@@ -5,6 +5,7 @@ import {
 } from "../db/repositories/messages";
 import { classifyEmail } from "../domain/classify-email";
 import type { AppContext } from "../runtime/context";
+import { logEvent } from "../runtime/log";
 import { parseIncomingEmail } from "./parse";
 
 /** Email Routing accepts up to 25 MB; OTP mail is tiny. Reject the rest early. */
@@ -13,11 +14,11 @@ export const MAX_RAW_MESSAGE_BYTES = 2 * 1024 * 1024;
 export const MAX_UNREVIEWED_QUARANTINE = 200;
 
 function log(event: string, fields: Record<string, unknown>) {
-  console.log(JSON.stringify({ event, ...fields }));
+  logEvent("info", event, fields);
 }
 
 function logError(event: string, fields: Record<string, unknown>) {
-  console.error(JSON.stringify({ event, ...fields }));
+  logEvent("error", event, fields);
 }
 
 function errorMessage(error: unknown) {

--- a/src/server/http/errors.ts
+++ b/src/server/http/errors.ts
@@ -2,6 +2,7 @@ import type { Context } from "hono";
 import { HTTPException } from "hono/http-exception";
 
 import { isUniqueViolation, uniqueViolationTarget } from "../db/errors";
+import { logEvent, requestFields } from "../runtime/log";
 
 /**
  * Last-resort error handler for the API: every failure becomes a JSON
@@ -25,15 +26,10 @@ export function handleApiError(error: unknown, c: Context): Response {
     );
   }
 
-  console.error(
-    JSON.stringify({
-      event: "unhandled_error",
-      method: c.req.method,
-      path: c.req.path,
-      ray: c.req.header("cf-ray") ?? null,
-      error: error instanceof Error ? error.message : String(error),
-    }),
-  );
+  logEvent("error", "unhandled_error", {
+    ...requestFields(c),
+    error: error instanceof Error ? error.message : String(error),
+  });
 
   return c.json({ error: "Internal error" }, 500);
 }

--- a/src/server/jobs/retention.ts
+++ b/src/server/jobs/retention.ts
@@ -2,6 +2,7 @@ import { recordRetentionRun } from "../db/repositories/installation-state";
 import { refreshExpiredInvitations } from "../db/repositories/invitations";
 import { purgeExpired } from "../db/repositories/messages";
 import type { AppContext } from "../runtime/context";
+import { logEvent } from "../runtime/log";
 
 /**
  * Daily retention job: purges expired inbox/quarantine messages in bounded
@@ -22,27 +23,21 @@ export async function purgeExpiredMessages(
     await refreshExpiredInvitations(appContext.env.DB, now);
     await recordRetentionRun(appContext.env.DB, nowIso);
 
-    console.log(
-      JSON.stringify({
-        event: "retention_completed",
-        scheduledFor: nowIso,
-        messagesPurged: purged.messages,
-        quarantinePurged: purged.quarantine,
-        batches: purged.batches,
-        durationMs: Date.now() - startedAt,
-      }),
-    );
+    logEvent("info", "retention_completed", {
+      scheduledFor: nowIso,
+      messagesPurged: purged.messages,
+      quarantinePurged: purged.quarantine,
+      batches: purged.batches,
+      durationMs: Date.now() - startedAt,
+    });
 
     return purged;
   } catch (error) {
-    console.error(
-      JSON.stringify({
-        event: "retention_failed",
-        scheduledFor: nowIso,
-        durationMs: Date.now() - startedAt,
-        error: error instanceof Error ? error.message : String(error),
-      }),
-    );
+    logEvent("error", "retention_failed", {
+      scheduledFor: nowIso,
+      durationMs: Date.now() - startedAt,
+      error: error instanceof Error ? error.message : String(error),
+    });
     throw error;
   }
 }

--- a/src/server/routes/admin.ts
+++ b/src/server/routes/admin.ts
@@ -44,6 +44,7 @@ import {
   updateSenderRule,
 } from "../db/repositories/provider-rules";
 import { sendHouseholdInvitationEmail } from "../email/sender";
+import { logEvent } from "../runtime/log";
 import { createInvitationToken } from "../security/tokens";
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -108,14 +109,11 @@ async function deliverInvitationEmail(
     return { emailSent: true };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.error(
-      JSON.stringify({
-        event: "invitation_email_failed",
-        invitationId: input.invitationId,
-        to: input.to,
-        error: message,
-      }),
-    );
+    logEvent("error", "invitation_email_failed", {
+      invitationId: input.invitationId,
+      to: input.to,
+      error: message,
+    });
     return { emailSent: false, emailError: message };
   }
 }
@@ -831,14 +829,11 @@ adminRoutes.delete("/:slug/members/:userId", async (c) => {
     householdId: household.id,
     userId,
   });
-  console.log(
-    JSON.stringify({
-      event: "member_removed",
-      householdId: household.id,
-      userId,
-      byUserId: currentUser.id,
-    }),
-  );
+  logEvent("info", "member_removed", {
+    householdId: household.id,
+    userId,
+    byUserId: currentUser.id,
+  });
   await audit(c, "member.removed", "user", userId);
 
   return c.json({ ok: true });

--- a/src/server/routes/households.ts
+++ b/src/server/routes/households.ts
@@ -18,6 +18,7 @@ import {
   normalizeHouseholdSlug,
   validateHouseholdSlug,
 } from "../domain/household-slug";
+import { logEvent } from "../runtime/log";
 import { RATE_LIMITS, rateLimit } from "../security/rate-limit";
 
 type CreateHouseholdPayload = {
@@ -161,13 +162,10 @@ householdRoutes.post("/:slug/leave", requireHouseholdContext, async (c) => {
     householdId: household.id,
     userId: user.id,
   });
-  console.log(
-    JSON.stringify({
-      event: "member_left",
-      householdId: household.id,
-      userId: user.id,
-    }),
-  );
+  logEvent("info", "member_left", {
+    householdId: household.id,
+    userId: user.id,
+  });
   await recordAuditEvent(c.env.DB, {
     actorUserId: user.id,
     householdId: household.id,

--- a/src/server/routes/invitations.ts
+++ b/src/server/routes/invitations.ts
@@ -11,6 +11,7 @@ import {
   refreshExpiredInvitations,
 } from "../db/repositories/invitations";
 import { deleteUserById, findUserByEmail } from "../db/repositories/users";
+import { logEvent } from "../runtime/log";
 import { RATE_LIMITS, rateLimit } from "../security/rate-limit";
 import { hashInvitationToken } from "../security/tokens";
 
@@ -205,13 +206,10 @@ invitationRoutes.post("/:token/accept", async (c) => {
 
     return response;
   } catch (error) {
-    console.error(
-      JSON.stringify({
-        event: "invitation_accept_failed",
-        invitationId: invitation.id,
-        error: error instanceof Error ? error.message : String(error),
-      }),
-    );
+    logEvent("error", "invitation_accept_failed", {
+      invitationId: invitation.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
 
     // Compensate: the sign-up succeeded but the membership did not; remove the
     // half-created account so the invitee can simply retry the link.

--- a/src/server/routes/setup.ts
+++ b/src/server/routes/setup.ts
@@ -19,6 +19,7 @@ import {
   normalizeHouseholdSlug,
   validateHouseholdSlug,
 } from "../domain/household-slug";
+import { logEvent } from "../runtime/log";
 import { secretsEqual } from "../security/compare";
 import { RATE_LIMITS, rateLimit } from "../security/rate-limit";
 
@@ -150,12 +151,9 @@ setupRoutes.post("/complete", rateLimit(RATE_LIMITS.setup), async (c) => {
         existingOwner.id,
         requestedEmail,
       );
-      console.warn(
-        JSON.stringify({
-          event: "setup_recovered_existing_owner",
-          userId: existingOwner.id,
-        }),
-      );
+      logEvent("warn", "setup_recovered_existing_owner", {
+        userId: existingOwner.id,
+      });
       return c.json(
         {
           error:
@@ -167,12 +165,9 @@ setupRoutes.post("/complete", rateLimit(RATE_LIMITS.setup), async (c) => {
 
     // Orphan from a failed attempt (no memberships): remove it so the retry
     // starts from a clean slate.
-    console.warn(
-      JSON.stringify({
-        event: "setup_orphan_user_removed",
-        userId: existingOwner.id,
-      }),
-    );
+    logEvent("warn", "setup_orphan_user_removed", {
+      userId: existingOwner.id,
+    });
     await deleteUserById(c.env.DB, existingOwner.id);
   }
 
@@ -228,27 +223,21 @@ setupRoutes.post("/complete", rateLimit(RATE_LIMITS.setup), async (c) => {
 
     return response;
   } catch (error) {
-    console.error(
-      JSON.stringify({
-        event: "setup_failed",
-        error: error instanceof Error ? error.message : String(error),
-      }),
-    );
+    logEvent("error", "setup_failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
 
     // Compensate: remove the owner user created in this attempt so the next
     // attempt does not fail with USER_ALREADY_EXISTS, then release the claim.
     if (createdUserId) {
       await deleteUserById(c.env.DB, createdUserId).catch((cleanupError) => {
-        console.error(
-          JSON.stringify({
-            event: "setup_cleanup_failed",
-            userId: createdUserId,
-            error:
-              cleanupError instanceof Error
-                ? cleanupError.message
-                : String(cleanupError),
-          }),
-        );
+        logEvent("error", "setup_cleanup_failed", {
+          userId: createdUserId,
+          error:
+            cleanupError instanceof Error
+              ? cleanupError.message
+              : String(cleanupError),
+        });
       });
     }
 

--- a/src/server/runtime/log.ts
+++ b/src/server/runtime/log.ts
@@ -1,0 +1,50 @@
+import type { Context, MiddlewareHandler } from "hono";
+
+export type LogLevel = "info" | "warn" | "error";
+
+/**
+ * Single-line JSON logs for Workers Logs / Logpush. Every line carries an
+ * `event` name (see docs/operations.md for the catalogue) plus structured
+ * fields. Never log message bodies or verification codes.
+ */
+export function logEvent(
+  level: LogLevel,
+  event: string,
+  fields: Record<string, unknown> = {},
+): void {
+  const line = JSON.stringify({ event, level, ...fields });
+  if (level === "error") {
+    console.error(line);
+  } else if (level === "warn") {
+    console.warn(line);
+  } else {
+    console.log(line);
+  }
+}
+
+/** Request correlation fields: Cloudflare's ray id, method and path. */
+export function requestFields(c: Context): Record<string, unknown> {
+  return {
+    ray: c.req.header("cf-ray") ?? null,
+    method: c.req.method,
+    path: c.req.path,
+  };
+}
+
+/**
+ * Logs API responses that failed (>= 400) with duration and correlation
+ * fields. Successful requests are not logged to keep the volume low; error
+ * rate and latency are available from Workers metrics.
+ */
+export const logFailedApiRequests: MiddlewareHandler = async (c, next) => {
+  const startedAt = Date.now();
+  await next();
+  const status = c.res.status;
+  if (status >= 400) {
+    logEvent(status >= 500 ? "error" : "warn", "api_request_failed", {
+      ...requestFields(c),
+      status,
+      durationMs: Date.now() - startedAt,
+    });
+  }
+};

--- a/test/integration/request-logging.test.ts
+++ b/test/integration/request-logging.test.ts
@@ -1,0 +1,32 @@
+import { SELF } from "cloudflare:test";
+import { describe, expect, it, vi } from "vitest";
+
+describe("failed API request logging", () => {
+  it("logs 4xx/5xx API responses with method, path, status and ray", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const response = await SELF.fetch(
+        "http://localhost:8787/api/does-not-exist",
+        {
+          headers: { "cf-ray": "abc123-OSL" },
+        },
+      );
+      expect(response.status).toBe(404);
+
+      const line = warn.mock.calls
+        .map((call) => String(call[0]))
+        .find((entry) => entry.includes("api_request_failed"));
+      expect(line).toBeDefined();
+      expect(JSON.parse(line as string)).toMatchObject({
+        event: "api_request_failed",
+        level: "warn",
+        method: "GET",
+        path: "/api/does-not-exist",
+        status: 404,
+        ray: "abc123-OSL",
+      });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { logEvent } from "../src/server/runtime/log";
+
+describe("logEvent", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("emits one JSON line per call with event and level first", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    logEvent("info", "thing_happened", { a: 1 });
+    logEvent("warn", "thing_odd");
+    logEvent("error", "thing_broke", { error: "boom" });
+
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+      event: "thing_happened",
+      level: "info",
+      a: 1,
+    });
+    expect(JSON.parse(String(warn.mock.calls[0]?.[0]))).toEqual({
+      event: "thing_odd",
+      level: "warn",
+    });
+    expect(JSON.parse(String(error.mock.calls[0]?.[0]))).toMatchObject({
+      event: "thing_broke",
+      level: "error",
+      error: "boom",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #106.

- `src/server/runtime/log.ts`: `logEvent(level, event, fields)` — one JSON line per event with `event` + `level` first; every structured log site (email pipeline, retention, setup recovery, invitations, audit, error handler, env guard) now goes through it.
- `logFailedApiRequests` middleware: every `/api/*` response ≥ 400 is logged as `api_request_failed` with `method`, `path`, `status`, `durationMs` and `cf-ray` (5xx at error level); successes are not logged (Workers metrics cover rate/latency). `unhandled_error` carries the same correlation fields.
- Unknown `/api/*` paths now return JSON 404 instead of falling through to the asset handler.
- **`docs/operations.md`**: log-event catalogue, Workers Logs queries, health endpoint semantics (`retention.stale`), and the **minimum alert set** (Workers error-rate + cron-failure notifications, external uptime monitor on `/api/health/ready`, log alerts on `email_ingest_failed` / `env_misconfigured` / `unhandled_error`). Linked from the README.

## Tests
- Unit: `logEvent` output shape per level.
- workerd: a failed API request emits `api_request_failed` with method/path/status/ray.

`npm run ci` green: 218 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)