### PR TITLE
feat: zod request validation for every JSON endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,10 +20,11 @@
         "drizzle-orm": "^0.45.2",
         "hono": "4.13.3",
         "postal-mime": "3.0.0",
-        "qrcode": "^1.5.4",
+        "qrcode": "1.5.4",
         "react": "19.2.8",
         "react-dom": "19.2.8",
-        "react-router-dom": "^7.18.2"
+        "react-router-dom": "^7.18.2",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.9",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "qrcode": "1.5.4",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "react-router-dom": "^7.18.2"
+    "react-router-dom": "^7.18.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.9",

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1696,11 +1696,14 @@ export function App() {
         getProviderAccessToggleRequest(shouldHaveAccess);
 
       await fetchJson<{ ok: boolean }>(
-        householdApiPath(`/admin/members/${userId}/provider-access`),
-        {
-          method,
-          body: JSON.stringify({ providerKey }),
-        },
+        householdApiPath(
+          method === "DELETE"
+            ? `/admin/members/${userId}/provider-access/${encodeURIComponent(providerKey)}`
+            : `/admin/members/${userId}/provider-access`,
+        ),
+        method === "DELETE"
+          ? { method }
+          : { method, body: JSON.stringify({ providerKey }) },
       );
 
       setStatusMessage(statusMessage);

--- a/src/server/http/schemas.ts
+++ b/src/server/http/schemas.ts
@@ -1,0 +1,176 @@
+import { z } from "zod";
+
+import { validateHouseholdSlug } from "../domain/household-slug";
+
+/** Request body schemas for every JSON endpoint (single source of truth). */
+
+const trimmed = (max: number, label = "value") =>
+  z
+    .string({ error: `${label} is required` })
+    .trim()
+    .min(1, `${label} is required`)
+    .max(max, `${label} must be at most ${max} characters`);
+
+export const emailSchema = z
+  .string({ error: "email is required" })
+  .trim()
+  .toLowerCase()
+  .min(3, "email is required")
+  .max(254, "email must be at most 254 characters")
+  .regex(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, "email must be a valid email address");
+
+export const passwordSchema = z
+  .string({ error: "password is required" })
+  .min(12, "password must be at least 12 characters")
+  .max(128, "password must be at most 128 characters");
+
+export const householdRoleSchema = z
+  .enum(["owner", "member", "admin"], {
+    error: "role must be owner or member",
+  })
+  .transform((role) => (role === "admin" ? "owner" : role));
+
+export const householdSlugSchema = z
+  .string({ error: "slug is required" })
+  .trim()
+  .toLowerCase()
+  .superRefine((slug, ctx) => {
+    const check = validateHouseholdSlug(slug);
+    if (!check.ok) ctx.addIssue({ code: "custom", message: check.error });
+  });
+
+const HOSTNAME =
+  /^(?=.{1,253}$)([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/;
+
+export const householdSettingsSchema = z.object({
+  displayName: trimmed(80, "displayName"),
+});
+
+export const createHouseholdSchema = z.object({
+  slug: householdSlugSchema,
+  displayName: trimmed(80, "displayName"),
+});
+
+export const providerSchema = z.object({
+  providerKey: z
+    .string({ error: "providerKey is required" })
+    .trim()
+    .toLowerCase()
+    .min(1, "providerKey is required")
+    .max(40, "providerKey must be at most 40 characters")
+    .regex(
+      /^[a-z0-9][a-z0-9-]*$/,
+      "providerKey may only contain lowercase letters, numbers and hyphens",
+    ),
+  displayName: trimmed(80, "displayName"),
+});
+
+export const senderRuleSchema = z
+  .object({
+    providerId: trimmed(64, "providerId"),
+    matchType: z.enum(["exact", "domain"], {
+      error: "matchType must be exact or domain",
+    }),
+    matchValue: z
+      .string({ error: "matchValue is required" })
+      .trim()
+      .toLowerCase()
+      .min(1, "matchValue is required")
+      .max(254, "matchValue must be at most 254 characters"),
+  })
+  .transform((rule) => ({
+    ...rule,
+    matchValue:
+      rule.matchType === "domain"
+        ? rule.matchValue.replace(/^@+/, "")
+        : rule.matchValue,
+  }))
+  .superRefine((rule, ctx) => {
+    if (rule.matchType === "domain" && !HOSTNAME.test(rule.matchValue)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["matchValue"],
+        message: "matchValue must be a domain like netflix.com",
+      });
+    }
+    if (
+      rule.matchType === "exact" &&
+      !emailSchema.safeParse(rule.matchValue).success
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["matchValue"],
+        message: "matchValue must be a full email address",
+      });
+    }
+  });
+
+export const invitationSchema = z.object({
+  email: emailSchema,
+  name: trimmed(80, "name"),
+  role: householdRoleSchema.default("member"),
+  providerIds: z
+    .array(z.string().trim().min(1).max(64))
+    .max(50, "at most 50 providers can be scoped")
+    .default([]),
+});
+
+export const createMemberSchema = z.object({
+  email: emailSchema,
+  name: trimmed(80, "name"),
+  role: householdRoleSchema.default("member"),
+});
+
+export const roleChangeSchema = z.object({ role: householdRoleSchema });
+
+export const providerAccessSchema = z.object({
+  providerKey: trimmed(40, "providerKey").toLowerCase(),
+});
+
+export const profileSchema = z.object({
+  name: trimmed(80, "name"),
+  image: z
+    .union([
+      z.literal(""),
+      z
+        .string()
+        .trim()
+        .max(2048, "image must be at most 2048 characters")
+        .url("image must be an http(s) URL")
+        .refine(
+          (url) => /^https?:\/\//i.test(url),
+          "image must be an http(s) URL",
+        ),
+    ])
+    .optional()
+    .transform((value) => (value ? value : null)),
+});
+
+export const setupSchema = z.object({
+  email: emailSchema,
+  name: trimmed(80, "name"),
+  password: passwordSchema,
+  householdName: trimmed(80, "householdName"),
+  householdSlug: householdSlugSchema,
+  setupSecret: z
+    .string({ error: "setupSecret is required" })
+    .min(1, "setupSecret is required"),
+});
+
+export const acceptInvitationSchema = z.object({
+  name: trimmed(80, "name"),
+  password: passwordSchema,
+});
+
+export const quarantineReviewSchema = z.object({
+  action: z.enum(["dismiss", "release"], {
+    error: "action must be dismiss or release",
+  }),
+  providerKey: z.string().trim().toLowerCase().min(1).max(40).optional(),
+});
+
+export const messageStatusSchema = z.object({
+  status: z.enum(["new", "used", "expired"], {
+    error: "status must be new, used or expired",
+  }),
+});

