### PR TITLE
ci: guard migration numbering against main for the shared preview D1; document preview isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,36 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # All pull requests deploy to one shared preview D1. Two open PRs that
+      # both add "0012_*.sql" with different names would be applied in PR
+      # order and never match main, so refuse migration numbers that already
+      # exist on main under another name, and require the branch to continue
+      # main's sequence.
+      - name: Check migration numbering against main
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin main
+          mapfile -t main_files < <(git ls-tree --name-only origin/main migrations/ | xargs -n1 basename | grep -E '^[0-9]{4}_.*\.sql$' | sort)
+          mapfile -t branch_files < <(ls migrations | grep -E '^[0-9]{4}_.*\.sql$' | sort)
+          declare -A main_by_number
+          for f in "${main_files[@]}"; do main_by_number["${f:0:4}"]="$f"; done
+          status=0
+          for f in "${branch_files[@]}"; do
+            n="${f:0:4}"
+            if [[ -n "${main_by_number[$n]:-}" && "${main_by_number[$n]}" != "$f" ]]; then
+              echo "::error::migrations/$f reuses number $n which main already has as ${main_by_number[$n]}; renumber it"
+              status=1
+            fi
+          done
+          for f in "${main_files[@]}"; do
+            if [[ ! -f "migrations/$f" ]]; then
+              echo "::error::migrations/$f exists on main but not on this branch; rebase onto main"
+              status=1
+            fi
+          done
+          exit $status
+
       - name: Lint and format check
         run: npm run check
 

--- a/docs/ci-cd-architecture.md
+++ b/docs/ci-cd-architecture.md
@@ -40,6 +40,15 @@ Flow:
 
 Fork pull requests do not get preview deploys by default because GitHub does not expose deployment secrets to fork-triggered workflows.
 
+#### The shared preview database
+
+Every pull request deploys to the **same** preview Worker and preview D1 (`mi-casa-su-casa-preview`). That keeps setup simple but has two consequences:
+
+- a PR's migrations are applied to the shared database as soon as its preview deploys, so a broken or destructive migration affects every other open PR's preview — reset it with the steps in [`runbook.md`](./runbook.md#7-reset-the-shared-preview-database);
+- two open PRs must not reuse a migration number: the `CI` workflow fails a PR whose `migrations/NNNN_*.sql` number already exists on `main` under a different name, or that is missing migrations `main` already has (rebase).
+
+If you need isolated previews, the Cloudflare way is one preview alias per PR (`wrangler versions upload --preview-alias pr-<n>`) plus a per-PR D1 created in the workflow (`wrangler d1 create preview-pr-<n>`) and deleted on PR close; the workflow is written so that swapping the injected database id is the only change needed.
+
 ### 3. `Production Deploy`
 
 File: `.github/workflows/production-deploy.yml`


### PR DESCRIPTION
## Summary

Closes #115.

All PRs share one preview D1, so two open PRs with the same migration number (different names) would be applied in PR order and never match `main`.

- `ci.yml` (pull requests): fetches `origin/main` and **fails** when a branch migration reuses a number that `main` already has under another name, or when the branch lacks migrations `main` already has (→ rebase). Bash syntax-checked; YAML validated.
- `docs/ci-cd-architecture.md`: a "shared preview database" section — consequences, the reset procedure (runbook §7, added in #151), and how to move to per-PR previews (preview alias + per-PR D1) if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)