### PR TITLE
fix: re-wrap ASSETS responses so security headers apply to the SPA (500 on every page)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,10 @@ app.route("/api/setup", setupRoutes);
 app.all("/api/*", (c) => c.json({ error: "Not found" }, 404));
 
 app.get("*", async (c) => {
-  return c.env.ASSETS.fetch(c.req.raw);
+  // Responses from a binding fetch() carry immutable headers; re-wrap so the
+  // security-header middleware above can decorate the SPA and its assets.
+  const response = await c.env.ASSETS.fetch(c.req.raw);
+  return new Response(response.body, response);
 });
 
 app.notFound((c) => c.json({ error: "Not found" }, 404));

--- a/test/fixtures/assets/assets/app.js
+++ b/test/fixtures/assets/assets/app.js
@@ -1,0 +1,1 @@
+console.log("fixture asset");

--- a/test/fixtures/assets/index.html
+++ b/test/fixtures/assets/index.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<html lang="en"><head><title>fixture shell</title></head><body><div id="root"></div></body></html>

--- a/test/integration/security-headers.test.ts
+++ b/test/integration/security-headers.test.ts
@@ -13,3 +13,34 @@ describe("security headers (workerd)", () => {
     expect(response.headers.get("permissions-policy")).toContain("camera=()");
   });
 });
+
+describe("static asset passthrough (workerd)", () => {
+  // Responses from the ASSETS binding arrive with immutable headers; the
+  // Worker must re-wrap them so the security-header middleware can apply.
+  it("serves the SPA shell with security headers", async () => {
+    const response = await SELF.fetch("http://localhost:8787/");
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('<div id="root">');
+    expect(response.headers.get("content-security-policy")).toContain(
+      "frame-ancestors 'none'",
+    );
+    expect(response.headers.get("x-frame-options")).toBe("DENY");
+  });
+
+  it("serves hashed assets with security headers", async () => {
+    const asset = await SELF.fetch("http://localhost:8787/assets/app.js");
+    expect(asset.status).toBe(200);
+    expect(await asset.text()).toContain("fixture asset");
+    expect(asset.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(asset.headers.get("content-security-policy")).toContain(
+      "default-src 'self'",
+    );
+  });
+
+  it("falls back to the SPA shell for deep links, with security headers", async () => {
+    const deepLink = await SELF.fetch("http://localhost:8787/casa/inbox");
+    expect(deepLink.status).toBe(200);
+    expect(await deepLink.text()).toContain('<div id="root">');
+    expect(deepLink.headers.get("x-frame-options")).toBe("DENY");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,6 +43,21 @@ export default defineConfig(async () => {
                 compatibilityFlags: ["nodejs_compat"],
                 d1Databases: ["DB"],
                 email: { send_email: [{ name: "EMAIL" }] },
+                // A tiny stand-in for dist/client so the SPA/asset passthrough
+                // (run_worker_first + security headers) is exercised in tests
+                // without requiring a Vite build first.
+                assets: {
+                  directory: "./test/fixtures/assets",
+                  binding: "ASSETS",
+                  run_worker_first: true,
+                  routerConfig: {
+                    has_user_worker: true,
+                    invoke_user_worker_ahead_of_assets: true,
+                  },
+                  assetConfig: {
+                    not_found_handling: "single-page-application",
+                  },
+                },
                 bindings: {
                   APP_NAME: "Mi Casa Su Casa (test)",
                   APP_URL: "http://localhost:8787",


### PR DESCRIPTION
## Summary
- `src/index.ts`: re-wrap the `ASSETS.fetch` response (`new Response(body, response)`) — binding responses carry immutable headers, so `secureHeaders` threw "Can't modify immutable headers" and **every non-API request (SPA shell, deep links, hashed assets) returned 500** on `main`.
- Integration suite now exercises the SPA/asset passthrough: miniflare `assets` option pointed at a tiny fixture dir (`test/fixtures/assets`) with `run_worker_first` + SPA not-found handling, and tests for the shell, a hashed asset and a deep-link fallback all carrying security headers.

Closes #166

## Test plan
- [x] `npm run ci` green (51 files / 231 tests)
- [x] `npm run build && npx wrangler dev`: `GET /` → 200 with CSP, `GET /casa/inbox` → 200 (SPA fallback), API unaffected
- [ ] Preview deploy serves the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)