--- a/src/server/http/validation.ts
+++ b/src/server/http/validation.ts
@@ -1,0 +1,44 @@
+import type { Context } from "hono";
+import type { z } from "zod";
+
+export type ParsedBody<T> =
+  | { ok: true; data: T }
+  | { ok: false; response: Response };
+
+/**
+ * Parses and validates a JSON request body against a zod schema. Returns a
+ * ready-made 400 JSON response listing the first problem per field so the
+ * client can show something actionable.
+ */
+export async function parseJsonBody<S extends z.ZodTypeAny>(
+  c: Context,
+  schema: S,
+): Promise<ParsedBody<z.infer<S>>> {
+  let raw: unknown;
+  try {
+    const text = await c.req.text();
+    raw = text.trim() ? JSON.parse(text) : {};
+  } catch {
+    return { ok: false, response: c.json({ error: "Invalid JSON body" }, 400) };
+  }
+
+  const result = schema.safeParse(raw);
+  if (!result.success) {
+    const fields: Record<string, string> = {};
+    for (const issue of result.error.issues) {
+      const key = issue.path.join(".") || "_";
+      if (!(key in fields)) fields[key] = issue.message;
+    }
+    const summary = Object.entries(fields)
+      .map(([key, message]) =>
+        key === "_" || message.startsWith(key) ? message : `${key}: ${message}`,
+      )
+      .join("; ");
+    return {
+      ok: false,
+      response: c.json({ error: summary || "Invalid request", fields }, 400),
+    };
+  }
+
+  return { ok: true, data: result.data };
+}

--- a/src/server/routes/admin.ts
+++ b/src/server/routes/admin.ts
@@ -44,14 +44,18 @@ import {
   updateSenderRule,
 } from "../db/repositories/provider-rules";
 import { sendHouseholdInvitationEmail } from "../email/sender";
+import {
+  createMemberSchema,
+  householdSettingsSchema,
+  invitationSchema,
+  providerAccessSchema,
+  providerSchema,
+  roleChangeSchema,
+  senderRuleSchema,
+} from "../http/schemas";
+import { parseJsonBody } from "../http/validation";
 import { logEvent } from "../runtime/log";
 import { createInvitationToken } from "../security/tokens";
-
-const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-function isValidEmail(value: string) {
-  return EMAIL_PATTERN.test(value) && value.length <= 254;
-}
 
 type AuditContext = {
   env: Env;
@@ -118,53 +122,10 @@ async function deliverInvitationEmail(
   }
 }
 
-type AccessPayload = {
-  providerKey?: string;
-};
-
-type CreateMemberPayload = {
-  email?: string;
-  name?: string;
-  role?: string;
-};
-
-type ProviderPayload = {
-  providerKey?: string;
-  displayName?: string;
-};
-
-type SenderRulePayload = {
-  providerId?: string;
-  matchType?: string;
-  matchValue?: string;
-};
-
-type InvitationPayload = {
-  email?: string;
-  name?: string;
-  /** "owner" | "member"; the legacy value "admin" is accepted as "owner". */
-  role?: InvitationRole | "admin";
-  providerIds?: string[];
-};
-
-type HouseholdSettingsPayload = {
-  displayName?: string;
-};
-
 export const adminRoutes = new Hono<{
   Bindings: Env;
   Variables: AppVariables;
 }>();
