### PR TITLE
feat(client): theme foundation — Inter/Nunito, warm brand palette, component defaults, persisted colour mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@better-auth/passkey": "^1.7.1",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@fontsource-variable/inter": "^5.3.0",
+        "@fontsource-variable/nunito": "^5.3.0",
         "@mui/icons-material": "^9.3.1",
         "@mui/material": "^9.3.1",
         "@mui/x-data-grid": "^9.11.0",
@@ -1715,6 +1717,24 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
       "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.3.0.tgz",
+      "integrity": "sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/nunito": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/nunito/-/nunito-5.3.0.tgz",
+      "integrity": "sha512-tw0ch7evIDSwoeUy+0XzocYHfbRWLeCRPJy22KgbrLjDLAbNw/fErBiil10Ssrs3Sjr55zaZrr36a975j8cBkQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@hexagon/base64": {
       "version": "1.1.28",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "@better-auth/passkey": "^1.7.1",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@fontsource-variable/inter": "^5.3.0",
+    "@fontsource-variable/nunito": "^5.3.0",
     "@mui/icons-material": "^9.3.1",
     "@mui/material": "^9.3.1",
     "@mui/x-data-grid": "^9.11.0",

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="Shared verification inbox for your household." />
-    <meta name="theme-color" content="#6366F1" />
+    <meta name="theme-color" content="#FFFFFF" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="icon" href="/icons/icon-192.png" type="image/png" />
     <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -1,29 +1,61 @@
+import "@fontsource-variable/inter";
+import "@fontsource-variable/nunito";
+
 import { CssBaseline, ThemeProvider, useMediaQuery } from "@mui/material";
-import { StrictMode, useMemo, useState } from "react";
+import { StrictMode, useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
 
 import { BrowserRouter } from "react-router-dom";
 
 import { App } from "./App";
 import { registerServiceWorker } from "./service-worker";
-import { ColorModeContext, getTheme } from "./theme";
+import {
+  ColorModeContext,
+  type ColorModePreference,
+  getTheme,
+  persistColorMode,
+  readStoredColorMode,
+  resolveColorMode,
+} from "./theme";
+
+function getStorage(): Storage | null {
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
 
 function AppWrapper() {
   const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)");
-  const [mode, setMode] = useState<"light" | "dark">(
-    prefersDarkMode ? "dark" : "light",
+  const [preference, setPreference] = useState<ColorModePreference>(() =>
+    readStoredColorMode(getStorage()),
   );
+  const mode = resolveColorMode(preference, prefersDarkMode);
 
   const colorMode = useMemo(
     () => ({
       toggleColorMode: () => {
-        setMode((prevMode) => (prevMode === "light" ? "dark" : "light"));
+        setPreference((current) => {
+          const next =
+            resolveColorMode(current, prefersDarkMode) === "light"
+              ? "dark"
+              : "light";
+          persistColorMode(getStorage(), next);
+          return next;
+        });
       },
     }),
-    [],
+    [prefersDarkMode],
   );
 
   const theme = useMemo(() => getTheme(mode), [mode]);
+
+  // Keep the browser/PWA chrome in step with the app surface colour.
+  useEffect(() => {
+    const meta = document.querySelector('meta[name="theme-color"]');
+    meta?.setAttribute("content", theme.palette.background.paper);
+  }, [theme]);
 
   return (
     <BrowserRouter>

--- a/src/client/public/manifest.webmanifest
+++ b/src/client/public/manifest.webmanifest
@@ -7,7 +7,7 @@
   "display": "standalone",
   "orientation": "portrait",
   "background_color": "#F7F8F2",
-  "theme_color": "#6366F1",
+  "theme_color": "#B55326",
   "icons": [
     { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
     { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" },

--- a/src/client/theme.ts
+++ b/src/client/theme.ts
@@ -1,83 +1,288 @@
-import { createTheme } from "@mui/material/styles";
+import { alpha, createTheme } from "@mui/material/styles";
 import { createContext } from "react";
+
+/**
+ * Colour mode handling.
+ *
+ * The user's choice is persisted in localStorage; "system" (the default)
+ * follows `prefers-color-scheme`. The context keeps the small surface the
+ * Layout menu needs.
+ */
+export type ColorMode = "light" | "dark";
+export type ColorModePreference = ColorMode | "system";
+
+export const COLOR_MODE_STORAGE_KEY = "mcsc:color-mode";
 
 export const ColorModeContext = createContext({ toggleColorMode: () => {} });
 
-export function getTheme(mode: "light" | "dark") {
+export function readStoredColorMode(
+  storage: Pick<Storage, "getItem"> | null | undefined,
+): ColorModePreference {
+  try {
+    const value = storage?.getItem(COLOR_MODE_STORAGE_KEY);
+    return value === "light" || value === "dark" ? value : "system";
+  } catch {
+    return "system";
+  }
+}
+
+export function persistColorMode(
+  storage: Pick<Storage, "setItem" | "removeItem"> | null | undefined,
+  preference: ColorModePreference,
+) {
+  try {
+    if (preference === "system") {
+      storage?.removeItem(COLOR_MODE_STORAGE_KEY);
+    } else {
+      storage?.setItem(COLOR_MODE_STORAGE_KEY, preference);
+    }
+  } catch {
+    // Private mode / storage disabled: the choice just won't survive reloads.
+  }
+}
+
+export function resolveColorMode(
+  preference: ColorModePreference,
+  prefersDark: boolean,
+): ColorMode {
+  if (preference === "system") {
+    return prefersDark ? "dark" : "light";
+  }
+  return preference;
+}
+
+/**
+ * Brand colours, sampled from assets/mi-casa-su-casa-logo.png and the PWA
+ * icons: a terracotta house, a coral envelope, on cream.
+ */
+export const brand = {
+  terracotta: "#CA6B3D",
+  terracottaDeep: "#B55326",
+  terracottaDark: "#A4481F",
+  coral: "#F38466",
+  coralSoft: "#F7AB94",
+  coralDeep: "#E07A58",
+  cream: "#F7F8F2",
+  sand: "#F3E8D6",
+  cocoa: "#2B211C",
+  cocoaDark: "#1C1715",
+} as const;
+
+export const FONT_FAMILY_BODY =
+  '"Inter Variable", "Inter", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
+export const FONT_FAMILY_HEADING =
+  '"Nunito Variable", "Nunito", "Inter Variable", "Inter", system-ui, sans-serif';
+export const FONT_FAMILY_MONO =
+  'ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace';
+
+const heading = {
+  fontFamily: FONT_FAMILY_HEADING,
+  fontWeight: 700,
+  lineHeight: 1.2,
+  letterSpacing: "-0.01em",
+} as const;
+
+export function getTheme(mode: ColorMode) {
+  const isLight = mode === "light";
+
+  const palette = {
+    mode,
+    primary: isLight
+      ? {
+          main: brand.terracottaDeep,
+          light: brand.terracotta,
+          dark: brand.terracottaDark,
+          contrastText: "#FFFFFF",
+        }
+      : {
+          main: brand.coral,
+          light: brand.coralSoft,
+          dark: brand.coralDeep,
+          contrastText: "#2B1A12",
+        },
+    secondary: isLight
+      ? {
+          main: brand.coral,
+          light: brand.coralSoft,
+          dark: brand.coralDeep,
+          contrastText: brand.cocoa,
+        }
+      : {
+          main: brand.terracotta,
+          light: "#D98A63",
+          dark: brand.terracottaDeep,
+          contrastText: "#FFFFFF",
+        },
+    background: isLight
+      ? { default: brand.cream, paper: "#FFFFFF" }
+      : { default: brand.cocoaDark, paper: "#262019" },
+    text: isLight
+      ? { primary: brand.cocoa, secondary: "#6F6158", disabled: "#A89C93" }
+      : { primary: "#F3ECE6", secondary: "#B8ACA3", disabled: "#7D716A" },
+    divider: isLight ? "#E9E3DA" : "#3A312B",
+    success: { main: isLight ? "#2F8F5B" : "#5CC08A" },
+    warning: { main: isLight ? "#C98A08" : "#F2B84B" },
+    error: { main: isLight ? "#C8382E" : "#F07A70" },
+    info: { main: isLight ? "#2F7FB8" : "#7DBDE8" },
+  };
+
+  // A palette-only theme so component overrides below can reference the
+  // resolved colours. Everything is then passed to ONE createTheme call:
+  // typography must be part of the initial options, otherwise the per-variant
+  // font families are already baked in and the override only changes the
+  // top-level value.
+  const base = createTheme({ palette });
+
   return createTheme({
-    palette: {
-      mode,
-      primary: {
-        main: "#6366F1",
-        light: "#818CF8",
-        dark: "#4F46E5",
-      },
-      secondary: {
-        main: "#A78BFA",
-        light: "#C4B5FD",
-        dark: "#7C3AED",
-      },
-      background: {
-        default: mode === "light" ? "#F8FAFC" : "#0F172A",
-        paper: mode === "light" ? "#FFFFFF" : "#1E293B",
-      },
-      text: {
-        primary: mode === "light" ? "#0F172A" : "#F1F5F9",
-        secondary: mode === "light" ? "#475569" : "#94A3B8",
-      },
-      divider: mode === "light" ? "#E2E8F0" : "#334155",
-      warning: {
-        main: "#F59E0B",
-      },
-      success: {
-        main: "#10B981",
-      },
-      error: {
-        main: "#EF4444",
-      },
-      info: {
-        main: "#38BDF8",
-      },
-    },
+    palette,
+    shape: { borderRadius: 12 },
     typography: {
-      fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
-      h1: {
-        fontSize: "2.5rem",
+      fontFamily: FONT_FAMILY_BODY,
+      h1: { ...heading, fontSize: "2.25rem" },
+      h2: { ...heading, fontSize: "1.75rem" },
+      h3: { ...heading, fontSize: "1.5rem" },
+      h4: { ...heading, fontSize: "1.25rem" },
+      h5: { ...heading, fontSize: "1.125rem" },
+      h6: { ...heading, fontSize: "1rem" },
+      subtitle1: { fontWeight: 600, lineHeight: 1.4 },
+      subtitle2: { fontWeight: 600, lineHeight: 1.4 },
+      body1: { lineHeight: 1.55 },
+      body2: { lineHeight: 1.5 },
+      button: {
         fontWeight: 600,
+        textTransform: "none",
+        letterSpacing: 0,
       },
-      h2: {
-        fontSize: "2rem",
-        fontWeight: 600,
+      overline: {
+        fontWeight: 700,
+        letterSpacing: "0.08em",
+        lineHeight: 1.6,
       },
-      h3: {
-        fontSize: "1.5rem",
-        fontWeight: 500,
-      },
-      h4: {
-        fontSize: "1.25rem",
-        fontWeight: 500,
-      },
-    },
-    shape: {
-      borderRadius: 12,
     },
     components: {
-      MuiButton: {
+      MuiCssBaseline: {
         styleOverrides: {
-          root: {
-            textTransform: "none",
-            fontWeight: 600,
+          html: {
+            WebkitTapHighlightColor: "transparent",
+            textRendering: "optimizeLegibility",
+          },
+          body: {
+            backgroundColor: base.palette.background.default,
+          },
+          "a:focus-visible, button:focus-visible, [tabindex]:focus-visible": {
+            outline: `2px solid ${base.palette.primary.main}`,
+            outlineOffset: 2,
           },
         },
       },
+      MuiButton: {
+        defaultProps: { disableElevation: true },
+        styleOverrides: {
+          root: { borderRadius: 10, paddingInline: 16 },
+          sizeSmall: { minHeight: 36 },
+          sizeMedium: { minHeight: 44, paddingInline: 20 },
+          sizeLarge: { minHeight: 52, paddingInline: 24, fontSize: "1rem" },
+        },
+      },
+      MuiIconButton: {
+        styleOverrides: {
+          root: { borderRadius: 10 },
+        },
+      },
+      MuiPaper: {
+        styleOverrides: {
+          root: { backgroundImage: "none" },
+          rounded: { borderRadius: 12 },
+          outlined: { borderColor: base.palette.divider },
+        },
+      },
       MuiCard: {
+        defaultProps: { variant: "outlined" },
+        styleOverrides: {
+          root: { borderRadius: 16 },
+        },
+      },
+      MuiCardHeader: {
+        defaultProps: {
+          slotProps: {
+            title: { variant: "h5" },
+            subheader: { variant: "body2" },
+          },
+        },
+      },
+      MuiOutlinedInput: {
         styleOverrides: {
           root: {
-            boxShadow:
-              mode === "light"
-                ? "0px 4px 20px rgba(99, 102, 241, 0.08)"
-                : "0px 4px 20px rgba(0, 0, 0, 0.4)",
+            borderRadius: 10,
+            backgroundColor: base.palette.background.paper,
           },
+          notchedOutline: { borderColor: base.palette.divider },
+        },
+      },
+      MuiDialog: {
+        styleOverrides: {
+          paper: {
+            borderRadius: 20,
+            [base.breakpoints.down("sm")]: {
+              margin: 16,
+              width: "calc(100% - 32px)",
+              maxHeight: "calc(100% - 32px)",
+            },
+          },
+        },
+      },
+      MuiDialogTitle: {
+        styleOverrides: {
+          root: { ...heading, fontSize: "1.25rem" },
+        },
+      },
+      MuiChip: {
+        styleOverrides: {
+          root: { borderRadius: 8, fontWeight: 600 },
+        },
+      },
+      MuiListItemButton: {
+        styleOverrides: {
+          root: {
+            borderRadius: 10,
+            "&.Mui-selected": {
+              backgroundColor: alpha(base.palette.primary.main, 0.1),
+              "&:hover": {
+                backgroundColor: alpha(base.palette.primary.main, 0.16),
+              },
+            },
+          },
+        },
+      },
+      MuiMenuItem: {
+        styleOverrides: {
+          root: { borderRadius: 8, marginInline: 6 },
+        },
+      },
+      MuiAlert: {
+        styleOverrides: {
+          root: { borderRadius: 12 },
+        },
+      },
+      MuiTooltip: {
+        styleOverrides: {
+          tooltip: { borderRadius: 8, fontSize: "0.8125rem" },
+        },
+      },
+      MuiLink: {
+        defaultProps: { underline: "hover" },
+        styleOverrides: {
+          root: { fontWeight: 500 },
+        },
+      },
+      MuiSkeleton: {
+        styleOverrides: {
+          root: { borderRadius: 8 },
+        },
+      },
+      MuiAvatar: {
+        styleOverrides: {
+          root: { fontWeight: 600 },
         },
       },
     },

--- a/test/theme.test.ts
+++ b/test/theme.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  COLOR_MODE_STORAGE_KEY,
+  FONT_FAMILY_BODY,
+  FONT_FAMILY_HEADING,
+  getTheme,
+  persistColorMode,
+  readStoredColorMode,
+  resolveColorMode,
+} from "../src/client/theme";
+
+function luminance(hex: string) {
+  const channels = [1, 3, 5]
+    .map((i) => Number.parseInt(hex.slice(i, i + 2), 16) / 255)
+    .map((v) => (v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4));
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function contrast(a: string, b: string) {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+describe("getTheme", () => {
+  it("uses the self-hosted Inter body font and Nunito for headings", () => {
+    const theme = getTheme("light");
+    expect(theme.typography.fontFamily).toBe(FONT_FAMILY_BODY);
+    expect(theme.typography.fontFamily).toContain("Inter Variable");
+    // The per-variant families are what components actually render with.
+    expect(theme.typography.body1.fontFamily).toBe(FONT_FAMILY_BODY);
+    expect(theme.typography.body2.fontFamily).toBe(FONT_FAMILY_BODY);
+    expect(theme.typography.button.fontFamily).toBe(FONT_FAMILY_BODY);
+    expect(theme.typography.h1.fontFamily).toBe(FONT_FAMILY_HEADING);
+    expect(theme.typography.h1.fontFamily).toContain("Nunito Variable");
+    expect(theme.typography.button.textTransform).toBe("none");
+  });
+
+  it("keeps primary buttons readable in both modes (WCAG AA)", () => {
+    const light = getTheme("light");
+    expect(
+      contrast(light.palette.primary.main, light.palette.primary.contrastText),
+    ).toBeGreaterThanOrEqual(4.5);
+    expect(
+      contrast(light.palette.text.primary, light.palette.background.default),
+    ).toBeGreaterThanOrEqual(7);
+    expect(
+      contrast(light.palette.text.secondary, light.palette.background.paper),
+    ).toBeGreaterThanOrEqual(4.5);
+
+    const dark = getTheme("dark");
+    expect(
+      contrast(dark.palette.primary.main, dark.palette.background.default),
+    ).toBeGreaterThanOrEqual(4.5);
+    expect(
+      contrast(dark.palette.primary.main, dark.palette.primary.contrastText),
+    ).toBeGreaterThanOrEqual(4.5);
+    expect(
+      contrast(dark.palette.text.primary, dark.palette.background.paper),
+    ).toBeGreaterThanOrEqual(7);
+  });
+
+  it("uses the warm brand palette rather than the old indigo", () => {
+    const light = getTheme("light");
+    expect(light.palette.primary.main.toUpperCase()).toBe("#B55326");
+    expect(light.palette.background.default.toUpperCase()).toBe("#F7F8F2");
+    expect(getTheme("dark").palette.primary.main.toUpperCase()).toBe("#F38466");
+  });
+});
+
+describe("colour mode persistence", () => {
+  function memoryStorage(initial: Record<string, string> = {}) {
+    const data = new Map(Object.entries(initial));
+    return {
+      getItem: (key: string) => data.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        data.set(key, value);
+      },
+      removeItem: (key: string) => {
+        data.delete(key);
+      },
+      data,
+    };
+  }
+
+  it("defaults to following the system when nothing (or junk) is stored", () => {
+    expect(readStoredColorMode(memoryStorage())).toBe("system");
+    expect(
+      readStoredColorMode(memoryStorage({ [COLOR_MODE_STORAGE_KEY]: "blue" })),
+    ).toBe("system");
+    expect(readStoredColorMode(null)).toBe("system");
+    expect(resolveColorMode("system", true)).toBe("dark");
+    expect(resolveColorMode("system", false)).toBe("light");
+  });
+
+  it("honours an explicit stored choice over the system preference", () => {
+    const storage = memoryStorage({ [COLOR_MODE_STORAGE_KEY]: "dark" });
+    expect(readStoredColorMode(storage)).toBe("dark");
+    expect(resolveColorMode("dark", false)).toBe("dark");
+    expect(resolveColorMode("light", true)).toBe("light");
+  });
+
+  it("persists explicit choices and clears the key for system", () => {
+    const storage = memoryStorage();
+    persistColorMode(storage, "dark");
+    expect(storage.data.get(COLOR_MODE_STORAGE_KEY)).toBe("dark");
+    persistColorMode(storage, "system");
+    expect(storage.data.has(COLOR_MODE_STORAGE_KEY)).toBe(false);
+    expect(() =>
+      persistColorMode(
+        {
+          setItem: () => {
+            throw new Error("quota");
+          },
+          removeItem: () => {},
+        },
+        "light",
+      ),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #178 (part of #169, Phase 1).

## Why
- `theme.ts` named Inter but nothing loaded it → the app rendered in Roboto/Helvetica/Arial.
- The UI was indigo-on-slate while the icon, logo and manifest are warm terracotta/coral on cream — the app didn't look like its own home-screen icon.
- Colour mode lived in `useState` only and reset on reload.
- Radius/CTA sizes were hand-set per component; nothing was consistent.

## What
- **Fonts**: self-hosted `@fontsource-variable/inter` (body/UI) and `@fontsource-variable/nunito` (headings — rounded, echoes the wordmark). Hashed into `/assets/`, so the existing service-worker cache-first rule covers them offline; no external font hosts.
- **Palette**: sampled from the logo. Light: terracotta primary `#B55326` (4.96:1 on white), coral secondary, cream `#F7F8F2` background, warm cocoa text/dividers. Dark: warm near-black surfaces with coral primary (7:1). Semantic colours slightly warmed.
- **Typography scale** + **component defaults** (buttons 44px medium targets, no uppercase; card 16px radius + outlined by default; inputs/dialogs/chips/list items/menu items/alerts/tooltips/skeletons; focus-visible rings; dialogs get 16px margins on phones).
- **Colour mode**: `readStoredColorMode` / `persistColorMode` / `resolveColorMode` — `system` by default (honours `prefers-color-scheme`), explicit choice persisted in `localStorage`. `<meta theme-color>` follows the surface colour.
- `index.html` theme-color and manifest `theme_color` updated to the brand.

Note: typography must be in the *first* `createTheme` options — passing it as the deep-merge argument leaves the per-variant families at Roboto (caught via headless screenshots; test now asserts `body1/body2/button` families).

## Screenshots
Taken with a headless-Chromium harness against a seeded local instance (light/dark × 390px/1280px). Visual direction confirmed; layout issues seen in them are Phase 2 work.

## Tests
- `test/theme.test.ts`: fonts per variant, WCAG AA contrast for primary/text in both modes, brand palette, colour-mode persistence.
- `npm run ci` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)