### PR TITLE
feat(client): app shell — brand mark, household switcher up top, drawer from md, mobile page title

### DIFF
--- a/src/client/components/Layout.tsx
+++ b/src/client/components/Layout.tsx
@@ -2,7 +2,6 @@ import {
   Add,
   Brightness4,
   Brightness7,
-  ExpandMore,
   HubOutlined,
   Inbox as InboxIcon,
   Logout as LogoutIcon,
@@ -10,6 +9,7 @@ import {
   Menu as MenuIcon,
   People as PeopleIcon,
   Security as SecurityIcon,
+  UnfoldMore,
 } from "@mui/icons-material";
 import {
   AppBar,
@@ -33,13 +33,15 @@ import {
   useTheme,
 } from "@mui/material";
 import type React from "react";
-import { useContext, useState } from "react";
+import { type ReactNode, useContext, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { ColorModeContext } from "../theme";
 import type { HouseholdSummary, SessionData } from "../types";
 import { buildHouseholdPath, getDisplayName, getUserInitials } from "../utils";
+import { BrandLockup } from "./ui";
 
-const DRAWER_WIDTH = 280;
+const DRAWER_WIDTH = 264;
+const APP_BAR_HEIGHT = 64;
 
 /**
  * Account settings (profile, password, 2FA, passkeys, sessions) are a global
@@ -61,7 +63,9 @@ interface LayoutProps {
   onLogout: () => void;
 }
 
-function getActiveView(pathname: string) {
+type ActiveView = "inbox" | "members" | "quarantine" | "providers" | "settings";
+
+function getActiveView(pathname: string): ActiveView {
   // Match on path segments (/:slug/:view), not substrings, so a household slug
   // that happens to contain a view name does not change the active view.
   const segments = pathname.split("/").filter(Boolean);
@@ -76,6 +80,22 @@ function getActiveView(pathname: string) {
 
 export function isSettingsPath(pathname: string) {
   return getActiveView(pathname) === "settings";
+}
+
+/** Title shown in the mobile app bar. */
+export function getPageTitle(pathname: string): string {
+  const view = getActiveView(pathname);
+  if (view === "settings") {
+    return pathname === ACCOUNT_SETTINGS_PATH
+      ? "Settings"
+      : "Household settings";
+  }
+  return {
+    inbox: "Latest codes",
+    members: "Members",
+    quarantine: "Quarantine",
+    providers: "Providers & rules",
+  }[view];
 }
 
 interface UserAccountMenuProps {
@@ -183,6 +203,42 @@ function UserAccountMenu({
   );
 }
 
+interface NavItemProps {
+  to: string;
+  icon: ReactNode;
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+}
+
+function NavItem({ to, icon, label, selected, onClick }: NavItemProps) {
+  return (
+    <ListItem disablePadding sx={{ mb: 0.5 }}>
+      <ListItemButton
+        selected={selected}
+        component={Link}
+        to={to}
+        onClick={onClick}
+        aria-current={selected ? "page" : undefined}
+        sx={{ minHeight: 44 }}
+      >
+        <ListItemIcon
+          sx={{ minWidth: 40, color: selected ? "primary.main" : "inherit" }}
+        >
+          {icon}
+        </ListItemIcon>
+        <ListItemText
+          primary={
+            <Typography sx={{ fontWeight: selected ? 700 : 500 }}>
+              {label}
+            </Typography>
+          }
+        />
+      </ListItemButton>
+    </ListItem>
+  );
+}
+
 export function Layout({
   children,
   session,
@@ -197,9 +253,10 @@ export function Layout({
 }: LayoutProps) {
   const location = useLocation();
   const activeView = getActiveView(location.pathname);
+  const pageTitle = getPageTitle(location.pathname);
   const theme = useTheme();
   const colorMode = useContext(ColorModeContext);
-  const isDesktop = useMediaQuery(theme.breakpoints.up("lg"));
+  const isDesktop = useMediaQuery(theme.breakpoints.up("md"));
   const [mobileOpen, setMobileOpen] = useState(false);
   const [householdMenuAnchor, setHouseholdMenuAnchor] =
     useState<null | HTMLElement>(null);
@@ -262,213 +319,75 @@ export function Layout({
   };
 
   const drawerContent = (
-    <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
-      <Toolbar>
-        <Typography
-          variant="h6"
-          noWrap
-          component="div"
-          sx={{ fontWeight: "bold" }}
-        >
-          Mi Casa Su Casa
-        </Typography>
-      </Toolbar>
-      <Divider />
-      <List sx={{ px: 2, pt: 2 }}>
-        <ListItem disablePadding sx={{ mb: 1 }}>
-          <ListItemButton
-            selected={activeView === "inbox"}
-            component={Link}
-            to={buildHouseholdPath(householdSlug, "/inbox")}
-            onClick={handleNavClick}
-            sx={{ borderRadius: 2 }}
-          >
-            <ListItemIcon>
-              <InboxIcon
-                color={activeView === "inbox" ? "primary" : "inherit"}
-              />
-            </ListItemIcon>
-            <ListItemText
-              primary={
-                <Typography
-                  sx={{
-                    fontWeight: activeView === "inbox" ? "bold" : "normal",
-                  }}
-                >
-                  Inbox
-                </Typography>
-              }
-            />
-          </ListItemButton>
-        </ListItem>
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        bgcolor: "background.default",
+      }}
+    >
+      <Box
+        sx={{
+          px: 2.5,
+          height: APP_BAR_HEIGHT,
+          display: "flex",
+          alignItems: "center",
+        }}
+      >
+        <BrandLockup size={30} />
+      </Box>
 
-        {isOwner && (
-          <>
-            <ListItem sx={{ px: 1, pt: 1, pb: 0.5 }}>
-              <Typography
-                variant="overline"
-                color="text.secondary"
-                sx={{ fontWeight: 700, letterSpacing: 1 }}
-              >
-                Settings
-              </Typography>
-            </ListItem>
-
-            <ListItem disablePadding sx={{ mb: 1 }}>
-              <ListItemButton
-                selected={activeView === "members"}
-                component={Link}
-                to={buildHouseholdPath(householdSlug, "/members")}
-                onClick={handleNavClick}
-                sx={{ borderRadius: 2 }}
-              >
-                <ListItemIcon>
-                  <PeopleIcon
-                    color={activeView === "members" ? "primary" : "inherit"}
-                  />
-                </ListItemIcon>
-                <ListItemText
-                  primary={
-                    <Typography
-                      sx={{
-                        fontWeight:
-                          activeView === "members" ? "bold" : "normal",
-                      }}
-                    >
-                      Members
-                    </Typography>
-                  }
-                />
-              </ListItemButton>
-            </ListItem>
-
-            <ListItem disablePadding sx={{ mb: 1 }}>
-              <ListItemButton
-                selected={activeView === "quarantine"}
-                component={Link}
-                to={buildHouseholdPath(householdSlug, "/quarantine")}
-                onClick={handleNavClick}
-                sx={{ borderRadius: 2 }}
-              >
-                <ListItemIcon>
-                  <SecurityIcon
-                    color={activeView === "quarantine" ? "primary" : "inherit"}
-                  />
-                </ListItemIcon>
-                <ListItemText
-                  primary={
-                    <Typography
-                      sx={{
-                        fontWeight:
-                          activeView === "quarantine" ? "bold" : "normal",
-                      }}
-                    >
-                      Quarantine
-                    </Typography>
-                  }
-                />
-              </ListItemButton>
-            </ListItem>
-
-            <ListItem disablePadding sx={{ mb: 1 }}>
-              <ListItemButton
-                selected={activeView === "providers"}
-                component={Link}
-                to={buildHouseholdPath(householdSlug, "/providers")}
-                onClick={handleNavClick}
-                sx={{ borderRadius: 2 }}
-              >
-                <ListItemIcon>
-                  <HubOutlined
-                    color={activeView === "providers" ? "primary" : "inherit"}
-                  />
-                </ListItemIcon>
-                <ListItemText
-                  primary={
-                    <Typography
-                      sx={{
-                        fontWeight:
-                          activeView === "providers" ? "bold" : "normal",
-                      }}
-                    >
-                      Providers &amp; rules
-                    </Typography>
-                  }
-                />
-              </ListItemButton>
-            </ListItem>
-
-            <ListItem disablePadding>
-              <ListItemButton
-                selected={activeView === "settings"}
-                component={Link}
-                to={buildHouseholdPath(householdSlug, "/settings")}
-                onClick={handleNavClick}
-                sx={{ borderRadius: 2 }}
-              >
-                <ListItemIcon>
-                  <ManageAccountsIcon
-                    color={activeView === "settings" ? "primary" : "inherit"}
-                  />
-                </ListItemIcon>
-                <ListItemText
-                  primary={
-                    <Typography
-                      sx={{
-                        fontWeight:
-                          activeView === "settings" ? "bold" : "normal",
-                      }}
-                    >
-                      Household settings
-                    </Typography>
-                  }
-                />
-              </ListItemButton>
-            </ListItem>
-          </>
-        )}
-      </List>
-      <Box sx={{ mt: "auto", px: 2, pb: 2, pt: 2 }}>
-        <Divider sx={{ mb: 2 }} />
+      {/* Household switcher: the primary context, so it sits at the top. */}
+      <Box sx={{ px: 2, pb: 1 }}>
         <ButtonBase
           onClick={handleOpenHouseholdMenu}
+          aria-haspopup="menu"
+          aria-expanded={isHouseholdMenuOpen ? "true" : undefined}
+          aria-label={`Household: ${householdName}. Switch household`}
           sx={{
             width: "100%",
             borderRadius: 3,
             border: 1,
             borderColor: "divider",
-            px: 2,
-            py: 1.5,
+            px: 1.5,
+            py: 1.25,
             textAlign: "left",
             justifyContent: "space-between",
             alignItems: "center",
             bgcolor: "background.paper",
+            gap: 1,
           }}
         >
-          <Box sx={{ minWidth: 0, pr: 2 }}>
-            <Typography variant="body2" sx={{ fontWeight: 700 }} noWrap>
+          <Box sx={{ minWidth: 0 }}>
+            <Typography
+              variant="overline"
+              color="text.secondary"
+              component="div"
+              sx={{ lineHeight: 1.4 }}
+            >
+              Household
+            </Typography>
+            <Typography variant="subtitle1" noWrap>
               {householdName}
             </Typography>
-            <Chip
-              label={roleLabel}
-              size="small"
-              sx={{ mt: 0.75, fontWeight: 600, maxWidth: "100%" }}
-            />
+            <Chip label={roleLabel} size="small" sx={{ mt: 0.5, height: 22 }} />
           </Box>
-          <ExpandMore color="action" />
+          <UnfoldMore color="action" fontSize="small" />
         </ButtonBase>
         <Menu
           anchorEl={householdMenuAnchor}
           open={isHouseholdMenuOpen}
           onClose={handleCloseHouseholdMenu}
-          anchorOrigin={{ vertical: "top", horizontal: "right" }}
-          transformOrigin={{ vertical: "bottom", horizontal: "right" }}
+          anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+          transformOrigin={{ vertical: "top", horizontal: "left" }}
           slotProps={{
             paper: {
               sx: {
-                width: 320,
+                width: 300,
                 maxWidth: "calc(100vw - 32px)",
                 borderRadius: 3,
+                mt: 0.5,
               },
             },
           }}
@@ -488,10 +407,7 @@ export function Layout({
                 key={household.id}
                 selected={selected}
                 onClick={() => handleHouseholdSelect(household)}
-                sx={{
-                  alignItems: "flex-start",
-                  py: 1.25,
-                }}
+                sx={{ alignItems: "flex-start", py: 1.25 }}
               >
                 <ListItemText
                   primary={
@@ -519,6 +435,61 @@ export function Layout({
           </MenuItem>
         </Menu>
       </Box>
+
+      <List component="nav" aria-label="Main" sx={{ px: 2, pt: 1 }}>
+        <NavItem
+          to={buildHouseholdPath(householdSlug, "/inbox")}
+          icon={<InboxIcon />}
+          label="Inbox"
+          selected={activeView === "inbox"}
+          onClick={handleNavClick}
+        />
+
+        {isOwner && (
+          <>
+            <ListItem sx={{ px: 1, pt: 2, pb: 0.5 }}>
+              <Typography
+                variant="overline"
+                color="text.secondary"
+                component="div"
+              >
+                Settings
+              </Typography>
+            </ListItem>
+            <NavItem
+              to={buildHouseholdPath(householdSlug, "/members")}
+              icon={<PeopleIcon />}
+              label="Members"
+              selected={activeView === "members"}
+              onClick={handleNavClick}
+            />
+            <NavItem
+              to={buildHouseholdPath(householdSlug, "/quarantine")}
+              icon={<SecurityIcon />}
+              label="Quarantine"
+              selected={activeView === "quarantine"}
+              onClick={handleNavClick}
+            />
+            <NavItem
+              to={buildHouseholdPath(householdSlug, "/providers")}
+              icon={<HubOutlined />}
+              label="Providers & rules"
+              selected={activeView === "providers"}
+              onClick={handleNavClick}
+            />
+            <NavItem
+              to={buildHouseholdPath(householdSlug, "/settings")}
+              icon={<ManageAccountsIcon />}
+              label="Household settings"
+              selected={
+                activeView === "settings" &&
+                location.pathname !== ACCOUNT_SETTINGS_PATH
+              }
+              onClick={handleNavClick}
+            />
+          </>
+        )}
+      </List>
     </Box>
   );
 
@@ -528,26 +499,40 @@ export function Layout({
         position="fixed"
         elevation={0}
         sx={{
-          width: { lg: `calc(100% - ${DRAWER_WIDTH}px)` },
-          ml: { lg: `${DRAWER_WIDTH}px` },
+          width: { md: `calc(100% - ${DRAWER_WIDTH}px)` },
+          ml: { md: `${DRAWER_WIDTH}px` },
           bgcolor: "background.paper",
           color: "text.primary",
           borderBottom: 1,
           borderColor: "divider",
         }}
       >
-        <Toolbar>
+        <Toolbar sx={{ minHeight: APP_BAR_HEIGHT, gap: 1 }}>
           <IconButton
             color="inherit"
-            aria-label="open drawer"
+            aria-label="Open menu"
             edge="start"
             onClick={handleDrawerToggle}
-            sx={{ mr: 2, display: { lg: "none" } }}
+            sx={{ display: { md: "none" } }}
           >
             <MenuIcon />
           </IconButton>
 
-          <Box sx={{ flexGrow: 1 }} />
+          <Box sx={{ flexGrow: 1, minWidth: 0, display: { md: "none" } }}>
+            <Typography variant="h6" component="div" noWrap>
+              {pageTitle}
+            </Typography>
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              noWrap
+              component="div"
+              sx={{ lineHeight: 1.2 }}
+            >
+              {householdName}
+            </Typography>
+          </Box>
+          <Box sx={{ flexGrow: 1, display: { xs: "none", md: "block" } }} />
 
           <IconButton
             onClick={handleOpenUserMenu}
@@ -580,7 +565,7 @@ export function Layout({
 
       <Box
         component="nav"
-        sx={{ width: { lg: DRAWER_WIDTH }, flexShrink: { lg: 0 } }}
+        sx={{ width: { md: DRAWER_WIDTH }, flexShrink: { md: 0 } }}
       >
         {/* Mobile Drawer */}
         <Drawer
@@ -591,7 +576,7 @@ export function Layout({
             keepMounted: true, // Better open performance on mobile.
           }}
           sx={{
-            display: { xs: "block", lg: "none" },
+            display: { xs: "block", md: "none" },
             "& .MuiDrawer-paper": {
               boxSizing: "border-box",
               width: DRAWER_WIDTH,
@@ -604,7 +589,7 @@ export function Layout({
         <Drawer
           variant="permanent"
           sx={{
-            display: { xs: "none", lg: "block" },
+            display: { xs: "none", md: "block" },
             "& .MuiDrawer-paper": {
               boxSizing: "border-box",
               width: DRAWER_WIDTH,
@@ -624,11 +609,11 @@ export function Layout({
           flexGrow: 1,
           p: { xs: 2, sm: 3, md: 4 },
           minWidth: 0,
-          width: { lg: `calc(100% - ${DRAWER_WIDTH}px)` },
-          mt: "64px", // Toolbar height
+          width: { md: `calc(100% - ${DRAWER_WIDTH}px)` },
+          mt: `${APP_BAR_HEIGHT}px`,
         }}
       >
-        <Box sx={{ width: "100%", maxWidth: 1600, mx: "auto", minWidth: 0 }}>
+        <Box sx={{ width: "100%", maxWidth: 1400, mx: "auto", minWidth: 0 }}>
           {children}
         </Box>
       </Box>

--- a/src/client/components/PublicEntryShell.tsx
+++ b/src/client/components/PublicEntryShell.tsx
@@ -1,5 +1,8 @@
 import { Box, Card, CardContent, Container, Typography } from "@mui/material";
 import type { ReactNode } from "react";
+import { BrandLockup } from "./ui";
+
+const APP_NAME = "Mi Casa Su Casa";
 
 interface PublicEntryShellProps {
   eyebrow: string;
@@ -37,13 +40,18 @@ export function PublicEntryShell({
             sx={{ borderRadius: { xs: 3, sm: 4 }, overflow: "hidden" }}
           >
             <CardContent sx={{ p: { xs: 3, sm: 4, md: 5 } }}>
-              <Typography
-                variant="overline"
-                color="text.secondary"
-                sx={{ fontWeight: "bold", letterSpacing: 1 }}
-              >
-                {eyebrow}
-              </Typography>
+              <Box sx={{ mb: 3 }}>
+                <BrandLockup size={36} />
+              </Box>
+              {eyebrow !== APP_NAME ? (
+                <Typography
+                  variant="overline"
+                  color="text.secondary"
+                  component="div"
+                >
+                  {eyebrow}
+                </Typography>
+              ) : null}
               <Typography
                 variant="h4"
                 component="h1"

--- a/src/client/components/ui/LogoMark.tsx
+++ b/src/client/components/ui/LogoMark.tsx
@@ -1,0 +1,78 @@
+import { Box, Typography } from "@mui/material";
+import { brand } from "../../theme";
+
+interface LogoMarkProps {
+  size?: number;
+}
+
+/** The brand mark: a terracotta house with a coral envelope, drawn inline so it is crisp at any size. */
+export function LogoMark({ size = 32 }: LogoMarkProps) {
+  return (
+    <Box
+      component="svg"
+      viewBox="0 0 64 64"
+      width={size}
+      height={size}
+      aria-hidden
+      sx={{ display: "block", flexShrink: 0 }}
+    >
+      <title>Mi Casa Su Casa</title>
+      {/* roof */}
+      <path
+        d="M32 8 L6 30 H14 V52 A6 6 0 0 0 20 58 H44 A6 6 0 0 0 50 52 V30 H58 Z"
+        fill={brand.terracotta}
+      />
+      {/* chimney */}
+      <rect
+        x="42"
+        y="12"
+        width="7"
+        height="12"
+        rx="2"
+        fill={brand.terracotta}
+      />
+      {/* envelope */}
+      <rect x="20" y="32" width="24" height="18" rx="3" fill={brand.coral} />
+      <path
+        d="M20 35 L32 44 L44 35"
+        fill="none"
+        stroke={brand.terracotta}
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Box>
+  );
+}
+
+interface BrandLockupProps {
+  size?: number;
+  /** Hide the wordmark (icon only). */
+  compact?: boolean;
+}
+
+/** Logo + wordmark, used in the drawer header and on public pages. */
+export function BrandLockup({ size = 32, compact = false }: BrandLockupProps) {
+  return (
+    <Box
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 1.25,
+        minWidth: 0,
+      }}
+    >
+      <LogoMark size={size} />
+      {compact ? null : (
+        <Typography
+          variant="h5"
+          component="span"
+          noWrap
+          sx={{ color: "text.primary", letterSpacing: "-0.01em" }}
+        >
+          Mi Casa Su Casa
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/src/client/components/ui/index.ts
+++ b/src/client/components/ui/index.ts
@@ -2,6 +2,7 @@ export { CopyButton, copyToClipboard } from "./CopyButton";
 export { EmptyState } from "./EmptyState";
 export { ErrorState } from "./ErrorState";
 export { LoadingState } from "./LoadingState";
+export { BrandLockup, LogoMark } from "./LogoMark";
 export { PageHeader } from "./PageHeader";
 export { PasswordField } from "./PasswordField";
 export { RelativeTime, useNow } from "./RelativeTime";

--- a/test/layout.test.tsx
+++ b/test/layout.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  getPageTitle,
   isSettingsPath,
   Layout,
   UserAccountMenuContent,
@@ -204,5 +205,17 @@ describe("getUserInitials", () => {
         },
       }),
     ).toBe("AM");
+  });
+});
+
+describe("getPageTitle", () => {
+  it("names the current page for the mobile app bar", () => {
+    expect(getPageTitle("/home/inbox")).toBe("Latest codes");
+    expect(getPageTitle("/home/inbox/netflix")).toBe("Latest codes");
+    expect(getPageTitle("/home/members")).toBe("Members");
+    expect(getPageTitle("/home/quarantine")).toBe("Quarantine");
+    expect(getPageTitle("/home/providers")).toBe("Providers & rules");
+    expect(getPageTitle("/home/settings")).toBe("Household settings");
+    expect(getPageTitle("/settings")).toBe("Settings");
   });
 });


### PR DESCRIPTION
Closes #184 (part of #169).

## What
- `LogoMark` / `BrandLockup` (inline SVG house + envelope in the brand colours) in the drawer header and on the public entry card (`PublicEntryShell`), replacing the plain-text app name.
- Household switcher moves to the **top** of the drawer (labelled "Household", role chip, `aria-label` + `aria-haspopup`); "Create new household" stays in its menu.
- Permanent drawer from **`md` (900px)** instead of `lg`; width 264; nav items 44px with `aria-current="page"`.
- Mobile app bar shows the **current page title** (`getPageTitle`) and household name instead of being empty.
- Main content max-width 1400.

## Tests
- `test/layout.test.tsx`: existing assertions + `getPageTitle` (`/settings` → "Settings", `/:slug/settings` → "Household settings", `/:slug/inbox/:providerKey` → "Latest codes").
- `npm run ci` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)