-
-/**
- * Household roles are "owner" | "member" everywhere. The UI used to send
- * "admin" for owners; keep accepting it so old clients don't break.
- */
-function normalizeHouseholdRole(value: unknown): "owner" | "member" | null {
-  if (value === "owner" || value === "admin") return "owner";
-  if (value === "member") return "member";
-  return null;
-}
 
 function householdSettingsPayload(
   env: Env,
@@ -177,34 +138,6 @@ function householdSettingsPayload(
     // The address providers must send codes to; null until EMAIL_DOMAIN is set.
     emailAddress: domain ? `${settings.slug}@${domain}` : null,
   };
-}
-
-function normalizeProviderKey(value: string | undefined) {
-  return value?.trim().toLowerCase() ?? "";
-}
-
-function normalizeDisplayName(value: string | undefined) {
-  return value?.trim() ?? "";
-}
-
-function normalizeEmail(value: string | undefined) {
-  return value?.trim().toLowerCase() ?? "";
-}
-
-function normalizeMatchValue(matchType: string, value: string | undefined) {
-  const trimmed = value?.trim().toLowerCase() ?? "";
-
-  if (matchType === "domain") {
-    return trimmed.replace(/^@+/, "");
-  }
-
-  return trimmed;
-}
-
-function isValidMatchType(
-  value: string | undefined,
-): value is "exact" | "domain" {
-  return value === "exact" || value === "domain";
 }
 
 adminRoutes.use("/:slug/*", requireHouseholdContext);
