### PR TITLE
feat(client): shared UI primitives + accessible ConfirmDialog

### DIFF
--- a/src/client/components/ConfirmDialog.tsx
+++ b/src/client/components/ConfirmDialog.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Button,
   Dialog,
   DialogActions,
@@ -6,7 +7,7 @@ import {
   DialogTitle,
   Typography,
 } from "@mui/material";
-import type { ReactNode } from "react";
+import { type ReactNode, useId } from "react";
 
 interface ConfirmDialogProps {
   open: boolean;
@@ -18,7 +19,12 @@ interface ConfirmDialogProps {
   confirmColor?: "primary" | "error" | "warning" | "info" | "success";
   confirmVariant?: "contained" | "outlined" | "text";
   isLoading?: boolean;
+  /** Label shown on the confirm button while `isLoading`, e.g. "Removing…". */
+  loadingLabel?: string;
   confirmDisabled?: boolean;
+  cancelLabel?: string;
+  /** Shown inside the dialog so a failed action is visible where the user is. */
+  error?: string | null;
 }
 
 export function ConfirmDialog({
@@ -31,17 +37,25 @@ export function ConfirmDialog({
   confirmColor = "primary",
   confirmVariant = "contained",
   isLoading = false,
+  loadingLabel = "Working…",
   confirmDisabled = false,
+  cancelLabel = "Cancel",
+  error = null,
 }: ConfirmDialogProps) {
+  const titleId = useId();
+  const descriptionId = useId();
+
   return (
     <Dialog
       open={open}
       onClose={isLoading ? undefined : onClose}
       fullWidth
       maxWidth="xs"
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
     >
-      <DialogTitle>{title}</DialogTitle>
-      <DialogContent>
+      <DialogTitle id={titleId}>{title}</DialogTitle>
+      <DialogContent id={descriptionId}>
         {typeof description === "string" ? (
           <Typography variant="body2" color="text.secondary">
             {description}
@@ -49,10 +63,20 @@ export function ConfirmDialog({
         ) : (
           description
         )}
+        {error ? (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
+        ) : null}
       </DialogContent>
       <DialogActions sx={{ px: 3, pb: 3 }}>
-        <Button onClick={onClose} disabled={isLoading}>
-          Cancel
+        <Button
+          onClick={onClose}
+          disabled={isLoading}
+          variant="outlined"
+          color="inherit"
+        >
+          {cancelLabel}
         </Button>
         <Button
           onClick={() => void onConfirm()}
@@ -60,7 +84,7 @@ export function ConfirmDialog({
           variant={confirmVariant}
           disabled={isLoading || confirmDisabled}
         >
-          {isLoading ? "Working…" : confirmLabel}
+          {isLoading ? loadingLabel : confirmLabel}
         </Button>
       </DialogActions>
     </Dialog>

--- a/src/client/components/InboxView.tsx
+++ b/src/client/components/InboxView.tsx
@@ -1,6 +1,4 @@
 import {
-  CheckCircleOutlined,
-  ContentCopyOutlined,
   EmailOutlined,
   HistoryOutlined,
   InboxOutlined,
@@ -17,18 +15,17 @@ import {
   CardContent,
   Chip,
   Divider,
-  IconButton,
   List,
   ListItem,
   ListItemButton,
   ListItemText,
   Paper,
-  Tooltip,
   Typography,
 } from "@mui/material";
-import React, { useState } from "react";
+import React from "react";
 import type { InboxMessage, ProviderSummary } from "../types";
 import { formatTimestamp, stringAvatar } from "../utils";
+import { CopyButton } from "./ui";
 
 interface InboxViewProps {
   providers: ProviderSummary[];
@@ -59,22 +56,10 @@ export function InboxView({
   isLoadingOlderMessages = false,
   onLoadOlderMessages,
 }: InboxViewProps) {
-  const [copiedCodeId, setCopiedCodeId] = useState<string | null>(null);
-
   const selectedProvider = providers.find(
     (p) => p.provider_key === selectedProviderKey,
   );
   const selectedMessage = messages.find((m) => m.id === selectedMessageId);
-
-  const handleCopyCode = async (code: string, id: string) => {
-    try {
-      await navigator.clipboard.writeText(code);
-      setCopiedCodeId(id);
-      setTimeout(() => setCopiedCodeId(null), 2000);
-    } catch (err) {
-      console.error("Failed to copy text: ", err);
-    }
-  };
 
   const getStatusColor = (status: InboxMessage["status"]) => {
     switch (status) {
@@ -467,36 +452,12 @@ export function InboxView({
                     {selectedMessage.extracted_code ?? "No code detected"}
                   </Typography>
                   {selectedMessage.extracted_code && (
-                    <Tooltip
-                      title={
-                        copiedCodeId === selectedMessage.id
-                          ? "Copied!"
-                          : "Copy code"
-                      }
-                      placement="top"
-                    >
-                      <IconButton
-                        onClick={() => {
-                          if (selectedMessage.extracted_code) {
-                            handleCopyCode(
-                              selectedMessage.extracted_code,
-                              selectedMessage.id,
-                            );
-                          }
-                        }}
-                        sx={{
-                          color: "primary.contrastText",
-                          opacity: 0.9,
-                          "&:hover": { opacity: 1 },
-                        }}
-                      >
-                        {copiedCodeId === selectedMessage.id ? (
-                          <CheckCircleOutlined />
-                        ) : (
-                          <ContentCopyOutlined />
-                        )}
-                      </IconButton>
-                    </Tooltip>
+                    <CopyButton
+                      value={selectedMessage.extracted_code}
+                      label="Copy code"
+                      color="inherit"
+                      sx={{ color: "primary.contrastText" }}
+                    />
                   )}
                 </Box>
               </CardContent>

--- a/src/client/components/QuarantineView.tsx
+++ b/src/client/components/QuarantineView.tsx
@@ -1,6 +1,4 @@
 import {
-  CheckCircleOutlined,
-  ContentCopyOutlined,
   DeleteOutlined,
   MoveToInboxOutlined,
   ShieldOutlined,
@@ -16,7 +14,6 @@ import {
   Chip,
   Divider,
   FormControl,
-  IconButton,
   InputLabel,
   List,
   ListItem,
@@ -26,13 +23,13 @@ import {
   Paper,
   Select,
   Stack,
-  Tooltip,
   Typography,
 } from "@mui/material";
 import React, { useState } from "react";
 import type { ProviderSummary, QuarantineMessage } from "../types";
 import { formatTimestamp, stringAvatar } from "../utils";
 import { ConfirmDialog } from "./ConfirmDialog";
+import { CopyButton } from "./ui";
 
 interface QuarantineViewProps {
   quarantineMessages: QuarantineMessage[];
@@ -63,7 +60,6 @@ export function QuarantineView({
   isLoadingOlderMessages = false,
   onLoadOlderMessages,
 }: QuarantineViewProps) {
-  const [copiedCodeId, setCopiedCodeId] = useState<string | null>(null);
   const [reviewAction, setReviewAction] = useState<
     "dismiss" | "release" | null
   >(null);
@@ -71,16 +67,6 @@ export function QuarantineView({
   const selectedQuarantineMessage = quarantineMessages.find(
     (m) => m.id === selectedQuarantineId,
   );
-
-  const handleCopyCode = async (code: string, id: string) => {
-    try {
-      await navigator.clipboard.writeText(code);
-      setCopiedCodeId(id);
-      setTimeout(() => setCopiedCodeId(null), 2000);
-    } catch (err) {
-      console.error("Failed to copy text: ", err);
-    }
-  };
 
   const handleReviewConfirm = async () => {
     if (!reviewAction) {
@@ -332,37 +318,11 @@ export function QuarantineView({
                       "No code detected"}
                   </Typography>
                   {selectedQuarantineMessage.extracted_code && (
-                    <Tooltip
-                      title={
-                        copiedCodeId === selectedQuarantineMessage.id
-                          ? "Copied!"
-                          : "Copy code"
-                      }
-                      placement="top"
-                    >
-                      <IconButton
-                        onClick={() => {
-                          if (selectedQuarantineMessage.extracted_code) {
-                            handleCopyCode(
-                              selectedQuarantineMessage.extracted_code,
-                              selectedQuarantineMessage.id,
-                            );
-                          }
-                        }}
-                        color={
-                          copiedCodeId === selectedQuarantineMessage.id
-                            ? "success"
-                            : "default"
-                        }
-                        sx={{ ml: 1 }}
-                      >
-                        {copiedCodeId === selectedQuarantineMessage.id ? (
-                          <CheckCircleOutlined />
-                        ) : (
-                          <ContentCopyOutlined />
-                        )}
-                      </IconButton>
-                    </Tooltip>
+                    <CopyButton
+                      value={selectedQuarantineMessage.extracted_code}
+                      label="Copy code"
+                      sx={{ ml: 1 }}
+                    />
                   )}
                 </Box>
               </CardContent>

--- a/src/client/components/ui/CopyButton.tsx
+++ b/src/client/components/ui/CopyButton.tsx
@@ -1,0 +1,134 @@
+import { CheckOutlined, ContentCopyOutlined } from "@mui/icons-material";
+import {
+  Box,
+  Button,
+  type ButtonProps,
+  IconButton,
+  Tooltip,
+} from "@mui/material";
+import { useEffect, useRef, useState } from "react";
+
+/** Copy text to the clipboard, falling back to a hidden textarea + execCommand. */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // fall through to the legacy path
+  }
+  try {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(textarea);
+    return ok;
+  } catch {
+    return false;
+  }
+}
+
+interface CopyButtonProps {
+  value: string;
+  /** What is being copied, used in labels: "Copy code". Default "Copy". */
+  label?: string;
+  copiedLabel?: string;
+  /** Icon-only (default) or a regular button with text. */
+  variant?: "icon" | "button";
+  size?: "small" | "medium" | "large";
+  color?: ButtonProps["color"] | "inherit";
+  onCopied?: () => void;
+  /** How long the "Copied" state is shown, in ms. */
+  resetAfterMs?: number;
+  sx?: ButtonProps["sx"];
+}
+
+export function CopyButton({
+  value,
+  label = "Copy",
+  copiedLabel = "Copied",
+  variant = "icon",
+  size = "medium",
+  color = "primary",
+  onCopied,
+  resetAfterMs = 2000,
+  sx,
+}: CopyButtonProps) {
+  const [state, setState] = useState<"idle" | "copied" | "failed">("idle");
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timer.current) clearTimeout(timer.current);
+    },
+    [],
+  );
+
+  const handleClick = async () => {
+    const ok = await copyToClipboard(value);
+    setState(ok ? "copied" : "failed");
+    if (ok) onCopied?.();
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setState("idle"), resetAfterMs);
+  };
+
+  const text =
+    state === "copied"
+      ? copiedLabel
+      : state === "failed"
+        ? "Couldn't copy — select it instead"
+        : label;
+  const icon = state === "copied" ? <CheckOutlined /> : <ContentCopyOutlined />;
+
+  return (
+    <>
+      <Tooltip title={text} placement="top">
+        {variant === "button" ? (
+          <Button
+            onClick={handleClick}
+            startIcon={icon}
+            size={size}
+            color={color === "inherit" ? "inherit" : color}
+            variant="contained"
+            aria-label={state === "idle" ? label : text}
+            sx={sx}
+          >
+            {text}
+          </Button>
+        ) : (
+          <IconButton
+            onClick={handleClick}
+            size={size}
+            color={color === "inherit" ? "inherit" : color}
+            aria-label={state === "idle" ? label : text}
+            sx={sx}
+          >
+            {icon}
+          </IconButton>
+        )}
+      </Tooltip>
+      {/* Announce the result to assistive tech without a visible toast. */}
+      <Box
+        component="span"
+        role="status"
+        aria-live="polite"
+        sx={{
+          position: "absolute",
+          width: 1,
+          height: 1,
+          overflow: "hidden",
+          clip: "rect(0 0 0 0)",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {state === "idle" ? "" : text}
+      </Box>
+    </>
+  );
+}

--- a/src/client/components/ui/EmptyState.tsx
+++ b/src/client/components/ui/EmptyState.tsx
@@ -1,0 +1,79 @@
+import { Box, Paper, Typography } from "@mui/material";
+import type { ReactNode } from "react";
+
+interface EmptyStateProps {
+  icon?: ReactNode;
+  title: ReactNode;
+  description?: ReactNode;
+  action?: ReactNode;
+  /** Less padding, for inside lists/cards. */
+  compact?: boolean;
+  /** Render without the outlined container (when already inside one). */
+  bare?: boolean;
+}
+
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  compact = false,
+  bare = false,
+}: EmptyStateProps) {
+  const content = (
+    <Box
+      sx={{
+        textAlign: "center",
+        px: 3,
+        py: compact ? 3 : 6,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 1,
+      }}
+    >
+      {icon ? (
+        <Box
+          aria-hidden
+          sx={{
+            width: compact ? 44 : 56,
+            height: compact ? 44 : 56,
+            borderRadius: "50%",
+            display: "grid",
+            placeItems: "center",
+            bgcolor: (theme) =>
+              theme.palette.mode === "light" ? "#F3E8D6" : "#3A2E26",
+            color: "primary.main",
+            mb: 1,
+            "& svg": { fontSize: compact ? 22 : 28 },
+          }}
+        >
+          {icon}
+        </Box>
+      ) : null}
+      <Typography variant="h5" component="p">
+        {title}
+      </Typography>
+      {description ? (
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ maxWidth: 420, textWrap: "pretty" }}
+        >
+          {description}
+        </Typography>
+      ) : null}
+      {action ? <Box sx={{ mt: 1.5 }}>{action}</Box> : null}
+    </Box>
+  );
+
+  if (bare) {
+    return content;
+  }
+
+  return (
+    <Paper variant="outlined" sx={{ borderStyle: "dashed" }}>
+      {content}
+    </Paper>
+  );
+}

--- a/src/client/components/ui/ErrorState.tsx
+++ b/src/client/components/ui/ErrorState.tsx
@@ -1,0 +1,34 @@
+import { Alert, AlertTitle, Button } from "@mui/material";
+import type { ReactNode } from "react";
+
+interface ErrorStateProps {
+  title?: ReactNode;
+  message: ReactNode;
+  onRetry?: () => void;
+  retryLabel?: string;
+}
+
+/** A visible, actionable error — never just a toast in the corner. */
+export function ErrorState({
+  title = "Something went wrong",
+  message,
+  onRetry,
+  retryLabel = "Try again",
+}: ErrorStateProps) {
+  return (
+    <Alert
+      severity="error"
+      role="alert"
+      action={
+        onRetry ? (
+          <Button color="inherit" size="small" onClick={onRetry}>
+            {retryLabel}
+          </Button>
+        ) : undefined
+      }
+    >
+      <AlertTitle>{title}</AlertTitle>
+      {message}
+    </Alert>
+  );
+}

--- a/src/client/components/ui/LoadingState.tsx
+++ b/src/client/components/ui/LoadingState.tsx
@@ -1,0 +1,52 @@
+import { Box, Skeleton, Stack } from "@mui/material";
+
+interface LoadingStateProps {
+  /** Shape of the content being loaded. */
+  variant?: "list" | "cards" | "detail";
+  rows?: number;
+  /** Accessible description, announced to screen readers. */
+  label?: string;
+}
+
+/** Skeleton placeholders shaped like the content they stand in for. */
+export function LoadingState({
+  variant = "list",
+  rows = 3,
+  label = "Loading…",
+}: LoadingStateProps) {
+  const items = Array.from({ length: rows }, (_, index) => index);
+
+  return (
+    <Box role="status" aria-live="polite" aria-label={label}>
+      {variant === "detail" ? (
+        <Stack spacing={2}>
+          <Skeleton variant="text" width="60%" height={36} />
+          <Skeleton variant="text" width="40%" />
+          <Skeleton variant="rounded" height={120} />
+          <Skeleton variant="rounded" height={160} />
+        </Stack>
+      ) : variant === "cards" ? (
+        <Stack spacing={2}>
+          {items.map((item) => (
+            <Skeleton key={item} variant="rounded" height={104} />
+          ))}
+        </Stack>
+      ) : (
+        <Stack spacing={0}>
+          {items.map((item) => (
+            <Box
+              key={item}
+              sx={{ display: "flex", alignItems: "center", gap: 2, py: 1.5 }}
+            >
+              <Skeleton variant="circular" width={36} height={36} />
+              <Box sx={{ flex: 1 }}>
+                <Skeleton variant="text" width="55%" />
+                <Skeleton variant="text" width="35%" />
+              </Box>
+            </Box>
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
+}

--- a/src/client/components/ui/PageHeader.tsx
+++ b/src/client/components/ui/PageHeader.tsx
@@ -1,0 +1,72 @@
+import { Box, Stack, Typography } from "@mui/material";
+import type { ReactNode } from "react";
+
+interface PageHeaderProps {
+  title: ReactNode;
+  /** Small label above the title, e.g. the household name. */
+  eyebrow?: ReactNode;
+  description?: ReactNode;
+  /** Primary action(s) shown beside the title (below it on phones). */
+  action?: ReactNode;
+}
+
+/** The one h1 every page starts with. */
+export function PageHeader({
+  title,
+  eyebrow,
+  description,
+  action,
+}: PageHeaderProps) {
+  return (
+    <Stack
+      direction={{ xs: "column", sm: "row" }}
+      spacing={2}
+      sx={{
+        mb: 3,
+        alignItems: { xs: "stretch", sm: "flex-start" },
+        justifyContent: "space-between",
+      }}
+    >
+      <Box sx={{ minWidth: 0 }}>
+        {eyebrow ? (
+          <Typography
+            variant="overline"
+            color="text.secondary"
+            component="div"
+            sx={{ mb: 0.5 }}
+          >
+            {eyebrow}
+          </Typography>
+        ) : null}
+        <Typography
+          variant="h2"
+          component="h1"
+          sx={{
+            fontSize: { xs: "1.5rem", sm: "1.75rem" },
+            textWrap: "balance",
+          }}
+        >
+          {title}
+        </Typography>
+        {description ? (
+          <Typography
+            variant="body1"
+            color="text.secondary"
+            sx={{ mt: 1, maxWidth: 640, textWrap: "pretty" }}
+          >
+            {description}
+          </Typography>
+        ) : null}
+      </Box>
+      {action ? (
+        <Stack
+          direction="row"
+          spacing={1.5}
+          sx={{ flexShrink: 0, "& > *": { flex: { xs: 1, sm: "0 0 auto" } } }}
+        >
+          {action}
+        </Stack>
+      ) : null}
+    </Stack>
+  );
+}

--- a/src/client/components/ui/PasswordField.tsx
+++ b/src/client/components/ui/PasswordField.tsx
@@ -1,0 +1,42 @@
+import { VisibilityOffOutlined, VisibilityOutlined } from "@mui/icons-material";
+import {
+  IconButton,
+  InputAdornment,
+  TextField,
+  type TextFieldProps,
+} from "@mui/material";
+import { useState } from "react";
+
+type PasswordFieldProps = Omit<TextFieldProps, "type">;
+
+/** A password TextField with a show/hide toggle. */
+export function PasswordField({ slotProps, ...props }: PasswordFieldProps) {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <TextField
+      {...props}
+      type={visible ? "text" : "password"}
+      slotProps={{
+        ...slotProps,
+        input: {
+          ...(slotProps?.input as object | undefined),
+          endAdornment: (
+            <InputAdornment position="end">
+              <IconButton
+                aria-label={visible ? "Hide password" : "Show password"}
+                aria-pressed={visible}
+                onClick={() => setVisible((current) => !current)}
+                onMouseDown={(event) => event.preventDefault()}
+                edge="end"
+                size="small"
+              >
+                {visible ? <VisibilityOffOutlined /> : <VisibilityOutlined />}
+              </IconButton>
+            </InputAdornment>
+          ),
+        },
+      }}
+    />
+  );
+}

--- a/src/client/components/ui/RelativeTime.tsx
+++ b/src/client/components/ui/RelativeTime.tsx
@@ -1,0 +1,40 @@
+import { Typography, type TypographyProps } from "@mui/material";
+import { useEffect, useState } from "react";
+import { formatRelativeTime, formatTimestamp } from "../../utils";
+
+/** Re-renders on an interval so relative labels stay fresh. */
+export function useNow(intervalMs = 30_000) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
+  return now;
+}
+
+interface RelativeTimeProps extends Omit<TypographyProps, "children"> {
+  value: string | null;
+  /** Prefix such as "Received". */
+  prefix?: string;
+}
+
+/** "2 min ago" with the absolute time as the tooltip and `<time>` dateTime. */
+export function RelativeTime({ value, prefix, ...props }: RelativeTimeProps) {
+  const now = useNow();
+  if (!value) return null;
+  const relative = formatRelativeTime(value, now);
+  const absolute = formatTimestamp(value);
+  return (
+    <Typography
+      component="time"
+      dateTime={value}
+      title={absolute}
+      variant="body2"
+      color="text.secondary"
+      {...props}
+    >
+      {prefix ? `${prefix} ` : ""}
+      {relative}
+    </Typography>
+  );
+}

--- a/src/client/components/ui/StatusChip.tsx
+++ b/src/client/components/ui/StatusChip.tsx
@@ -1,0 +1,72 @@
+import {
+  CheckCircleOutlined,
+  HistoryOutlined,
+  MarkEmailUnreadOutlined,
+} from "@mui/icons-material";
+import { Chip, type ChipProps } from "@mui/material";
+import type { ReactElement } from "react";
+import type { InboxMessage } from "../../types";
+
+export type StatusTone = "success" | "neutral" | "warning" | "error" | "info";
+
+interface StatusChipProps extends Omit<ChipProps, "color" | "label" | "icon"> {
+  tone: StatusTone;
+  label: string;
+  icon?: ReactElement;
+}
+
+const TONE_COLOR: Record<StatusTone, ChipProps["color"]> = {
+  success: "success",
+  neutral: "default",
+  warning: "warning",
+  error: "error",
+  info: "info",
+};
+
+/** A small status label that always pairs colour with text (and an icon). */
+export function StatusChip({
+  tone,
+  label,
+  icon,
+  size = "small",
+  variant = "outlined",
+  ...props
+}: StatusChipProps) {
+  return (
+    <Chip
+      {...props}
+      size={size}
+      variant={variant}
+      color={TONE_COLOR[tone]}
+      label={label}
+      icon={icon}
+    />
+  );
+}
+
+export const MESSAGE_STATUS: Record<
+  InboxMessage["status"],
+  { label: string; tone: StatusTone; icon: ReactElement }
+> = {
+  new: { label: "New", tone: "success", icon: <MarkEmailUnreadOutlined /> },
+  used: { label: "Used", tone: "neutral", icon: <CheckCircleOutlined /> },
+  expired: { label: "Expired", tone: "warning", icon: <HistoryOutlined /> },
+};
+
+export function MessageStatusChip({
+  status,
+  ...props
+}: { status: InboxMessage["status"] } & Omit<
+  StatusChipProps,
+  "tone" | "label" | "icon"
+>) {
+  const meta = MESSAGE_STATUS[status];
+  return (
+    <StatusChip
+      {...props}
+      tone={meta.tone}
+      label={meta.label}
+      icon={meta.icon}
+    />
+  );
+}

--- a/src/client/components/ui/index.ts
+++ b/src/client/components/ui/index.ts
@@ -1,0 +1,13 @@
+export { CopyButton, copyToClipboard } from "./CopyButton";
+export { EmptyState } from "./EmptyState";
+export { ErrorState } from "./ErrorState";
+export { LoadingState } from "./LoadingState";
+export { PageHeader } from "./PageHeader";
+export { PasswordField } from "./PasswordField";
+export { RelativeTime, useNow } from "./RelativeTime";
+export {
+  MESSAGE_STATUS,
+  MessageStatusChip,
+  StatusChip,
+  type StatusTone,
+} from "./StatusChip";

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -158,3 +158,43 @@ export function stringAvatar(name: string) {
     children: initials || "?",
   };
 }
+
+/**
+ * Human relative time for message ages: "just now", "5 min ago", "2 hr ago",
+ * "yesterday 10:44", then a short date. Codes are only useful for minutes,
+ * so the near end of the scale is the precise one.
+ */
+export function formatRelativeTime(
+  value: string,
+  now: number = Date.now(),
+): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  const diffSeconds = Math.round((now - date.getTime()) / 1000);
+  if (diffSeconds < 45) return "just now";
+  const minutes = Math.round(diffSeconds / 60);
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours} hr ago`;
+  const time = new Intl.DateTimeFormat(undefined, {
+    timeStyle: "short",
+  }).format(date);
+  const startOfToday = new Date(now);
+  startOfToday.setHours(0, 0, 0, 0);
+  const startOfYesterday = startOfToday.getTime() - 86_400_000;
+  if (date.getTime() >= startOfYesterday) return `yesterday ${time}`;
+  const days = Math.round(
+    (startOfToday.getTime() - date.getTime()) / 86_400_000,
+  );
+  if (days < 7) {
+    const weekday = new Intl.DateTimeFormat(undefined, {
+      weekday: "short",
+    }).format(date);
+    return `${weekday} ${time}`;
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+  }).format(date);
+}

--- a/test/ui-primitives.test.tsx
+++ b/test/ui-primitives.test.tsx
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { InboxOutlined } from "@mui/icons-material";
+import { Button } from "@mui/material";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ConfirmDialog } from "../src/client/components/ConfirmDialog";
+import {
+  CopyButton,
+  EmptyState,
+  ErrorState,
+  LoadingState,
+  MessageStatusChip,
+  PageHeader,
+  PasswordField,
+  RelativeTime,
+} from "../src/client/components/ui";
+import { formatRelativeTime } from "../src/client/utils";
+import { renderClient, screen, userEvent, within } from "./client-test-utils";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("PageHeader", () => {
+  it("renders the title as the page h1 with description and action", () => {
+    renderClient(
+      <PageHeader
+        eyebrow="Familien Olsen"
+        title="Inbox"
+        description="Latest codes for your services."
+        action={<Button>Refresh</Button>}
+      />,
+    );
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Inbox" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Familien Olsen")).toBeInTheDocument();
+    expect(
+      screen.getByText("Latest codes for your services."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Refresh" })).toBeInTheDocument();
+  });
+});
+
+describe("EmptyState / LoadingState / ErrorState", () => {
+  it("shows title, description and action", () => {
+    renderClient(
+      <EmptyState
+        icon={<InboxOutlined />}
+        title="No codes yet"
+        description="They'll show up here."
+        action={<Button>Invite someone</Button>}
+      />,
+    );
+    expect(screen.getByText("No codes yet")).toBeInTheDocument();
+    expect(screen.getByText("They'll show up here.")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Invite someone" }),
+    ).toBeInTheDocument();
+  });
+
+  it("LoadingState is announced as a status", () => {
+    renderClient(<LoadingState label="Loading inbox" rows={2} />);
+    expect(
+      screen.getByRole("status", { name: "Loading inbox" }),
+    ).toBeInTheDocument();
+  });
+
+  it("ErrorState offers a retry action", async () => {
+    const onRetry = vi.fn();
+    renderClient(<ErrorState message="Could not load." onRetry={onRetry} />);
+    expect(screen.getByRole("alert")).toHaveTextContent("Could not load.");
+    await userEvent
+      .setup()
+      .click(screen.getByRole("button", { name: "Try again" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("MessageStatusChip", () => {
+  it("maps statuses to plain labels", () => {
+    renderClient(
+      <>
+        <MessageStatusChip status="new" />
+        <MessageStatusChip status="used" />
+        <MessageStatusChip status="expired" />
+      </>,
+    );
+    expect(screen.getByText("New")).toBeInTheDocument();
+    expect(screen.getByText("Used")).toBeInTheDocument();
+    expect(screen.getByText("Expired")).toBeInTheDocument();
+  });
+});
+
+describe("CopyButton", () => {
+  it("copies the value and shows a copied state, announced politely", async () => {
+    // user-event installs its own clipboard stub on setup, so stub after.
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    const onCopied = vi.fn();
+    renderClient(
+      <CopyButton value="482913" label="Copy code" onCopied={onCopied} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Copy code" }));
+
+    expect(writeText).toHaveBeenCalledWith("482913");
+    expect(onCopied).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getAllByRole("button", { name: "Copied" }).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByRole("status").some((el) => el.textContent === "Copied"),
+    ).toBe(true);
+  });
+
+  it("falls back to execCommand when the clipboard API is unavailable", async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+    });
+    const execCommand = vi.fn().mockReturnValue(true);
+    Object.assign(document, { execCommand });
+    renderClient(
+      <CopyButton value="7731" variant="button" label="Copy code" />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Copy code" }));
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(
+      screen.getAllByRole("button", { name: "Copied" }).length,
+    ).toBeGreaterThan(0);
+  });
+});
+
+describe("PasswordField", () => {
+  it("toggles between hidden and visible", async () => {
+    renderClient(
+      <PasswordField label="Password" defaultValue="hunter22hunter22" />,
+    );
+    const input = screen.getByLabelText("Password");
+    expect(input).toHaveAttribute("type", "password");
+    await userEvent
+      .setup()
+      .click(screen.getByRole("button", { name: "Show password" }));
+    expect(input).toHaveAttribute("type", "text");
+    expect(
+      screen.getByRole("button", { name: "Hide password" }),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+});
+
+describe("ConfirmDialog (accessible)", () => {
+  it("is labelled by its title, described by its body, and shows errors inline", () => {
+    renderClient(
+      <ConfirmDialog
+        open
+        title="Remove Kari?"
+        description="She loses access right away."
+        confirmLabel="Remove"
+        loadingLabel="Removing…"
+        error="Could not remove member."
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    );
+    const dialog = screen.getByRole("dialog", { name: "Remove Kari?" });
+    expect(dialog).toHaveAccessibleDescription(/She loses access right away/);
+    expect(
+      within(dialog).getByText("Could not remove member."),
+    ).toBeInTheDocument();
+  });
+
+  it("uses the specific loading label", () => {
+    renderClient(
+      <ConfirmDialog
+        open
+        isLoading
+        title="Leave?"
+        description="…"
+        confirmLabel="Leave"
+        loadingLabel="Leaving…"
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Leaving…" })).toBeDisabled();
+  });
+});
+
+describe("RelativeTime / formatRelativeTime", () => {
+  const now = new Date("2026-08-21T10:00:00Z").getTime();
+
+  it("formats ages the way people say them", () => {
+    expect(formatRelativeTime("2026-08-21T09:59:40Z", now)).toBe("just now");
+    expect(formatRelativeTime("2026-08-21T09:55:00Z", now)).toBe("5 min ago");
+    expect(formatRelativeTime("2026-08-21T07:00:00Z", now)).toBe("3 hr ago");
+    expect(formatRelativeTime("2026-08-20T08:00:00Z", now)).toMatch(
+      /^yesterday /,
+    );
+    expect(formatRelativeTime("2026-08-18T08:00:00Z", now)).toMatch(/^\w{3} /);
+    expect(formatRelativeTime("2026-07-01T08:00:00Z", now)).toMatch(/2026/);
+    expect(formatRelativeTime("garbage", now)).toBe("garbage");
+  });
+
+  it("renders a <time> element with the absolute timestamp as title", () => {
+    vi.useFakeTimers({ now });
+    renderClient(
+      <RelativeTime value="2026-08-21T09:55:00Z" prefix="Received" />,
+    );
+    const time = screen.getByText(/Received 5 min ago/);
+    expect(time.tagName).toBe("TIME");
+    expect(time).toHaveAttribute("dateTime", "2026-08-21T09:55:00Z");
+    expect(time).toHaveAttribute("title");
+  });
+});


### PR DESCRIPTION
Closes #180 (part of #169, Phase 1).

## What
New `src/client/components/ui/` (all with jsdom interaction tests):
- `PageHeader` — the page h1 + description + action (stacks on phones).
- `EmptyState`, `LoadingState` (skeletons, `role=status`), `ErrorState` (alert + retry).
- `StatusChip` / `MessageStatusChip` — colour always paired with a plain label + icon (New / Used / Expired).
- `CopyButton` — clipboard API with `execCommand` fallback, "Copied" state, tooltip, `aria-label`, polite live-region announcement; icon or button variant.
- `PasswordField` — show/hide toggle with `aria-pressed`.
- `RelativeTime` + `formatRelativeTime()` — "just now / 5 min ago / 3 hr ago / yesterday 10:44 / Tue 09:12 / 1 Jul 2026", rendered as `<time dateTime title=absolute>`, refreshed every 30 s.

`ConfirmDialog` (same API, upgraded in place): `aria-labelledby`/`aria-describedby`, `loadingLabel` ("Removing…" instead of "Working…"), `cancelLabel`, and an inline `error` so a failed action is visible inside the dialog rather than in a snackbar behind the scrim. Cancel is now an outlined button so it isn't the weakest target in a destructive dialog.

Adopted now: `CopyButton` replaces the hand-rolled clipboard code in `InboxView` and `QuarantineView`. The other primitives get used by the screen redesign PRs.

## Tests
`test/ui-primitives.test.tsx` (12) + existing `confirm-dialog.test.tsx`; `npm run ci` green locally (263 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)