### PR TITLE
feat: paginate provider messages and quarantine lists (keyset cursor) with load-older controls

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -53,6 +53,7 @@ import type {
   ProviderOption,
   ProviderSummary,
   QuarantineMessage,
+  QuarantineMessagesResponse,
   SenderRule,
   SenderRuleFormState,
   SetupStatus,
@@ -237,6 +238,15 @@ export function App() {
   const [isSavingProviderConfiguration, setIsSavingProviderConfiguration] =
     useState(false);
 
+  const [messagesNextBefore, setMessagesNextBefore] = useState<string | null>(
+    null,
+  );
+  const [isLoadingOlderMessages, setIsLoadingOlderMessages] = useState(false);
+  const [quarantineNextBefore, setQuarantineNextBefore] = useState<
+    string | null
+  >(null);
+  const [isLoadingOlderQuarantine, setIsLoadingOlderQuarantine] =
+    useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [viewError, setViewError] = useState<string | null>(null);
   const [pendingInviteLink, setPendingInviteLink] = useState<string | null>(
@@ -1000,12 +1010,13 @@ export function App() {
 
       try {
         const response = await fetchJson<ProviderMessagesResponse>(
-          householdApiPath(`/inbox/providers/${selectedProviderKey}`),
+          householdApiPath(`/inbox/providers/${selectedProviderKey}?limit=50`),
         );
 
         if (cancelled) return;
 
         setMessages(response.messages);
+        setMessagesNextBefore(response.page?.nextBefore ?? null);
         setSelectedMessageId((current) => {
           if (current && response.messages.some((m) => m.id === current)) {
             return current;
@@ -1053,13 +1064,14 @@ export function App() {
       setIsLoadingQuarantine(true);
 
       try {
-        const response = await fetchJson<{ messages: QuarantineMessage[] }>(
-          householdApiPath("/inbox/quarantine"),
+        const response = await fetchJson<QuarantineMessagesResponse>(
+          householdApiPath("/inbox/quarantine?limit=50"),
         );
 
         if (cancelled) return;
 
         setQuarantineMessages(response.messages);
+        setQuarantineNextBefore(response.page?.nextBefore ?? null);
         setSelectedQuarantineId((current) => {
           if (current && response.messages.some((m) => m.id === current)) {
             return current;
@@ -1277,12 +1289,73 @@ export function App() {
     });
   }
 
+  async function loadOlderMessages() {
+    if (!messagesNextBefore || !selectedProviderKey || isLoadingOlderMessages) {
+      return;
+    }
+    setIsLoadingOlderMessages(true);
+    try {
+      const response = await fetchJson<ProviderMessagesResponse>(
+        householdApiPath(
+          `/inbox/providers/${selectedProviderKey}?limit=50&before=${encodeURIComponent(messagesNextBefore)}`,
+        ),
+      );
+      setMessages((current) => {
+        const seen = new Set(current.map((m) => m.id));
+        return [
+          ...current,
+          ...response.messages.filter((m) => !seen.has(m.id)),
+        ];
+      });
+      setMessagesNextBefore(response.page?.nextBefore ?? null);
+    } catch (error) {
+      setViewError(
+        error instanceof Error
+          ? error.message
+          : "Unable to load older messages",
+      );
+    } finally {
+      setIsLoadingOlderMessages(false);
+    }
+  }
+
+  async function loadOlderQuarantine() {
+    if (!quarantineNextBefore || isLoadingOlderQuarantine) {
+      return;
+    }
+    setIsLoadingOlderQuarantine(true);
+    try {
+      const response = await fetchJson<QuarantineMessagesResponse>(
+        householdApiPath(
+          `/inbox/quarantine?limit=50&before=${encodeURIComponent(quarantineNextBefore)}`,
+        ),
+      );
+      setQuarantineMessages((current) => {
+        const seen = new Set(current.map((m) => m.id));
+        return [
+          ...current,
+          ...response.messages.filter((m) => !seen.has(m.id)),
+        ];
+      });
+      setQuarantineNextBefore(response.page?.nextBefore ?? null);
+    } catch (error) {
+      setViewError(
+        error instanceof Error
+          ? error.message
+          : "Unable to load older quarantined messages",
+      );
+    } finally {
+      setIsLoadingOlderQuarantine(false);
+    }
+  }
+
   async function refreshQuarantine() {
     if (!isAuthenticated || !isOwner || !currentHousehold) return;
-    const response = await fetchJson<{ messages: QuarantineMessage[] }>(
-      householdApiPath("/inbox/quarantine"),
+    const response = await fetchJson<QuarantineMessagesResponse>(
+      householdApiPath("/inbox/quarantine?limit=50"),
     );
     setQuarantineMessages(response.messages);
+    setQuarantineNextBefore(response.page?.nextBefore ?? null);
     setSelectedQuarantineId((current) => {
       if (current && response.messages.some((m) => m.id === current)) {
         return current;
@@ -2024,6 +2097,9 @@ export function App() {
               isLoadingInbox={isLoadingInbox}
               isSavingMessage={isSavingMessage}
               onStatusChange={handleStatusChange}
+              hasOlderMessages={messagesNextBefore !== null}
+              isLoadingOlderMessages={isLoadingOlderMessages}
+              onLoadOlderMessages={loadOlderMessages}
             />
           }
         />
@@ -2095,6 +2171,9 @@ export function App() {
                 onReleaseProviderKeyChange={setReleaseProviderKey}
                 isReviewingQuarantine={isReviewingQuarantine}
                 onQuarantineReview={handleQuarantineReview}
+                hasOlderMessages={quarantineNextBefore !== null}
+                isLoadingOlderMessages={isLoadingOlderQuarantine}
+                onLoadOlderMessages={loadOlderQuarantine}
               />
             ) : (
               <Navigate

--- a/src/client/components/InboxView.tsx
+++ b/src/client/components/InboxView.tsx
@@ -40,6 +40,9 @@ interface InboxViewProps {
   isLoadingInbox: boolean;
   isSavingMessage: boolean;
   onStatusChange: (status: InboxMessage["status"]) => void;
+  hasOlderMessages?: boolean;
+  isLoadingOlderMessages?: boolean;
+  onLoadOlderMessages?: () => void;
 }
 
 export function InboxView({
@@ -52,6 +55,9 @@ export function InboxView({
   isLoadingInbox,
   isSavingMessage,
   onStatusChange,
+  hasOlderMessages = false,
+  isLoadingOlderMessages = false,
+  onLoadOlderMessages,
 }: InboxViewProps) {
   const [copiedCodeId, setCopiedCodeId] = useState<string | null>(null);
 
@@ -353,6 +359,19 @@ export function InboxView({
                   Select another provider or wait for the next verification
                   email.
                 </Typography>
+              </Box>
+            )}
+
+            {hasOlderMessages && (
+              <Box sx={{ p: 1.5, textAlign: "center" }}>
+                <Button
+                  size="small"
+                  variant="text"
+                  disabled={isLoadingOlderMessages}
+                  onClick={onLoadOlderMessages}
+                >
+                  {isLoadingOlderMessages ? "Loading…" : "Load older messages"}
+                </Button>
               </Box>
             )}
           </List>

--- a/src/client/components/QuarantineView.tsx
+++ b/src/client/components/QuarantineView.tsx
@@ -44,6 +44,9 @@ interface QuarantineViewProps {
   onReleaseProviderKeyChange: (key: string) => void;
   isReviewingQuarantine: boolean;
   onQuarantineReview: (action: "dismiss" | "release") => Promise<boolean>;
+  hasOlderMessages?: boolean;
+  isLoadingOlderMessages?: boolean;
+  onLoadOlderMessages?: () => void;
 }
 
 export function QuarantineView({
@@ -56,6 +59,9 @@ export function QuarantineView({
   onReleaseProviderKeyChange,
   isReviewingQuarantine,
   onQuarantineReview,
+  hasOlderMessages = false,
+  isLoadingOlderMessages = false,
+  onLoadOlderMessages,
 }: QuarantineViewProps) {
   const [copiedCodeId, setCopiedCodeId] = useState<string | null>(null);
   const [reviewAction, setReviewAction] = useState<
@@ -216,6 +222,19 @@ export function QuarantineView({
                   Messages that need manual classification will appear here for
                   owner review.
                 </Typography>
+              </Box>
+            )}
+
+            {hasOlderMessages && (
+              <Box sx={{ p: 1.5, textAlign: "center" }}>
+                <Button
+                  size="small"
+                  variant="text"
+                  disabled={isLoadingOlderMessages}
+                  onClick={onLoadOlderMessages}
+                >
+                  {isLoadingOlderMessages ? "Loading…" : "Load older messages"}
+                </Button>
               </Box>
             )}
           </List>

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -190,12 +190,24 @@ export type InvitationAcceptanceState = {
   password: string;
 };
 
+export type PageInfo = {
+  limit: number;
+  /** Cursor for older items, null when everything has been loaded. */
+  nextBefore: string | null;
+};
+
 export type ProviderMessagesResponse = {
   provider: {
     providerKey: string;
     displayName: string;
   };
   messages: InboxMessage[];
+  page: PageInfo;
+};
+
+export type QuarantineMessagesResponse = {
+  messages: QuarantineMessage[];
+  page: PageInfo;
 };
 
 export type LoginState = {

--- a/src/server/db/repositories/messages.ts
+++ b/src/server/db/repositories/messages.ts
@@ -122,11 +122,54 @@ export async function insertQuarantineMessage(
   return { id, receivedAt, deleteAfter };
 }
 
+export const DEFAULT_PAGE_SIZE = 50;
+export const MAX_PAGE_SIZE = 200;
+
+export type PageOptions = {
+  /** Maximum rows to return (1..MAX_PAGE_SIZE). */
+  limit?: number;
+  /** Only rows received strictly before this ISO timestamp (keyset cursor). */
+  before?: string | null;
+};
+
+export type Page<T> = {
+  items: T[];
+  /** Cursor for the next (older) page, or null when this was the last page. */
+  nextBefore: string | null;
+};
+
+export function normalizePageOptions(options: PageOptions = {}) {
+  const requested = Number(options.limit ?? DEFAULT_PAGE_SIZE);
+  const limit = Number.isFinite(requested)
+    ? Math.min(MAX_PAGE_SIZE, Math.max(1, Math.floor(requested)))
+    : DEFAULT_PAGE_SIZE;
+  const before =
+    options.before && !Number.isNaN(Date.parse(options.before))
+      ? new Date(options.before).toISOString()
+      : null;
+  return { limit, before };
+}
+
+function toPage<T extends { received_at: string }>(
+  rows: T[],
+  limit: number,
+): Page<T> {
+  const hasMore = rows.length > limit;
+  const items = hasMore ? rows.slice(0, limit) : rows;
+  return {
+    items,
+    nextBefore: hasMore ? (items[items.length - 1]?.received_at ?? null) : null,
+  };
+}
+
 export async function listMessagesForProvider(
   db: D1Database,
   householdId: string,
   providerKey: string,
-): Promise<InboxMessageRow[]> {
+  options: PageOptions = {},
+): Promise<Page<InboxMessageRow>> {
+  const { limit, before } = normalizePageOptions(options);
+  // Fetch one extra row to know whether an older page exists.
   const result = await dbForDatabase(db).all<InboxMessageRow>(sql`
     SELECT messages.id, households.slug AS household_slug, providers.provider_key, providers.display_name AS provider_display_name,
             messages.subject, messages.from_header, messages.text_body,
@@ -135,10 +178,12 @@ export async function listMessagesForProvider(
     INNER JOIN providers ON providers.id = messages.provider_id
     INNER JOIN households ON households.id = messages.household_id
     WHERE messages.household_id = ${householdId} AND providers.provider_key = ${providerKey}
-    ORDER BY messages.received_at DESC
+      AND (${before} IS NULL OR messages.received_at < ${before})
+    ORDER BY messages.received_at DESC, messages.id DESC
+    LIMIT ${limit + 1}
   `);
 
-  return result;
+  return toPage(result, limit);
 }
 
 export async function listProviderSummariesForUser(
@@ -188,7 +233,9 @@ export async function countUnreviewedQuarantine(
 export async function listQuarantineMessages(
   db: D1Database,
   householdId: string,
-): Promise<QuarantineMessageRow[]> {
+  options: PageOptions = {},
+): Promise<Page<QuarantineMessageRow>> {
+  const { limit, before } = normalizePageOptions(options);
   const result = await dbForDatabase(db).all<QuarantineMessageRow>(sql`
     SELECT quarantine_messages.id,
             households.slug AS household_slug,
@@ -205,10 +252,12 @@ export async function listQuarantineMessages(
     FROM quarantine_messages
     INNER JOIN households ON households.id = quarantine_messages.household_id
     WHERE quarantine_messages.household_id = ${householdId} AND reviewed_at IS NULL
-    ORDER BY received_at DESC
+      AND (${before} IS NULL OR received_at < ${before})
+    ORDER BY received_at DESC, quarantine_messages.id DESC
+    LIMIT ${limit + 1}
   `);
 
-  return result;
+  return toPage(result, limit);
 }
 
 export async function updateMessageStatus(

--- a/src/server/routes/inbox.ts
+++ b/src/server/routes/inbox.ts
@@ -11,6 +11,7 @@ import {
   listMessagesForProvider,
   listProviderSummariesForUser,
   listQuarantineMessages,
+  normalizePageOptions,
   reviewQuarantineMessage,
   updateMessageStatus,
 } from "../db/repositories/messages";
@@ -80,17 +81,23 @@ inboxRoutes.get("/:slug/providers/:providerKey", async (c) => {
     return c.json({ error: "Provider not found" }, 404);
   }
 
-  const messages = await listMessagesForProvider(
+  const page = normalizePageOptions({
+    limit: Number(c.req.query("limit") ?? Number.NaN),
+    before: c.req.query("before") ?? null,
+  });
+  const result = await listMessagesForProvider(
     c.env.DB,
     household.id,
     providerKey,
+    page,
   );
   return c.json({
     provider: {
       providerKey: provider.provider_key,
       displayName: provider.display_name,
     },
-    messages,
+    messages: result.items,
+    page: { limit: page.limit, nextBefore: result.nextBefore },
   });
 });
 
@@ -159,8 +166,15 @@ inboxRoutes.get("/:slug/quarantine", async (c) => {
     return c.json({ error: "Forbidden" }, 403);
   }
 
-  const messages = await listQuarantineMessages(c.env.DB, household.id);
-  return c.json({ messages });
+  const page = normalizePageOptions({
+    limit: Number(c.req.query("limit") ?? Number.NaN),
+    before: c.req.query("before") ?? null,
+  });
+  const result = await listQuarantineMessages(c.env.DB, household.id, page);
+  return c.json({
+    messages: result.items,
+    page: { limit: page.limit, nextBefore: result.nextBefore },
+  });
 });
 
 inboxRoutes.post("/:slug/quarantine/:messageId/review", async (c) => {

--- a/test/inbox-routes.test.ts
+++ b/test/inbox-routes.test.ts
@@ -586,12 +586,20 @@ vi.mock("../src/server/db/repositories/messages", () => ({
     _db: D1Database,
     householdId: string,
     providerKey: string,
-  ) =>
-    repoState.messages.filter(
+  ) => ({
+    items: repoState.messages.filter(
       (message) =>
         message.householdId === householdId &&
         message.provider_key === providerKey,
     ),
+    nextBefore: null,
+  }),
+  normalizePageOptions: (
+    options: { limit?: number; before?: string | null } = {},
+  ) => ({
+    limit: Number.isFinite(options.limit) ? Number(options.limit) : 50,
+    before: options.before ?? null,
+  }),
   findMessageById: async (
     _db: D1Database,
     householdId: string,
@@ -615,10 +623,12 @@ vi.mock("../src/server/db/repositories/messages", () => ({
     message.status = status;
     return message;
   },
-  listQuarantineMessages: async (_db: D1Database, householdId: string) =>
-    repoState.quarantine.filter(
+  listQuarantineMessages: async (_db: D1Database, householdId: string) => ({
+    items: repoState.quarantine.filter(
       (message) => message.householdId === householdId && !message.reviewed,
     ),
+    nextBefore: null,
+  }),
   reviewQuarantineMessage: async (
     _db: D1Database,
     householdId: string,

--- a/test/integration/email-pipeline.test.ts
+++ b/test/integration/email-pipeline.test.ts
@@ -88,7 +88,8 @@ describe("inbound email pipeline (worker.email against D1)", () => {
 
     expect(first.setReject).not.toHaveBeenCalled();
     expect(second.setReject).not.toHaveBeenCalled();
-    const rows = await listMessagesForProvider(db, household.id, "netflix");
+    const rows = (await listMessagesForProvider(db, household.id, "netflix"))
+      .items;
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({
       extracted_code: "482913",
@@ -153,7 +154,7 @@ describe("inbound email pipeline (worker.email against D1)", () => {
 
     expect(setReject).not.toHaveBeenCalled();
     expect(
-      (await listMessagesForProvider(db, household.id, "netflix"))[0],
+      (await listMessagesForProvider(db, household.id, "netflix")).items[0],
     ).toMatchObject({
       extracted_code: "555444",
     });
@@ -186,7 +187,7 @@ describe("inbound email pipeline (worker.email against D1)", () => {
     });
 
     expect(
-      await listMessagesForProvider(db, household.id, "netflix"),
+      (await listMessagesForProvider(db, household.id, "netflix")).items,
     ).toHaveLength(0);
     const quarantined = await db
       .prepare("SELECT quarantine_reason FROM quarantine_messages")

--- a/test/integration/error-handling.test.ts
+++ b/test/integration/error-handling.test.ts
@@ -145,9 +145,11 @@ describe("quarantine release", () => {
 
     expect(result?.releasedMessage).toMatchObject({ provider_key: "netflix" });
     expect(await count("messages")).toBe(1);
-    expect(await listQuarantineMessages(db, household.id)).toHaveLength(0);
+    expect((await listQuarantineMessages(db, household.id)).items).toHaveLength(
+      0,
+    );
     expect(
-      await listMessagesForProvider(db, household.id, "netflix"),
+      (await listMessagesForProvider(db, household.id, "netflix")).items,
     ).toHaveLength(1);
   });
 });

--- a/test/integration/messages-repository.test.ts
+++ b/test/integration/messages-repository.test.ts
@@ -48,7 +48,8 @@ describe("messages repository (D1)", () => {
       reason: "matched",
     });
 
-    const rows = await listMessagesForProvider(db, household.id, "netflix");
+    const rows = (await listMessagesForProvider(db, household.id, "netflix"))
+      .items;
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({
       household_slug: "casa",
@@ -136,11 +137,13 @@ describe("messages repository (D1)", () => {
       },
     );
 
-    expect(await listQuarantineMessages(db, household.id)).toHaveLength(2);
+    expect((await listQuarantineMessages(db, household.id)).items).toHaveLength(
+      2,
+    );
 
     await purgeExpired(db, new Date().toISOString());
 
-    const remaining = await listQuarantineMessages(db, household.id);
+    const remaining = (await listQuarantineMessages(db, household.id)).items;
     expect(remaining).toHaveLength(1);
   });
 });
@@ -188,7 +191,8 @@ describe("received_at is server time, not the Date: header (D1)", () => {
       new Date("2026-05-10T12:05:00Z"),
     );
 
-    const rows = await listMessagesForProvider(db, household.id, "netflix");
+    const rows = (await listMessagesForProvider(db, household.id, "netflix"))
+      .items;
     expect(rows.map((row) => row.received_at)).toEqual([
       "2026-05-10T12:05:00.000Z",
       "2026-05-10T12:00:00.000Z",

--- a/test/integration/pagination.test.ts
+++ b/test/integration/pagination.test.ts
@@ -1,0 +1,157 @@
+import { SELF } from "cloudflare:test";
+import { provisioningAuthForEnv } from "@server/auth/auth";
+import { createHousehold } from "@server/db/repositories/households";
+import {
+  listMessagesForProvider,
+  listQuarantineMessages,
+  normalizePageOptions,
+} from "@server/db/repositories/messages";
+import { createProvider } from "@server/db/repositories/provider-rules";
+import { describe, expect, it } from "vitest";
+
+import { db, testEnv } from "./helpers";
+
+async function ownerWithHousehold() {
+  const result = await provisioningAuthForEnv(testEnv()).api.signUpEmail({
+    body: {
+      email: "owner@example.com",
+      name: "Owner",
+      password: "averylongpassword123",
+    },
+    returnHeaders: true,
+  });
+  const cookie = result.headers
+    .getSetCookie()
+    .map((entry: string) => entry.split(";")[0])
+    .join("; ");
+  const household = await createHousehold(db, {
+    slug: "casa",
+    displayName: "Casa",
+    ownerUserId: result.response.user.id,
+  });
+  return { cookie, householdId: household?.id ?? "" };
+}
+
+async function seedMessages(
+  householdId: string,
+  providerId: string,
+  n: number,
+) {
+  const statements = [];
+  for (let i = 0; i < n; i += 1) {
+    const receivedAt = new Date(Date.UTC(2026, 0, 1, 0, i)).toISOString();
+    statements.push(
+      db
+        .prepare(
+          `INSERT INTO messages (id, household_id, message_id, provider_id, envelope_from, envelope_to,
+             text_body, classification_reason, raw_size, received_at, delete_after)
+           VALUES (?1, ?2, ?3, ?4, 'a@b.c', 'casa@x.y', 'body', 'r', 1, ?5, '2099-01-01T00:00:00.000Z')`,
+        )
+        .bind(`m-${i}`, householdId, `<m-${i}@t>`, providerId, receivedAt),
+    );
+    statements.push(
+      db
+        .prepare(
+          `INSERT INTO quarantine_messages (id, household_id, message_id, envelope_from, envelope_to,
+             text_body, quarantine_reason, raw_size, received_at, delete_after)
+           VALUES (?1, ?2, ?3, 'a@b.c', 'casa@x.y', 'body', 'r', 1, ?4, '2099-01-01T00:00:00.000Z')`,
+        )
+        .bind(`q-${i}`, householdId, `<q-${i}@t>`, receivedAt),
+    );
+  }
+  for (let i = 0; i < statements.length; i += 100) {
+    await db.batch(statements.slice(i, i + 100));
+  }
+}
+
+describe("list pagination", () => {
+  it("normalises page options", () => {
+    expect(normalizePageOptions()).toEqual({ limit: 50, before: null });
+    expect(normalizePageOptions({ limit: 0 })).toEqual({
+      limit: 1,
+      before: null,
+    });
+    expect(normalizePageOptions({ limit: 9999 })).toEqual({
+      limit: 200,
+      before: null,
+    });
+    expect(
+      normalizePageOptions({ limit: Number.NaN, before: "garbage" }),
+    ).toEqual({
+      limit: 50,
+      before: null,
+    });
+    expect(
+      normalizePageOptions({ before: "2026-01-01T00:10:00Z" }).before,
+    ).toBe("2026-01-01T00:10:00.000Z");
+  });
+
+  it("pages provider messages and quarantine newest-first with a keyset cursor", async () => {
+    const { cookie, householdId } = await ownerWithHousehold();
+    const provider = await createProvider(
+      db,
+      householdId,
+      "netflix",
+      "Netflix",
+    );
+    await seedMessages(householdId, provider.id, 60);
+
+    const first = await listMessagesForProvider(db, householdId, "netflix", {
+      limit: 50,
+    });
+    expect(first.items).toHaveLength(50);
+    expect(first.items[0]?.id).toBe("m-59");
+    expect(first.nextBefore).toBe(first.items[49]?.received_at ?? null);
+
+    const second = await listMessagesForProvider(db, householdId, "netflix", {
+      limit: 50,
+      before: first.nextBefore,
+    });
+    expect(second.items).toHaveLength(10);
+    expect(second.items.at(-1)?.id).toBe("m-0");
+    expect(second.nextBefore).toBeNull();
+
+    const quarantine = await listQuarantineMessages(db, householdId, {
+      limit: 25,
+    });
+    expect(quarantine.items).toHaveLength(25);
+    expect(quarantine.nextBefore).not.toBeNull();
+
+    // Over HTTP: defaults, page info, and the cursor round-trip.
+    const page1 = await SELF.fetch(
+      "http://localhost:8787/api/inbox/casa/providers/netflix",
+      { headers: { cookie } },
+    );
+    const body1 = await page1.json<{
+      messages: unknown[];
+      page: { limit: number; nextBefore: string | null };
+    }>();
+    expect(body1.messages).toHaveLength(50);
+    expect(body1.page).toMatchObject({ limit: 50 });
+    expect(body1.page.nextBefore).toBeTruthy();
+
+    const page2 = await SELF.fetch(
+      `http://localhost:8787/api/inbox/casa/providers/netflix?limit=50&before=${encodeURIComponent(body1.page.nextBefore as string)}`,
+      { headers: { cookie } },
+    );
+    const body2 = await page2.json<{
+      messages: unknown[];
+      page: { nextBefore: string | null };
+    }>();
+    expect(body2.messages).toHaveLength(10);
+    expect(body2.page.nextBefore).toBeNull();
+
+    const q = await SELF.fetch(
+      "http://localhost:8787/api/inbox/casa/quarantine?limit=200",
+      {
+        headers: { cookie },
+      },
+    );
+    const qBody = await q.json<{
+      messages: unknown[];
+      page: { nextBefore: string | null };
+    }>();
+    expect(qBody.messages).toHaveLength(60);
+    expect(qBody.page.nextBefore).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #120.

- `listMessagesForProvider` / `listQuarantineMessages` accept `{ limit, before }` (default **50**, max **200**), order by `received_at DESC, id DESC`, fetch `limit+1` to detect more, and return `{ items, nextBefore }` (keyset cursor = last `received_at`).
- `GET /api/inbox/:slug/providers/:providerKey` and `GET /api/inbox/:slug/quarantine` accept `?limit=&before=` and return `page: { limit, nextBefore }` alongside `messages` (existing shape preserved).
- Client: first page of 50, "Load older messages" button in the inbox and quarantine lists appends further pages by cursor (dedupes by id); `normalizePageOptions` clamps/validates input.

## Tests
- D1: 60 seeded messages → 50 + cursor, then 10 + `null`; quarantine paging; HTTP round-trip of the cursor; option normalisation (defaults, clamps, garbage `before`).
- Existing tests updated to the `{ items }` shape.

`npm run ci` green: 222 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)