@@ -240,19 +173,9 @@ adminRoutes.patch("/:slug/settings", async (c) => {
     return c.json({ error: "Forbidden" }, 403);
   }
 
-  let payload: HouseholdSettingsPayload;
-
-  try {
-    payload = await c.req.json<HouseholdSettingsPayload>();
-  } catch {
-    return c.json({ error: "Invalid JSON body" }, 400);
-  }
-
-  const displayName = normalizeDisplayName(payload.displayName);
-
-  if (!displayName) {
-    return c.json({ error: "displayName is required" }, 400);
-  }
+  const body = await parseJsonBody(c, householdSettingsSchema);
+  if (!body.ok) return body.response;
+  const { displayName } = body.data;
 
   const settings = await updateHouseholdDisplayName(
     c.env.DB,
@@ -288,20 +211,9 @@ adminRoutes.get("/:slug/providers", async (c) => {
 adminRoutes.post("/:slug/providers", async (c) => {
   const household = c.get("household");
   if (!household) return c.json({ error: "Forbidden" }, 403);
-  let payload: ProviderPayload;
-
-  try {
-    payload = await c.req.json<ProviderPayload>();
-  } catch {
-    return c.json({ error: "Invalid JSON body" }, 400);
-  }
-
-  const providerKey = normalizeProviderKey(payload.providerKey);
-  const displayName = normalizeDisplayName(payload.displayName);
-
-  if (!providerKey || !displayName) {
-    return c.json({ error: "providerKey and displayName are required" }, 400);
-  }
+  const body = await parseJsonBody(c, providerSchema);
+  if (!body.ok) return body.response;
+  const { providerKey, displayName } = body.data;
 
   const existing = await getProviderByKey(c.env.DB, household.id, providerKey);
 
@@ -326,21 +238,10 @@ adminRoutes.post("/:slug/providers", async (c) => {
 adminRoutes.patch("/:slug/providers/:providerId", async (c) => {
   const household = c.get("household");
   if (!household) return c.json({ error: "Forbidden" }, 403);
-  let payload: ProviderPayload;
-
-  try {
-    payload = await c.req.json<ProviderPayload>();
-  } catch {
-    return c.json({ error: "Invalid JSON body" }, 400);
-  }
-
+  const body = await parseJsonBody(c, providerSchema);
+  if (!body.ok) return body.response;
   const providerId = c.req.param("providerId");
-  const providerKey = normalizeProviderKey(payload.providerKey);
-  const displayName = normalizeDisplayName(payload.displayName);
-
-  if (!providerKey || !displayName) {
-    return c.json({ error: "providerKey and displayName are required" }, 400);
-  }
+  const { providerKey, displayName } = body.data;
 
   const existing = await getProviderById(c.env.DB, household.id, providerId);
 
@@ -390,26 +291,10 @@ adminRoutes.delete("/:slug/providers/:providerId", async (c) => {
 adminRoutes.post("/:slug/provider-rules", async (c) => {
   const household = c.get("household");
   if (!household) return c.json({ error: "Forbidden" }, 403);
-  let payload: SenderRulePayload;
-
-  try {
-    payload = await c.req.json<SenderRulePayload>();
-  } catch {
-    return c.json({ error: "Invalid JSON body" }, 400);
-  }
-
-  if (!payload.providerId || !isValidMatchType(payload.matchType)) {
-    return c.json(
-      { error: "providerId and a valid matchType are required" },
-      400,
-    );
-  }
-
-  const matchValue = normalizeMatchValue(payload.matchType, payload.matchValue);
-
-  if (!matchValue) {
-    return c.json({ error: "matchValue is required" }, 400);
-  }
+  const body = await parseJsonBody(c, senderRuleSchema);
+  if (!body.ok) return body.response;
+  const payload = body.data;
+  const matchValue = payload.matchValue;
 
   const provider = await getProviderById(
     c.env.DB,
@@ -440,28 +325,11 @@ adminRoutes.post("/:slug/provider-rules", async (c) => {
 adminRoutes.patch("/:slug/provider-rules/:ruleId", async (c) => {
   const household = c.get("household");
   if (!household) return c.json({ error: "Forbidden" }, 403);
-  let payload: SenderRulePayload;
-
-  try {
-    payload = await c.req.json<SenderRulePayload>();
-  } catch {
-    return c.json({ error: "Invalid JSON body" }, 400);
-  }
-
+  const body = await parseJsonBody(c, senderRuleSchema);
+  if (!body.ok) return body.response;
+  const payload = body.data;
   const ruleId = c.req.param("ruleId");
-
-  if (!payload.providerId || !isValidMatchType(payload.matchType)) {
-    return c.json(
-      { error: "providerId and a valid matchType are required" },
-      400,
-    );
-  }
-
-  const matchValue = normalizeMatchValue(payload.matchType, payload.matchValue);
-
-  if (!matchValue) {
-    return c.json({ error: "matchValue is required" }, 400);
-  }
+  const matchValue = payload.matchValue;
 
   const [provider, existingRule] = await Promise.all([
     getProviderById(c.env.DB, household.id, payload.providerId),
@@ -558,28 +426,9 @@ adminRoutes.get("/:slug/invitations", async (c) => {
 adminRoutes.post("/:slug/invitations", async (c) => {
   const household = c.get("household");
   if (!household) return c.json({ error: "Forbidden" }, 403);
-  let payload: InvitationPayload;
-
-  try {
-    payload = await c.req.json<InvitationPayload>();
-  } catch {
-    return c.json({ error: "Invalid JSON body" }, 400);
-  }
-
-  const email = normalizeEmail(payload.email);
-  const name = normalizeDisplayName(payload.name);
-  const role: InvitationRole = normalizeHouseholdRole(payload.role) ?? "member";
-  const providerIds = Array.isArray(payload.providerIds)
-    ? payload.providerIds.filter((providerId) => Boolean(providerId))
-    : [];
-
-  if (!email || !name) {
-    return c.json({ error: "email and name are required" }, 400);
-  }
-
-  if (!isValidEmail(email)) {
-    return c.json({ error: "email must be a valid email address" }, 400);
-  }
+  const body = await parseJsonBody(c, invitationSchema);
+  if (!body.ok) return body.response;
+  const { email, name, role, providerIds } = body.data;
 
   const providersBelong = await assertProvidersBelongToHousehold(
     c.env.DB,
@@ -727,23 +576,10 @@ adminRoutes.delete("/:slug/invitations/:invitationId", async (c) => {
 adminRoutes.post("/:slug/members", async (c) => {
   const household = c.get("household");
   if (!household) return c.json({ error: "Forbidden" }, 403);
-  let payload: CreateMemberPayload;
-
-  try {
-    payload = await c.req.json<CreateMemberPayload>();
-  } catch {
-    return c.json({ error: "Invalid JSON body" }, 400);
-  }
-
-  if (!payload.email || !payload.name) {
-    return c.json({ error: "email and name are required" }, 400);
-  }
-
-  const memberEmail = normalizeEmail(payload.email);
-
-  if (!isValidEmail(memberEmail)) {
-    return c.json({ error: "email must be a valid email address" }, 400);
-  }
+  const body = await parseJsonBody(c, createMemberSchema);
+  if (!body.ok) return body.response;
+  const payload = body.data;
+  const memberEmail = payload.email;
 
   const inviter = c.get("user");
 
@@ -755,13 +591,12 @@ adminRoutes.post("/:slug/members", async (c) => {
   const expiresAt = new Date(
     Date.now() + 1000 * 60 * 60 * 24 * 7,
   ).toISOString();
-  const invitationRole: InvitationRole =
-    normalizeHouseholdRole(payload.role) ?? "member";
+  const invitationRole: InvitationRole = payload.role;
 
   const invitationId = await createHouseholdInvitation(c.env.DB, {
     householdId: household.id,
     email: memberEmail,
-    name: payload.name.trim(),
+    name: payload.name,
     role: invitationRole,
     tokenHash,
     invitedByUserId: inviter.id,
@@ -850,19 +685,9 @@ adminRoutes.patch("/:slug/members/:userId/role", async (c) => {
     );
   }
 
-  let payload: { role?: string };
-
-  try {
-    payload = await c.req.json<{ role?: string }>();
-  } catch {
-    return c.json({ error: "Invalid JSON body" }, 400);
-  }
-
-  const nextRole = normalizeHouseholdRole(payload.role);
-
-  if (!nextRole) {
-    return c.json({ error: "role must be owner or member" }, 400);
-  }
+  const body = await parseJsonBody(c, roleChangeSchema);
+  if (!body.ok) return body.response;
+  const nextRole = body.data.role;
 
   const household = c.get("household");
 
@@ -894,17 +719,9 @@ adminRoutes.post("/:slug/members/:userId/provider-access", async (c) => {
   const household = c.get("household");
   if (!household) return c.json({ error: "Forbidden" }, 403);
   const userId = c.req.param("userId");
-  let payload: AccessPayload;
-
-  try {
-    payload = await c.req.json<AccessPayload>();
-  } catch {
-    return c.json({ error: "Invalid JSON body" }, 400);
-  }
-
-  if (!payload.providerKey) {
-    return c.json({ error: "providerKey is required" }, 400);
-  }
+  const body = await parseJsonBody(c, providerAccessSchema);
+  if (!body.ok) return body.response;
+  const payload = body.data;
 
   const provider = await getProviderByKey(
     c.env.DB,
@@ -933,45 +750,52 @@ adminRoutes.post("/:slug/members/:userId/provider-access", async (c) => {
   return c.json({ ok: true });
 });
 
-adminRoutes.delete("/:slug/members/:userId/provider-access", async (c) => {
-  const household = c.get("household");
-  if (!household) return c.json({ error: "Forbidden" }, 403);
-  const userId = c.req.param("userId");
-  let payload: AccessPayload;
+// Accepts the provider key in the URL (preferred) or, for older clients, in a
+// JSON body on DELETE.
+adminRoutes.delete(
+  "/:slug/members/:userId/provider-access/:providerKey?",
+  async (c) => {
+    const household = c.get("household");
+    if (!household) return c.json({ error: "Forbidden" }, 403);
+    const userId = c.req.param("userId");
+    let payload: { providerKey: string };
+    const fromPath = c.req.param("providerKey");
+    if (fromPath) {
+      const parsed = providerAccessSchema.safeParse({ providerKey: fromPath });
+      if (!parsed.success) {
+        return c.json({ error: "providerKey is invalid" }, 400);
+      }
+      payload = parsed.data;
+    } else {
+      const body = await parseJsonBody(c, providerAccessSchema);
+      if (!body.ok) return body.response;
+      payload = body.data;
+    }
 
-  try {
-    payload = await c.req.json<AccessPayload>();
-  } catch {
-    return c.json({ error: "Invalid JSON body" }, 400);
-  }
+    const provider = await getProviderByKey(
+      c.env.DB,
+      household.id,
+      payload.providerKey,
+    );
 
-  if (!payload.providerKey) {
-    return c.json({ error: "providerKey is required" }, 400);
-  }
+    if (!provider) {
+      return c.json({ error: "Provider not found" }, 404);
+    }
 
-  const provider = await getProviderByKey(
-    c.env.DB,
-    household.id,
-    payload.providerKey,
-  );
+    const membership = await getHouseholdMembership(
+      c.env.DB,
+      userId,
+      household.id,
+    );
 
-  if (!provider) {
-    return c.json({ error: "Provider not found" }, 404);
-  }
+    if (!membership) {
+      return c.json({ error: "Member not found" }, 404);
+    }
 
-  const membership = await getHouseholdMembership(
-    c.env.DB,
-    userId,
-    household.id,
-  );
-
-  if (!membership) {
-    return c.json({ error: "Member not found" }, 404);
-  }
-
-  await revokeProviderAccess(c.env.DB, household.id, userId, provider.id);
-  await audit(c, "member.provider_access_revoked", "user", userId, {
-    providerKey: payload.providerKey,
-  });
-  return c.json({ ok: true });
-});
+    await revokeProviderAccess(c.env.DB, household.id, userId, provider.id);
+    await audit(c, "member.provider_access_revoked", "user", userId, {
+      providerKey: payload.providerKey,
+    });
+    return c.json({ ok: true });
+  },
+);

--- a/src/server/routes/households.ts
+++ b/src/server/routes/households.ts
@@ -14,17 +14,10 @@ import {
   removeUserFromHousehold,
 } from "../db/repositories/households";
 import { getInstallationState } from "../db/repositories/installation-state";
-import {
-  normalizeHouseholdSlug,
-  validateHouseholdSlug,
-} from "../domain/household-slug";
+import { createHouseholdSchema } from "../http/schemas";
+import { parseJsonBody } from "../http/validation";
 import { logEvent } from "../runtime/log";
 import { RATE_LIMITS, rateLimit } from "../security/rate-limit";
-
-type CreateHouseholdPayload = {
-  slug?: string;
-  displayName?: string;
-};
 
 /**
  * Who may create households: the installation owner and app-level admins
@@ -45,10 +38,6 @@ async function mayCreateHousehold(
   }
   const memberships = await listHouseholdsForUser(db, user.id);
   return memberships.length === 0;
-}
-
-function normalizeDisplayName(value: string | undefined) {
-  return value?.trim() ?? "";
 }
 
 export const householdRoutes = new Hono<{
@@ -75,28 +64,9 @@ householdRoutes.post("/", rateLimit(RATE_LIMITS.householdCreate), async (c) => {
     return c.json({ error: "Unauthorized" }, 401);
   }
 
-  let payload: CreateHouseholdPayload;
-
-  try {
-    payload = await c.req.json<CreateHouseholdPayload>();
-  } catch {
-    return c.json({ error: "Invalid JSON body" }, 400);
-  }
-
-  const slug = normalizeHouseholdSlug(payload.slug);
-  const displayName = normalizeDisplayName(payload.displayName);
-  const slugCheck = validateHouseholdSlug(slug);
-
-  if (!slugCheck.ok) {
-    return c.json({ error: slugCheck.error }, 400);
-  }
-
-  if (!displayName || displayName.length > 80) {
-    return c.json(
-      { error: "displayName is required (max 80 characters)" },
-      400,
-    );
-  }
+  const body = await parseJsonBody(c, createHouseholdSchema);
+  if (!body.ok) return body.response;
+  const { slug, displayName } = body.data;
 
   if (!(await mayCreateHousehold(c.env.DB, user))) {
     return c.json(

--- a/src/server/routes/inbox.ts
+++ b/src/server/routes/inbox.ts
@@ -19,14 +19,10 @@ import {
   getProviderByKey,
   userHasProviderAccess,
 } from "../db/repositories/provider-rules";
+import { messageStatusSchema, quarantineReviewSchema } from "../http/schemas";
+import { parseJsonBody } from "../http/validation";
 
 const VALID_MESSAGE_STATUSES = new Set(["new", "used", "expired"]);
-
-function isValidMessageStatus(
-  status: string,
-): status is "new" | "used" | "expired" {
-  return VALID_MESSAGE_STATUSES.has(status);
-}
 
 export const inboxRoutes = new Hono<{
   Bindings: Env;
@@ -133,17 +129,9 @@ inboxRoutes.patch("/:slug/messages/:messageId/status", async (c) => {
     }
   }
 
-  let payload: { status?: string };
-
-  try {
-    payload = await c.req.json<{ status?: string }>();
-  } catch {
-    return c.json({ error: "Invalid JSON body" }, 400);
-  }
-
-  if (!payload.status || !isValidMessageStatus(payload.status)) {
-    return c.json({ error: "Invalid message status" }, 400);
-  }
+  const body = await parseJsonBody(c, messageStatusSchema);
+  if (!body.ok) return body.response;
+  const payload = body.data;
 
   const message = await updateMessageStatus(
     c.env.DB,
@@ -185,20 +173,9 @@ inboxRoutes.post("/:slug/quarantine/:messageId/review", async (c) => {
     return c.json({ error: "Forbidden" }, 403);
   }
 
-  let payload: { action?: "dismiss" | "release"; providerKey?: string };
-
-  try {
-    payload = await c.req.json<{
-      action?: "dismiss" | "release";
-      providerKey?: string;
-    }>();
-  } catch {
-    return c.json({ error: "Invalid JSON body" }, 400);
-  }
-
-  if (payload.action !== "dismiss" && payload.action !== "release") {
-    return c.json({ error: "Invalid review action" }, 400);
-  }
+  const body = await parseJsonBody(c, quarantineReviewSchema);
+  if (!body.ok) return body.response;
+  const payload = body.data;
 
   let providerId: string | undefined;
 

--- a/src/server/routes/invitations.ts
+++ b/src/server/routes/invitations.ts
@@ -11,14 +11,10 @@ import {
   refreshExpiredInvitations,
 } from "../db/repositories/invitations";
 import { deleteUserById, findUserByEmail } from "../db/repositories/users";
+import { acceptInvitationSchema } from "../http/schemas";
 import { logEvent } from "../runtime/log";
 import { RATE_LIMITS, rateLimit } from "../security/rate-limit";
 import { hashInvitationToken } from "../security/tokens";
-
-type AcceptInvitationPayload = {
-  name?: string;
-  password?: string;
-};
 
 export const invitationRoutes = new Hono<{
   Bindings: Env;
@@ -83,14 +79,8 @@ invitationRoutes.post("/accept", async (c) => {
   }
   await refreshExpiredInvitations(c.env.DB);
 
-  let payload: AcceptInvitationPayload = {};
-
-  try {
-    const raw = await c.req.text();
-    payload = raw.trim() ? (JSON.parse(raw) as AcceptInvitationPayload) : {};
-  } catch {
-    return c.json({ error: "Invalid JSON body" }, 400);
-  }
+  // Read the raw body once; a signed-in user may send an empty body.
+  const rawBody = (await c.req.text()).trim();
 
   const tokenHash = await hashInvitationToken(token);
   const invitation = await getInvitationByTokenHash(c.env.DB, tokenHash);
@@ -107,16 +97,28 @@ invitationRoutes.post("/accept", async (c) => {
   const currentUser = c.get("user");
 
   // A signed-in user accepts with their existing account: no password, no
-  // name required.
+  // name required. Everyone else must provide both.
+  let accountDetails: { name: string; password: string } | null = null;
   if (!currentUser) {
-    if (!payload.name || !payload.password || payload.password.length < 12) {
+    let raw: unknown;
+    try {
+      raw = rawBody ? JSON.parse(rawBody) : {};
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+    const parsed = acceptInvitationSchema.safeParse(raw);
+    if (!parsed.success) {
+      const first = parsed.error.issues[0];
       return c.json(
         {
-          error: "name and a password with at least 12 characters are required",
+          error: first
+            ? `${first.path.join(".")}: ${first.message}`
+            : "Invalid request",
         },
         400,
       );
     }
+    accountDetails = parsed.data;
   }
 
   if (currentUser) {
@@ -153,8 +155,8 @@ invitationRoutes.post("/accept", async (c) => {
     );
   }
 
-  const name = payload.name?.trim() ?? "";
-  const password = payload.password ?? "";
+  const name = accountDetails?.name ?? "";
+  const password = accountDetails?.password ?? "";
 
   // An account for the invited address already exists (e.g. an earlier
   // attempt was interrupted after sign-up, or the person already has an

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -11,11 +11,8 @@ import {
   listUserSessions,
   updateUserProfile,
 } from "../db/repositories/settings";
-
-type ProfilePayload = {
-  name?: string;
-  image?: string | null;
-};
+import { profileSchema } from "../http/schemas";
+import { parseJsonBody } from "../http/validation";
 
 export const settingsRoutes = new Hono<{
   Bindings: Env;
@@ -69,36 +66,9 @@ settingsRoutes.patch("/profile", async (c) => {
     return c.json({ error: "Unauthorized" }, 401);
   }
 
-  let payload: ProfilePayload;
-
-  try {
-    payload = await c.req.json<ProfilePayload>();
-  } catch {
-    return c.json({ error: "Invalid JSON body" }, 400);
-  }
-
-  const name = payload.name?.trim() ?? "";
-  const image = payload.image?.trim() || null;
-
-  if (!name || name.length > 80) {
-    return c.json({ error: "name is required (max 80 characters)" }, 400);
-  }
-
-  if (image !== null) {
-    let valid = image.length <= 2048;
-    try {
-      const url = new URL(image);
-      valid = valid && (url.protocol === "https:" || url.protocol === "http:");
-    } catch {
-      valid = false;
-    }
-    if (!valid) {
-      return c.json(
-        { error: "image must be an http(s) URL of at most 2048 characters" },
-        400,
-      );
-    }
-  }
+  const body = await parseJsonBody(c, profileSchema);
+  if (!body.ok) return body.response;
+  const { name, image } = body.data;
 
   const profile = await updateUserProfile(c.env.DB, currentUser.id, {
     name,

--- a/src/server/routes/setup.ts
+++ b/src/server/routes/setup.ts
@@ -15,22 +15,11 @@ import {
   resetInstallationSetup,
 } from "../db/repositories/installation-state";
 import { deleteUserById, findUserByEmail } from "../db/repositories/users";
-import {
-  normalizeHouseholdSlug,
-  validateHouseholdSlug,
-} from "../domain/household-slug";
+import { setupSchema } from "../http/schemas";
+import { parseJsonBody } from "../http/validation";
 import { logEvent } from "../runtime/log";
 import { secretsEqual } from "../security/compare";
 import { RATE_LIMITS, rateLimit } from "../security/rate-limit";
-
-type SetupPayload = {
-  email?: string;
-  name?: string;
-  password?: string;
-  householdName?: string;
-  householdSlug?: string;
-  setupSecret?: string;
-};
 
 export const setupRoutes = new Hono<{ Bindings: Env }>();
 
@@ -78,32 +67,11 @@ setupRoutes.post("/complete", rateLimit(RATE_LIMITS.setup), async (c) => {
     );
   }
 
-  let payload: SetupPayload;
+  const body = await parseJsonBody(c, setupSchema);
+  if (!body.ok) return body.response;
+  const payload = body.data;
 
-  try {
-    payload = await c.req.json<SetupPayload>();
-  } catch {
-    return c.json({ error: "Invalid JSON body" }, 400);
-  }
-
-  if (
-    !payload.email ||
-    !payload.name ||
-    !payload.password ||
-    !payload.householdName ||
-    !payload.householdSlug ||
-    !payload.setupSecret
-  ) {
-    return c.json(
-      {
-        error:
-          "email, name, password, householdName, householdSlug, and setupSecret are required",
-      },
-      400,
-    );
-  }
-
-  const requestedEmail = normalizeEmail(payload.email);
+  const requestedEmail = payload.email;
   const ownerEmail = normalizeEmail(c.env.OWNER_EMAIL);
 
   if (!(await secretsEqual(payload.setupSecret, c.env.SETUP_SECRET))) {
@@ -114,16 +82,7 @@ setupRoutes.post("/complete", rateLimit(RATE_LIMITS.setup), async (c) => {
     return c.json({ error: "Setup email must match OWNER_EMAIL" }, 403);
   }
 
-  if (payload.password.length < 12) {
-    return c.json({ error: "Password must be at least 12 characters" }, 400);
-  }
-
-  const householdSlug = normalizeHouseholdSlug(payload.householdSlug);
-  const slugCheck = validateHouseholdSlug(householdSlug);
-
-  if (!slugCheck.ok) {
-    return c.json({ error: `householdSlug: ${slugCheck.error}` }, 400);
-  }
+  const householdSlug = payload.householdSlug;
 
   const claimed = await beginInstallationSetup(c.env.DB);
 
@@ -178,7 +137,7 @@ setupRoutes.post("/complete", rateLimit(RATE_LIMITS.setup), async (c) => {
     const signUpResult = await auth.api.signUpEmail({
       body: {
         email: requestedEmail,
-        name: payload.name.trim(),
+        name: payload.name,
         password: payload.password,
       },
       headers: new Headers(c.req.raw.headers),
@@ -190,7 +149,7 @@ setupRoutes.post("/complete", rateLimit(RATE_LIMITS.setup), async (c) => {
 
     const household = await createHousehold(c.env.DB, {
       slug: householdSlug,
-      displayName: payload.householdName.trim(),
+      displayName: payload.householdName,
       ownerUserId: createdUser.id,
     });
 

--- a/test/inbox-routes.test.ts
+++ b/test/inbox-routes.test.ts
@@ -1244,7 +1244,7 @@ describe("worker routes", () => {
     });
 
     expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toEqual({
+    await expect(response.json()).resolves.toMatchObject({
       error: "displayName is required",
     });
   });

--- a/test/schemas.test.ts
+++ b/test/schemas.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createHouseholdSchema,
+  invitationSchema,
+  profileSchema,
+  providerSchema,
+  senderRuleSchema,
+  setupSchema,
+} from "../src/server/http/schemas";
+
+describe("request schemas", () => {
+  it("normalises and validates sender rules", () => {
+    expect(
+      senderRuleSchema.parse({
+        providerId: "p1",
+        matchType: "domain",
+        matchValue: " @Netflix.COM ",
+      }),
+    ).toMatchObject({ matchValue: "netflix.com" });
+    expect(
+      senderRuleSchema.safeParse({
+        providerId: "p1",
+        matchType: "domain",
+        matchValue: "not a domain",
+      }).success,
+    ).toBe(false);
+    expect(
+      senderRuleSchema.safeParse({
+        providerId: "p1",
+        matchType: "exact",
+        matchValue: "netflix.com",
+      }).success,
+    ).toBe(false);
+    expect(
+      senderRuleSchema.parse({
+        providerId: "p1",
+        matchType: "exact",
+        matchValue: "Info@Netflix.com",
+      }),
+    ).toMatchObject({ matchValue: "info@netflix.com" });
+    expect(
+      senderRuleSchema.safeParse({
+        providerId: "p1",
+        matchType: "regex",
+        matchValue: "x",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("enforces lengths, formats and legacy role mapping", () => {
+    expect(
+      providerSchema.safeParse({ providerKey: "Net flix", displayName: "x" })
+        .success,
+    ).toBe(false);
+    expect(
+      providerSchema.parse({
+        providerKey: " NETFLIX ",
+        displayName: " Netflix ",
+      }),
+    ).toEqual({
+      providerKey: "netflix",
+      displayName: "Netflix",
+    });
+    expect(
+      providerSchema.safeParse({
+        providerKey: "netflix",
+        displayName: "x".repeat(81),
+      }).success,
+    ).toBe(false);
+
+    expect(
+      invitationSchema.parse({
+        email: "Kid@Example.com",
+        name: "Kid",
+        role: "admin",
+      }),
+    ).toMatchObject({
+      email: "kid@example.com",
+      role: "owner",
+      providerIds: [],
+    });
+    expect(
+      invitationSchema.safeParse({ email: "nope", name: "Kid" }).success,
+    ).toBe(false);
+    expect(
+      invitationSchema.safeParse({
+        email: "a@b.co",
+        name: "Kid",
+        providerIds: Array(51).fill("p"),
+      }).success,
+    ).toBe(false);
+
+    expect(
+      createHouseholdSchema.safeParse({ slug: "settings", displayName: "x" })
+        .success,
+    ).toBe(false);
+    expect(
+      createHouseholdSchema.parse({ slug: " Casa ", displayName: "Casa" }),
+    ).toEqual({
+      slug: "casa",
+      displayName: "Casa",
+    });
+
+    expect(profileSchema.parse({ name: "Me", image: "" })).toEqual({
+      name: "Me",
+      image: null,
+    });
+    expect(
+      profileSchema.parse({ name: "Me", image: "https://x.y/a.png" }),
+    ).toEqual({
+      name: "Me",
+      image: "https://x.y/a.png",
+    });
+    expect(
+      profileSchema.safeParse({ name: "Me", image: "javascript:alert(1)" })
+        .success,
+    ).toBe(false);
+    expect(
+      profileSchema.safeParse({
+        name: "Me",
+        image: `https://x.y/${"a".repeat(2100)}`,
+      }).success,
+    ).toBe(false);
+
+    expect(
+      setupSchema.safeParse({
+        email: "owner@example.com",
+        name: "Owner",
+        password: "short",
+        householdName: "Casa",
+        householdSlug: "casa",
+        setupSecret: "s",
+      }).success,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #103.

- **`src/server/http/schemas.ts`**: one zod schema per endpoint — length caps (names 80, provider keys 40, display names 80, emails 254, image URLs 2048), formats (email regex, hostname for domain rules, full address for exact rules, household slug via the shared validator incl. reserved words, http(s) image URLs), enums (match type, roles with legacy `admin→owner`, statuses, review actions), provider-scope cap (50).
- **`src/server/http/validation.ts`**: `parseJsonBody(c, schema)` → typed data or a ready 400 `{ error: "<readable summary>", fields: { … } }`.
- Applied to: admin settings / providers / rules / invitations / members / role change / provider access; household creation; profile update; setup; invitation accept; inbox status; quarantine review. Hand-rolled `normalize*` helpers and optional-everything payload types removed.
- `DELETE …/provider-access/:providerKey` (URL param) added; JSON-body form still accepted; client uses the URL.
- `zod` (already a transitive dep) is now a direct dependency.

## Tests
- `test/schemas.test.ts`: rule normalisation/validation, length/format/enum rejections, legacy role mapping, slug reserved words, image URL rules, setup password policy.
- Existing route/integration tests pass against the new validation (one assertion loosened to `toMatchObject` because responses now also carry `fields`).

`npm run ci` green: 224 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)