### PR TITLE
feat(client): sign-in page — passkeys, show/hide password, inline validation, plain copy

### DIFF
--- a/src/client/components/LoginPage.tsx
+++ b/src/client/components/LoginPage.tsx
@@ -1,15 +1,41 @@
-import { Alert, Box, Button, Link as MuiLink, TextField } from "@mui/material";
+import { FingerprintOutlined } from "@mui/icons-material";
+import {
+  Alert,
+  Box,
+  Button,
+  Divider,
+  Link as MuiLink,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
 import { authClient } from "@server/auth/client";
-import { type FormEvent, useState } from "react";
+import { type FormEvent, useEffect, useRef, useState } from "react";
 import { Link as RouterLink, useNavigate } from "react-router-dom";
 import type { LoginState, SetupStatus } from "../types";
 import { PublicEntryShell } from "./PublicEntryShell";
+import { PasswordField } from "./ui";
 
 interface LoginPageProps {
   setupStatus: SetupStatus | null;
   setupError: string | null;
   onLoginSuccess: () => void;
 }
+
+/** True when the browser can offer passkeys in the email field's autofill. */
+export async function supportsPasskeyAutofill(): Promise<boolean> {
+  try {
+    return Boolean(
+      typeof window !== "undefined" &&
+        window.PublicKeyCredential &&
+        (await window.PublicKeyCredential.isConditionalMediationAvailable?.()),
+    );
+  } catch {
+    return false;
+  }
+}
+
+const PASSKEY_CANCELLED = /not allowed|timed out|abort|cancel/i;
 
 export function LoginPage({
   setupStatus,
@@ -21,115 +47,199 @@ export function LoginPage({
     email: "",
     password: "",
   });
+  const [fieldErrors, setFieldErrors] = useState<{
+    email?: string;
+    password?: string;
+  }>({});
   const [loginError, setLoginError] = useState<string | null>(null);
   const [isLoggingIn, setIsLoggingIn] = useState(false);
+  const [isPasskeyPending, setIsPasskeyPending] = useState(false);
+  const autofillStarted = useRef(false);
+  // The autofill effect runs once but must call the latest finishSignIn.
+  const finishSignInRef = useRef<(data: unknown) => void>(() => {});
+
+  const finishSignIn = (data: unknown) => {
+    setLoginState({ email: "", password: "" });
+    // Accounts with two-factor enabled get no session yet; finish on the
+    // challenge page.
+    if (
+      data &&
+      typeof data === "object" &&
+      "twoFactorRedirect" in data &&
+      (data as { twoFactorRedirect?: boolean }).twoFactorRedirect
+    ) {
+      navigate("/two-factor");
+      return;
+    }
+    onLoginSuccess();
+  };
+  finishSignInRef.current = finishSignIn;
+
+  // Offer saved passkeys in the email field's autofill (conditional UI). This
+  // never shows a prompt on its own, so failures are silent.
+  useEffect(() => {
+    if (autofillStarted.current) return;
+    autofillStarted.current = true;
+    let cancelled = false;
+    void (async () => {
+      if (!(await supportsPasskeyAutofill())) return;
+      const result = await authClient.signIn.passkey({ autoFill: true });
+      if (cancelled || !result || result.error) return;
+      finishSignInRef.current(result.data);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handlePasskey = async () => {
+    setLoginError(null);
+    setIsPasskeyPending(true);
+    const result = await authClient.signIn.passkey();
+    setIsPasskeyPending(false);
+    if (!result || result.error) {
+      const message = result?.error?.message ?? "";
+      setLoginError(
+        PASSKEY_CANCELLED.test(message)
+          ? "Passkey sign-in was cancelled. You can try again or use your password."
+          : message ||
+              "Couldn't sign in with a passkey on this device. Use your password instead.",
+      );
+      return;
+    }
+    finishSignIn(result.data);
+  };
 
   const handleLogin = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setLoginError(null);
-    setIsLoggingIn(true);
 
+    const nextErrors: typeof fieldErrors = {};
+    if (!loginState.email.trim())
+      nextErrors.email = "Enter your email address.";
+    if (!loginState.password) nextErrors.password = "Enter your password.";
+    setFieldErrors(nextErrors);
+    if (nextErrors.email || nextErrors.password) return;
+
+    setIsLoggingIn(true);
     const { data, error } = await authClient.signIn.email({
-      email: loginState.email,
+      email: loginState.email.trim(),
       password: loginState.password,
       rememberMe: true,
     });
-
     setIsLoggingIn(false);
 
     if (error) {
-      setLoginError(error.message ?? "Unable to sign in with that account.");
+      setLoginError(
+        error.message ?? "That email and password don't match. Try again.",
+      );
       return;
     }
 
-    setLoginState({ email: "", password: "" });
-
-    // Accounts with two-factor enabled get no session yet; finish on the
-    // challenge page.
-    if (data && "twoFactorRedirect" in data && data.twoFactorRedirect) {
-      navigate("/two-factor");
-      return;
-    }
-
-    onLoginSuccess();
+    finishSignIn(data);
   };
 
   return (
     <PublicEntryShell
       eyebrow="Mi Casa Su Casa"
-      title="Shared verification inbox, without the chaos."
-      description="Sign in with your invited household account to see the provider groups you have access to and quickly find the latest verification code."
+      title="Your family's login codes, in one place."
+      description="Sign in to see the latest verification codes for the services your household shares."
     >
-      <Box component="form" onSubmit={handleLogin} noValidate>
-        <TextField
-          margin="normal"
-          required
-          fullWidth
-          id="email"
-          label="Email Address"
-          name="email"
-          autoComplete="email"
-          autoFocus
-          value={loginState.email}
-          onChange={(e) =>
-            setLoginState((current) => ({
-              ...current,
-              email: e.target.value,
-            }))
-          }
-        />
-        <TextField
-          margin="normal"
-          required
-          fullWidth
-          name="password"
-          label="Password"
-          type="password"
-          id="password"
-          autoComplete="current-password"
-          value={loginState.password}
-          onChange={(e) =>
-            setLoginState((current) => ({
-              ...current,
-              password: e.target.value,
-            }))
-          }
-          sx={{ mb: 3 }}
-        />
-
-        {loginError && (
-          <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
-            {loginError}
-          </Alert>
-        )}
-
-        {setupError && !setupStatus?.isConfigured && (
-          <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
-            {setupError}
-          </Alert>
-        )}
-
+      <Stack spacing={2.5}>
         <Button
-          type="submit"
-          fullWidth
-          variant="contained"
+          type="button"
+          variant="outlined"
           size="large"
-          disabled={isLoggingIn}
-          sx={{ py: 1.5 }}
+          startIcon={<FingerprintOutlined />}
+          onClick={handlePasskey}
+          disabled={isPasskeyPending || isLoggingIn}
+          fullWidth
         >
-          {isLoggingIn ? "Signing in…" : "Sign in"}
+          {isPasskeyPending
+            ? "Waiting for your device…"
+            : "Sign in with a passkey"}
         </Button>
+        <Divider>
+          <Typography variant="body2" color="text.secondary">
+            or with your password
+          </Typography>
+        </Divider>
 
-        <Box sx={{ mt: 2, textAlign: "center" }}>
-          <MuiLink
-            component={RouterLink}
-            to="/forgot-password"
-            underline="hover"
+        <Box component="form" onSubmit={handleLogin} noValidate>
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            id="email"
+            label="Email address"
+            name="email"
+            type="email"
+            inputMode="email"
+            autoComplete="username webauthn"
+            autoFocus
+            value={loginState.email}
+            error={Boolean(fieldErrors.email)}
+            helperText={fieldErrors.email}
+            onChange={(e) => {
+              setLoginState((current) => ({
+                ...current,
+                email: e.target.value,
+              }));
+              if (fieldErrors.email)
+                setFieldErrors((f) => ({ ...f, email: undefined }));
+            }}
+          />
+          <PasswordField
+            margin="normal"
+            required
+            fullWidth
+            name="password"
+            label="Password"
+            id="password"
+            autoComplete="current-password"
+            value={loginState.password}
+            error={Boolean(fieldErrors.password)}
+            helperText={fieldErrors.password}
+            onChange={(e) => {
+              setLoginState((current) => ({
+                ...current,
+                password: e.target.value,
+              }));
+              if (fieldErrors.password)
+                setFieldErrors((f) => ({ ...f, password: undefined }));
+            }}
+            sx={{ mb: 3 }}
+          />
+
+          {loginError && (
+            <Alert severity="error" sx={{ mb: 3 }} role="alert">
+              {loginError}
+            </Alert>
+          )}
+
+          {setupError && !setupStatus?.isConfigured && (
+            <Alert severity="error" sx={{ mb: 3 }}>
+              {setupError}
+            </Alert>
+          )}
+
+          <Button
+            type="submit"
+            fullWidth
+            variant="contained"
+            size="large"
+            disabled={isLoggingIn || isPasskeyPending}
           >
-            Forgot your password?
-          </MuiLink>
+            {isLoggingIn ? "Signing in…" : "Sign in"}
+          </Button>
+
+          <Box sx={{ mt: 2, textAlign: "center" }}>
+            <MuiLink component={RouterLink} to="/forgot-password">
+              Forgot your password?
+            </MuiLink>
+          </Box>
         </Box>
-      </Box>
+      </Stack>
     </PublicEntryShell>
   );
 }

--- a/test/login-page.test.tsx
+++ b/test/login-page.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const signInEmail = vi.fn();
+const signInPasskey = vi.fn();
+vi.mock("@server/auth/client", () => ({
+  authClient: {
+    signIn: {
+      email: (...args: unknown[]) => signInEmail(...args),
+      passkey: (...args: unknown[]) => signInPasskey(...args),
+    },
+  },
+}));
+
+import { LoginPage } from "../src/client/components/LoginPage";
+import { renderClient, screen, userEvent, waitFor } from "./client-test-utils";
+
+function renderLogin(onLoginSuccess = vi.fn()) {
+  renderClient(
+    <LoginPage
+      setupStatus={null}
+      setupError={null}
+      onLoginSuccess={onLoginSuccess}
+    />,
+    { initialEntries: ["/login"] },
+  );
+  return { onLoginSuccess };
+}
+
+describe("LoginPage", () => {
+  beforeEach(() => {
+    signInEmail.mockReset();
+    signInPasskey.mockReset();
+    // jsdom has no WebAuthn; conditional autofill must stay silent.
+    signInPasskey.mockResolvedValue({
+      data: null,
+      error: { message: "unsupported" },
+    });
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("offers passkey sign-in and finishes when the device confirms", async () => {
+    const { onLoginSuccess } = renderLogin();
+    signInPasskey.mockResolvedValueOnce({ data: { session: {} }, error: null });
+
+    await userEvent
+      .setup()
+      .click(screen.getByRole("button", { name: "Sign in with a passkey" }));
+
+    await waitFor(() => expect(onLoginSuccess).toHaveBeenCalledTimes(1));
+    expect(signInEmail).not.toHaveBeenCalled();
+  });
+
+  it("explains a cancelled passkey prompt and lets the user fall back to a password", async () => {
+    renderLogin();
+    signInPasskey.mockResolvedValueOnce({
+      data: null,
+      error: { message: "The operation either timed out or was not allowed." },
+    });
+
+    await userEvent
+      .setup()
+      .click(screen.getByRole("button", { name: "Sign in with a passkey" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/cancelled/i);
+    expect(screen.getByLabelText(/^Password/)).toBeInTheDocument();
+  });
+
+  it("validates inline before calling the API", async () => {
+    renderLogin();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+
+    expect(screen.getByText("Enter your email address.")).toBeInTheDocument();
+    expect(screen.getByText("Enter your password.")).toBeInTheDocument();
+    expect(signInEmail).not.toHaveBeenCalled();
+
+    await user.type(screen.getByLabelText(/Email address/), "kari@example.com");
+    expect(screen.queryByText("Enter your email address.")).toBeNull();
+  });
+
+  it("signs in with email + password and supports show/hide", async () => {
+    const { onLoginSuccess } = renderLogin();
+    signInEmail.mockResolvedValue({ data: { user: {} }, error: null });
+    const user = userEvent.setup();
+
+    await user.type(screen.getByLabelText(/Email address/), "kari@example.com");
+    const password = screen.getByLabelText(/^Password/);
+    await user.type(password, "correct-horse-battery");
+    expect(password).toHaveAttribute("type", "password");
+    await user.click(screen.getByRole("button", { name: "Show password" }));
+    expect(password).toHaveAttribute("type", "text");
+
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+
+    await waitFor(() => expect(onLoginSuccess).toHaveBeenCalledTimes(1));
+    expect(signInEmail).toHaveBeenCalledWith({
+      email: "kari@example.com",
+      password: "correct-horse-battery",
+      rememberMe: true,
+    });
+  });
+
+  it("shows the server's error for a wrong password", async () => {
+    renderLogin();
+    signInEmail.mockResolvedValue({
+      data: null,
+      error: { message: "Invalid email or password" },
+    });
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/Email address/), "kari@example.com");
+    await user.type(screen.getByLabelText(/^Password/), "nope");
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Invalid email or password",
+    );
+  });
+});


### PR DESCRIPTION
Closes #186 (part of #169, Phase 3).

## What
- **"Sign in with a passkey"** button (`authClient.signIn.passkey()`), plus conditional-UI autofill (`autoFill: true` when `isConditionalMediationAvailable()`; email field has `autoComplete="username webauthn"`). Cancelled/unsupported prompts get a friendly message and the password form stays available.
- `PasswordField` (show/hide) for the password.
- Inline validation ("Enter your email address." / "Enter your password.") before any API call; server errors in an `Alert` with `role="alert"`.
- Copy: "Your family's login codes, in one place. — Sign in to see the latest verification codes for the services your household shares." (was "provider groups you have access to").
- 2FA redirect behaviour unchanged.

## Tests
`test/login-page.test.tsx` (5, jsdom, auth client mocked): passkey success, cancelled passkey message, inline validation blocks the API, email+password + show/hide, server error shown. `npm run ci` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)