### PR TITLE
ci: pin actions to commit SHAs; CodeQL builds instead of re-running the test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
           cache: npm
@@ -34,14 +34,15 @@ jobs:
         run: npm ci
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           languages: javascript-typescript
 
-      - name: Validate project before analysis
-        run: npm run ci
+      # CodeQL needs the compiled sources, not the test suite (CI runs that).
+      - name: Build for analysis
+        run: npm run build
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           category: "/language:javascript-typescript"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Explain why preview deploy is skipped
         if: env.HAS_CLOUDFLARE_API_TOKEN != 'true' || env.HAS_CLOUDFLARE_ACCOUNT_ID != 'true' || env.HAS_D1_DATABASE_ID_PREVIEW != 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const marker = '<!-- mcsc-preview-deploy -->';
@@ -61,10 +61,10 @@ jobs:
               });
             }
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         if: env.HAS_CLOUDFLARE_API_TOKEN == 'true' && env.HAS_CLOUDFLARE_ACCOUNT_ID == 'true' && env.HAS_D1_DATABASE_ID_PREVIEW == 'true'
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         if: env.HAS_CLOUDFLARE_API_TOKEN == 'true' && env.HAS_CLOUDFLARE_ACCOUNT_ID == 'true' && env.HAS_D1_DATABASE_ID_PREVIEW == 'true'
         with:
           node-version: 22
@@ -107,7 +107,7 @@ jobs:
 
       - name: Comment preview status on pull request
         if: env.HAS_CLOUDFLARE_API_TOKEN == 'true' && env.HAS_CLOUDFLARE_ACCOUNT_ID == 'true' && env.HAS_D1_DATABASE_ID_PREVIEW == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           PREVIEW_URL: ${{ vars.CLOUDFLARE_PREVIEW_URL }}
         with:
@@ -150,7 +150,7 @@ jobs:
 
     steps:
       - name: Explain why preview deploy is skipped
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const marker = '<!-- mcsc-preview-deploy -->';

--- a/.github/workflows/production-d1-migrate.yml
+++ b/.github/workflows/production-d1-migrate.yml
@@ -29,11 +29,11 @@ jobs:
       url: ${{ vars.CLOUDFLARE_PRODUCTION_URL }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ inputs.ref }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -23,9 +23,9 @@ jobs:
       url: ${{ vars.CLOUDFLARE_PRODUCTION_URL }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Summary

Closes #116.

- Every `uses:` in `.github/workflows/*.yml` is pinned to a full commit SHA with the tag kept as a trailing comment (`actions/checkout@d23441a… # v6`, `setup-node@2499707… # v6`, `github-script@3a2844b… # v9`, `codeql-action/{init,analyze}@ff2f1c6… # v4`). The Dependabot `github-actions` group keeps them current.
- CodeQL runs `npm run build` instead of `npm run ci` (it needs compiled sources, not a second test run — CI already gates on tests).
- `ci.yml` `permissions: contents: read` and the guarded `sed` placeholder injection already landed in #140.

YAML validated; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)