### PR TITLE
fix: keep invitation tokens out of URLs and turn off URL-recording invocation logs

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,6 +1,6 @@
 # Operations: observability and alerting
 
-Mi Casa Su Casa runs as one Cloudflare Worker. Everything it reports goes to **Workers Logs** (enabled in `wrangler.jsonc` → `observability.logs`) as single-line JSON, and to Cloudflare's built-in Worker metrics.
+Mi Casa Su Casa runs as one Cloudflare Worker. Everything it reports goes to **Workers Logs** (enabled in `wrangler.jsonc` → `observability.logs`) as single-line JSON, and to Cloudflare's built-in Worker metrics. Automatic *invocation logs* are **off** because they would record full request URLs — invitation and password-reset links carry one-time secrets — so failed requests are logged explicitly by the app (`api_request_failed`) and the invitation API takes its token in the `X-Invitation-Token` header rather than the URL.
 
 ## Log events
 

--- a/src/client/components/InvitePage.tsx
+++ b/src/client/components/InvitePage.tsx
@@ -41,7 +41,8 @@ export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
     async function loadInvitation() {
       try {
         const response = await fetchJson<InvitationLookupResponse>(
-          `/api/invitations/${token}`,
+          "/api/invitations/lookup",
+          { headers: { "X-Invitation-Token": token } },
         );
 
         if (cancelled) return;
@@ -75,8 +76,12 @@ export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
 
     try {
       const response = await fetchJson<{ household?: { slug: string } | null }>(
-        `/api/invitations/${token}/accept`,
-        { method: "POST", body: JSON.stringify(body) },
+        "/api/invitations/accept",
+        {
+          method: "POST",
+          headers: { "X-Invitation-Token": token },
+          body: JSON.stringify(body),
+        },
       );
 
       if (!response.household?.slug) {

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -38,13 +38,14 @@ export async function fetchJson<T>(
   input: RequestInfo,
   init?: RequestInit,
 ): Promise<T> {
+  const { headers: initHeaders, ...restInit } = init ?? {};
   const response = await fetch(input, {
     credentials: "include",
+    ...restInit,
     headers: {
       "Content-Type": "application/json",
-      ...(init?.headers ?? {}),
+      ...(initHeaders as Record<string, string> | undefined),
     },
-    ...init,
   });
 
   if (!response.ok) {

--- a/src/server/routes/invitations.ts
+++ b/src/server/routes/invitations.ts
@@ -38,9 +38,24 @@ export const invitationRoutes = new Hono<{
 invitationRoutes.use("*", loadAuthSession);
 invitationRoutes.use("*", rateLimit(RATE_LIMITS.invitations));
 
-invitationRoutes.get("/:token", async (c) => {
+export const INVITATION_TOKEN_HEADER = "x-invitation-token";
+
+/**
+ * The invitation token is a secret; it travels in a header instead of the
+ * URL so it never lands in request/URL logs or referrers.
+ */
+function invitationTokenFrom(headers: Headers): string | null {
+  const value = headers.get(INVITATION_TOKEN_HEADER)?.trim();
+  return value ? value : null;
+}
+
+invitationRoutes.get("/lookup", async (c) => {
+  const token = invitationTokenFrom(c.req.raw.headers);
+  if (!token) {
+    return c.json({ error: "Invitation token header is required" }, 400);
+  }
   await refreshExpiredInvitations(c.env.DB);
-  const tokenHash = await hashInvitationToken(c.req.param("token"));
+  const tokenHash = await hashInvitationToken(token);
   const invitation = await getInvitationByTokenHash(c.env.DB, tokenHash);
 
   if (!invitation || invitation.status !== "pending") {
@@ -71,7 +86,11 @@ invitationRoutes.get("/:token", async (c) => {
   });
 });
 
-invitationRoutes.post("/:token/accept", async (c) => {
+invitationRoutes.post("/accept", async (c) => {
+  const token = invitationTokenFrom(c.req.raw.headers);
+  if (!token) {
+    return c.json({ error: "Invitation token header is required" }, 400);
+  }
   await refreshExpiredInvitations(c.env.DB);
 
   let payload: AcceptInvitationPayload = {};
@@ -83,7 +102,7 @@ invitationRoutes.post("/:token/accept", async (c) => {
     return c.json({ error: "Invalid JSON body" }, 400);
   }
 
-  const tokenHash = await hashInvitationToken(c.req.param("token"));
+  const tokenHash = await hashInvitationToken(token);
   const invitation = await getInvitationByTokenHash(c.env.DB, tokenHash);
 
   if (!invitation || invitation.status !== "pending") {

--- a/test/inbox-routes.test.ts
+++ b/test/inbox-routes.test.ts
@@ -1387,8 +1387,9 @@ describe("worker routes", () => {
   });
 
   it("accepts an invitation via provisioning signup and attaches the user to the invited household", async () => {
-    const response = await invokeWorker("/api/invitations/test-token/accept", {
+    const response = await invokeWorker("/api/invitations/accept", {
       method: "POST",
+      headers: { "x-invitation-token": "test-token" },
       body: JSON.stringify({
         name: "Invited Person",
         password: "super-secure-password",

--- a/test/integration/invitation-accept.test.ts
+++ b/test/integration/invitation-accept.test.ts
@@ -52,9 +52,12 @@ async function signUpWithCookie(email: string) {
 }
 
 async function postAccept(token: string, body: unknown) {
-  return SELF.fetch(`http://localhost:8787/api/invitations/${token}/accept`, {
+  return SELF.fetch("http://localhost:8787/api/invitations/accept", {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: {
+      "content-type": "application/json",
+      "x-invitation-token": token,
+    },
     body: JSON.stringify(body),
   });
 }
@@ -110,9 +113,9 @@ describe("invitation acceptance (end-to-end against D1)", () => {
     const cookie = await signUpWithCookie("kid@example.com");
 
     const lookup = await SELF.fetch(
-      `http://localhost:8787/api/invitations/${token}`,
+      "http://localhost:8787/api/invitations/lookup",
       {
-        headers: { cookie },
+        headers: { cookie, "x-invitation-token": token },
       },
     );
     await expect(lookup.json()).resolves.toMatchObject({
@@ -121,10 +124,14 @@ describe("invitation acceptance (end-to-end against D1)", () => {
     });
 
     const response = await SELF.fetch(
-      `http://localhost:8787/api/invitations/${token}/accept`,
+      "http://localhost:8787/api/invitations/accept",
       {
         method: "POST",
-        headers: { cookie, "content-type": "application/json" },
+        headers: {
+          cookie,
+          "content-type": "application/json",
+          "x-invitation-token": token,
+        },
       },
     );
 
@@ -149,9 +156,9 @@ describe("invitation acceptance (end-to-end against D1)", () => {
     const cookie = await signUpWithCookie("someone-else@example.com");
 
     const lookup = await SELF.fetch(
-      `http://localhost:8787/api/invitations/${token}`,
+      "http://localhost:8787/api/invitations/lookup",
       {
-        headers: { cookie },
+        headers: { cookie, "x-invitation-token": token },
       },
     );
     await expect(lookup.json()).resolves.toMatchObject({
@@ -159,8 +166,8 @@ describe("invitation acceptance (end-to-end against D1)", () => {
     });
 
     const response = await SELF.fetch(
-      `http://localhost:8787/api/invitations/${token}/accept`,
-      { method: "POST", headers: { cookie } },
+      "http://localhost:8787/api/invitations/accept",
+      { method: "POST", headers: { cookie, "x-invitation-token": token } },
     );
     expect(response.status).toBe(403);
     expect(await count("household_invitations", "status = 'pending'")).toBe(1);
@@ -171,7 +178,8 @@ describe("invitation acceptance (end-to-end against D1)", () => {
     await createTestUser({ email: "kid@example.com" });
 
     const lookup = await SELF.fetch(
-      `http://localhost:8787/api/invitations/${token}`,
+      "http://localhost:8787/api/invitations/lookup",
+      { headers: { "x-invitation-token": token } },
     );
     await expect(lookup.json()).resolves.toMatchObject({
       accountExists: true,

--- a/test/integration/invitation-expiry.test.ts
+++ b/test/integration/invitation-expiry.test.ts
@@ -65,15 +65,19 @@ describe("invitation expiry", () => {
     const token = await seed(new Date(Date.now() - 60_000));
 
     const lookup = await SELF.fetch(
-      `http://localhost:8787/api/invitations/${token}`,
+      "http://localhost:8787/api/invitations/lookup",
+      { headers: { "x-invitation-token": token } },
     );
     expect([404, 410]).toContain(lookup.status);
 
     const accept = await SELF.fetch(
-      `http://localhost:8787/api/invitations/${token}/accept`,
+      "http://localhost:8787/api/invitations/accept",
       {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: {
+          "content-type": "application/json",
+          "x-invitation-token": token,
+        },
         body: JSON.stringify({ name: "Kid", password: "averylongpassword123" }),
       },
     );

--- a/test/integration/rate-limit.test.ts
+++ b/test/integration/rate-limit.test.ts
@@ -66,8 +66,11 @@ describe("rate limiting (D1-backed)", () => {
 
   it("throttles invitation token probing", async () => {
     const probe = () =>
-      SELF.fetch("http://localhost:8787/api/invitations/does-not-exist", {
-        headers: { "cf-connecting-ip": "198.51.100.2" },
+      SELF.fetch("http://localhost:8787/api/invitations/lookup", {
+        headers: {
+          "cf-connecting-ip": "198.51.100.2",
+          "x-invitation-token": "does-not-exist",
+        },
       });
 
     for (let attempt = 0; attempt < RATE_LIMITS.invitations.max; attempt += 1) {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -98,7 +98,10 @@
   "observability": {
     "logs": {
       "enabled": true,
-      "invocation_logs": true
+      // Invocation logs record full request URLs. Invitation and reset links
+      // carry secrets in the path/query, so we rely on the app's structured
+      // logs (docs/operations.md) instead.
+      "invocation_logs": false
     }
   }
 }


### PR DESCRIPTION
## Summary

Closes #117.

- The invitation API now takes the secret in an **`X-Invitation-Token`** header: `GET /api/invitations/lookup` and `POST /api/invitations/accept` replace the `/:token` path routes. The emailed SPA link `/invite/<token>` is unchanged (asset/SPA navigation), but no API call carries the token in the path any more.
- `fetchJson` merges caller headers with the JSON content-type (previously a caller-supplied `headers` replaced it).
- `wrangler.jsonc`: `observability.logs.invocation_logs: false` — invocation logs record full request URLs, and since #143 every request (incl. `/invite/<token>` and `/reset-password?token=…`) passes through the Worker. The app's structured `api_request_failed` / event logs (#150) cover what invocation logs provided. `docs/operations.md` explains.

## Tests
All invitation tests (accept, expiry, recovery, rate-limit probing, route test) moved to the header form; `npm run ci` green: 220 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)