### PR TITLE
fix(client): account menu Settings opens account settings, not household settings

### DIFF
--- a/src/client/components/Layout.tsx
+++ b/src/client/components/Layout.tsx
@@ -41,6 +41,13 @@ import { buildHouseholdPath, getDisplayName, getUserInitials } from "../utils";
 
 const DRAWER_WIDTH = 280;
 
+/**
+ * Account settings (profile, password, 2FA, passkeys, sessions) are a global
+ * route — not scoped to a household. Household settings live at
+ * /:slug/settings and are linked from the sidebar instead.
+ */
+export const ACCOUNT_SETTINGS_PATH = "/settings";
+
 interface LayoutProps {
   children: React.ReactNode;
   session: SessionData | null | undefined;
@@ -74,7 +81,6 @@ export function isSettingsPath(pathname: string) {
 interface UserAccountMenuProps {
   session: SessionData | null | undefined;
   mode: "light" | "dark";
-  settingsPath: string;
   onSettingsClick: () => void;
   onToggleColorMode: () => void;
   onLogout: () => void;
@@ -83,7 +89,6 @@ interface UserAccountMenuProps {
 export function UserAccountMenuContent({
   session,
   mode,
-  settingsPath,
   onSettingsClick,
   onToggleColorMode,
   onLogout,
@@ -101,7 +106,7 @@ export function UserAccountMenuContent({
       <Divider />
       <MenuItem
         component={Link}
-        to={settingsPath}
+        to={ACCOUNT_SETTINGS_PATH}
         onClick={onSettingsClick}
         sx={{ py: 1.25 }}
       >
@@ -205,7 +210,6 @@ export function Layout({
   const activeHousehold =
     households.find((household) => household.slug === householdSlug) ?? null;
   const roleLabel = householdRole === "owner" ? "Owner" : "Member";
-  const settingsPath = buildHouseholdPath(householdSlug, "/settings");
   const isHouseholdMenuOpen = Boolean(householdMenuAnchor);
   const isUserMenuOpen = Boolean(userMenuAnchor);
 
@@ -567,7 +571,6 @@ export function Layout({
             anchorEl={userMenuAnchor}
             open={isUserMenuOpen}
             mode={theme.palette.mode}
-            settingsPath={settingsPath}
             onClose={handleCloseUserMenu}
             onToggleColorMode={handleToggleColorMode}
             onLogout={handleLogoutClick}

--- a/test/layout.test.tsx
+++ b/test/layout.test.tsx
@@ -163,7 +163,6 @@ describe("UserAccountMenuContent", () => {
                 },
               }}
               mode="dark"
-              settingsPath="/home/settings"
               onSettingsClick={vi.fn()}
               onToggleColorMode={vi.fn()}
               onLogout={vi.fn()}
@@ -176,7 +175,10 @@ describe("UserAccountMenuContent", () => {
     expect(html).toContain("Alex Member");
     expect(html).toContain("alex.member@example.com");
     expect(html).toContain("Settings");
-    expect(html).toContain('href="/home/settings"');
+    // Account settings are a global route, distinct from /:slug/settings
+    // (household settings).
+    expect(html).toContain('href="/settings"');
+    expect(html).not.toContain('href="/home/settings"');
     expect(html).toContain("Light mode");
     expect(html).toContain("Sign out");
   });


### PR DESCRIPTION
Closes #170 (part of #169, Phase 0).

## Problem
The avatar/account menu's "Settings" item linked to `/:slug/settings` — the **household** settings route. Account settings moved to the global `/settings` route in #43; #47 regressed the menu link. Owners landed on household settings; members were redirected to the inbox, making 2FA/passkeys/sessions/leave-household unreachable from the UI.

## Fix
- `UserAccountMenuContent` now links to an exported `ACCOUNT_SETTINGS_PATH = "/settings"` constant instead of taking a `settingsPath` prop, so Layout cannot wire it wrongly again.
- Sidebar "Household settings" still points at `/:slug/settings`.

## Tests
- `test/layout.test.tsx`: the account menu renders `href="/settings"` and not `href="/home/settings"`.
- `npm run ci` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)