### PR TITLE
feat(client): invite page — who invited you, which household, plain copy, inline validation, sign-out

### DIFF
--- a/src/client/components/InvitePage.tsx
+++ b/src/client/components/InvitePage.tsx
@@ -2,73 +2,74 @@ import {
   Alert,
   Box,
   Button,
-  CircularProgress,
+  Stack,
   TextField,
   Typography,
 } from "@mui/material";
-import { type FormEvent, useEffect, useState } from "react";
+import { authClient } from "@server/auth/client";
+import { type FormEvent, useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type {
   InvitationAcceptanceState,
   InvitationLookupResponse,
-  InvitationSummary,
 } from "../types";
 import { fetchJson } from "../utils";
 import { PublicEntryShell } from "./PublicEntryShell";
+import { LoadingState, PasswordField } from "./ui";
 
 interface InvitePageProps {
   token: string;
   onAcceptSuccess: (householdSlug: string) => void;
 }
 
+const MIN_PASSWORD_LENGTH = 12;
+const APP_NAME = "Mi Casa Su Casa";
+
+function roleSentence(role: string, inviter: string) {
+  return role === "owner" || role === "admin"
+    ? "As an owner you can add services and family members, and review anything that needs a second look."
+    : `As a member you'll see the login codes for the services ${inviter} shares with you.`;
+}
+
 export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
   const navigate = useNavigate();
-  const [invitation, setInvitation] = useState<InvitationSummary | null>(null);
+  const [lookup, setLookup] = useState<InvitationLookupResponse | null>(null);
   const [accountExists, setAccountExists] = useState(false);
-  const [viewer, setViewer] =
-    useState<InvitationLookupResponse["viewer"]>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isAccepting, setIsAccepting] = useState(false);
+  const [isSigningOut, setIsSigningOut] = useState(false);
   const [formState, setFormState] = useState<InvitationAcceptanceState>({
     name: "",
     password: "",
   });
+  const [fieldErrors, setFieldErrors] = useState<{
+    name?: string;
+    password?: string;
+  }>({});
+
+  const loadInvitation = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await fetchJson<InvitationLookupResponse>(
+        "/api/invitations/lookup",
+        { headers: { "X-Invitation-Token": token } },
+      );
+      setLookup(response);
+      setAccountExists(response.accountExists);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Unable to load invitation",
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token]);
 
   useEffect(() => {
-    let cancelled = false;
-
-    async function loadInvitation() {
-      try {
-        const response = await fetchJson<InvitationLookupResponse>(
-          "/api/invitations/lookup",
-          { headers: { "X-Invitation-Token": token } },
-        );
-
-        if (cancelled) return;
-
-        setInvitation(response.invitation);
-        setAccountExists(response.accountExists);
-        setViewer(response.viewer);
-      } catch (err) {
-        if (!cancelled) {
-          setError(
-            err instanceof Error ? err.message : "Unable to load invitation",
-          );
-        }
-      } finally {
-        if (!cancelled) {
-          setIsLoading(false);
-        }
-      }
-    }
-
     void loadInvitation();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [token]);
+  }, [loadInvitation]);
 
   async function submitAcceptance(body: Record<string, string>) {
     setError(null);
@@ -102,16 +103,16 @@ export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
 
   async function handleAccept(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-
-    if (!formState.name || formState.password.length < 12) {
-      setError(
-        "Please provide a name and a password of at least 12 characters.",
-      );
-      return;
+    const nextErrors: typeof fieldErrors = {};
+    if (!formState.name.trim()) nextErrors.name = "Tell us what to call you.";
+    if (formState.password.length < MIN_PASSWORD_LENGTH) {
+      nextErrors.password = `Use at least ${MIN_PASSWORD_LENGTH} characters — a short sentence works well.`;
     }
+    setFieldErrors(nextErrors);
+    if (nextErrors.name || nextErrors.password) return;
 
     await submitAcceptance({
-      name: formState.name,
+      name: formState.name.trim(),
       password: formState.password,
     });
   }
@@ -121,66 +122,69 @@ export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
     navigate("/login");
   }
 
+  async function handleSignOut() {
+    setIsSigningOut(true);
+    try {
+      await authClient.signOut();
+    } finally {
+      setIsSigningOut(false);
+    }
+    await loadInvitation();
+  }
+
   if (isLoading) {
     return (
-      <Box
-        sx={{
-          display: "flex",
-          minHeight: "100vh",
-          alignItems: "center",
-          justifyContent: "center",
-          flexDirection: "column",
-        }}
-      >
-        <CircularProgress size={60} sx={{ mb: 4 }} />
-        <Typography variant="h5" sx={{ fontWeight: "bold" }}>
-          Loading invitation…
-        </Typography>
-      </Box>
+      <PublicEntryShell eyebrow={APP_NAME} title="Opening your invitation…">
+        <LoadingState variant="detail" label="Loading invitation" />
+      </PublicEntryShell>
     );
   }
 
-  if (error && !invitation) {
+  if (error && !lookup) {
     return (
       <PublicEntryShell
-        eyebrow="Mi Casa Su Casa"
-        title="This invitation is not available."
-        description="The invite may have expired, already been accepted, or the link may be invalid."
+        eyebrow={APP_NAME}
+        title="This invitation isn't available any more."
+        description="It may have expired or already been used, or the link may be incomplete. Ask the person who invited you to send a new one."
       >
-        <Alert severity="error" sx={{ mb: 2, borderRadius: 2 }}>
+        <Alert severity="error" sx={{ mb: 3 }}>
           {error}
         </Alert>
         <Button
           variant="outlined"
           fullWidth
-          onClick={() => {
-            navigate("/login", { replace: true });
-          }}
+          size="large"
+          onClick={() => navigate("/login", { replace: true })}
         >
-          Return to Login
+          Go to sign in
         </Button>
       </PublicEntryShell>
     );
   }
 
-  if (!invitation) {
+  if (!lookup) {
     return null;
   }
+
+  const { invitation, viewer } = lookup;
+  const householdName = lookup.household?.displayName ?? "the household";
+  const inviterName = lookup.invitedBy?.name ?? "Someone";
 
   if (viewer?.emailMatches) {
     return (
       <PublicEntryShell
-        eyebrow="Mi Casa Su Casa"
-        title="Accept invitation"
+        eyebrow={APP_NAME}
+        title={`Join ${householdName}`}
         description={
           <>
-            You are signed in as <strong>{viewer.email}</strong> and have been
-            invited to join as a <strong>{invitation.role}</strong>.
+            {inviterName} invited you. You're signed in as{" "}
+            <strong>{viewer.email}</strong> — accept to see the household's
+            login codes.
           </>
         }
       >
         {error && (
-          <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
+          <Alert severity="error" sx={{ mb: 3 }} role="alert">
             {error}
           </Alert>
         )}
@@ -190,9 +194,8 @@ export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
           size="large"
           disabled={isAccepting}
           onClick={() => void submitAcceptance({})}
-          sx={{ py: 1.5 }}
         >
-          {isAccepting ? "Accepting…" : `Accept as ${viewer.email}`}
+          {isAccepting ? "Joining…" : "Accept invitation"}
         </Button>
       </PublicEntryShell>
     );
@@ -201,23 +204,31 @@ export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
   if (viewer && !viewer.emailMatches) {
     return (
       <PublicEntryShell
-        eyebrow="Mi Casa Su Casa"
+        eyebrow={APP_NAME}
         title="This invitation is for a different account"
         description={
           <>
-            The invitation was sent to <strong>{invitation.email}</strong>, but
-            you are signed in as <strong>{viewer.email}</strong>. Sign out and
-            open the link again with the invited account.
+            {inviterName} sent this invitation to{" "}
+            <strong>{invitation.email}</strong>, but you're signed in as{" "}
+            <strong>{viewer.email}</strong>. Sign out to continue with the
+            invited address.
           </>
         }
       >
-        <Button
-          variant="outlined"
-          fullWidth
-          onClick={() => navigate("/settings")}
-        >
-          Go to account settings
-        </Button>
+        <Stack spacing={1.5}>
+          <Button
+            variant="contained"
+            size="large"
+            fullWidth
+            disabled={isSigningOut}
+            onClick={() => void handleSignOut()}
+          >
+            {isSigningOut ? "Signing out…" : "Sign out and continue"}
+          </Button>
+          <Button variant="text" fullWidth onClick={() => navigate("/")}>
+            Stay signed in as {viewer.email}
+          </Button>
+        </Stack>
       </PublicEntryShell>
     );
   }
@@ -225,28 +236,21 @@ export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
   if (accountExists) {
     return (
       <PublicEntryShell
-        eyebrow="Mi Casa Su Casa"
-        title="Sign in to accept"
+        eyebrow={APP_NAME}
+        title={`Welcome back — sign in to join ${householdName}`}
         description={
           <>
-            An account already exists for <strong>{invitation.email}</strong>.
-            Sign in with it and you will be brought back here to accept the
-            invitation.
+            There's already an account for <strong>{invitation.email}</strong>.
+            Sign in with it and we'll bring you straight back here.
           </>
         }
       >
         {error && (
-          <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
+          <Alert severity="error" sx={{ mb: 3 }} role="alert">
             {error}
           </Alert>
         )}
-        <Button
-          fullWidth
-          variant="contained"
-          size="large"
-          onClick={goToSignIn}
-          sx={{ py: 1.5 }}
-        >
+        <Button fullWidth variant="contained" size="large" onClick={goToSignIn}>
           Sign in to accept
         </Button>
       </PublicEntryShell>
@@ -255,63 +259,78 @@ export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
 
   return (
     <PublicEntryShell
-      eyebrow="Mi Casa Su Casa"
-      title="Accept invitation"
+      eyebrow={APP_NAME}
+      title={`${inviterName} invited you to ${householdName}`}
       description={
         <>
-          You have been invited to join as a <strong>{invitation.role}</strong>.
-          Set up your account details to continue.
+          {APP_NAME} is where your household finds the login codes for the
+          services it shares — Netflix, streaming, and the like — without
+          digging through email. {roleSentence(invitation.role, inviterName)}{" "}
+          Create your account to join.
         </>
       }
     >
       <Box component="form" onSubmit={handleAccept} noValidate>
         <TextField
           margin="normal"
-          required
           fullWidth
-          label="Email Address"
+          label="Email address"
           value={invitation.email}
-          disabled
+          helperText="This is the address the invitation was sent to."
+          slotProps={{ input: { readOnly: true } }}
         />
         <TextField
           margin="normal"
           required
           fullWidth
           id="name"
-          label="Your Name"
+          label="Your name"
           name="name"
           autoComplete="name"
           autoFocus
           value={formState.name}
-          onChange={(e) =>
-            setFormState((current) => ({
-              ...current,
-              name: e.target.value,
-            }))
+          error={Boolean(fieldErrors.name)}
+          helperText={
+            fieldErrors.name ?? "How the rest of the household will see you."
           }
+          onChange={(e) => {
+            setFormState((current) => ({ ...current, name: e.target.value }));
+            if (fieldErrors.name)
+              setFieldErrors((f) => ({ ...f, name: undefined }));
+          }}
         />
-        <TextField
+        <PasswordField
           margin="normal"
           required
           fullWidth
           name="password"
-          label="Password"
-          type="password"
+          label="Choose a password"
           id="password"
           autoComplete="new-password"
-          helperText="Must be at least 12 characters."
           value={formState.password}
-          onChange={(e) =>
+          error={Boolean(fieldErrors.password)}
+          helperText={
+            fieldErrors.password ??
+            `At least ${MIN_PASSWORD_LENGTH} characters — a short sentence works well.${
+              formState.password.length > 0 &&
+              formState.password.length < MIN_PASSWORD_LENGTH
+                ? ` (${MIN_PASSWORD_LENGTH - formState.password.length} more to go)`
+                : ""
+            }`
+          }
+          onChange={(e) => {
             setFormState((current) => ({
               ...current,
               password: e.target.value,
-            }))
-          }
+            }));
+            if (fieldErrors.password)
+              setFieldErrors((f) => ({ ...f, password: undefined }));
+          }}
           sx={{ mb: 3 }}
         />
 
         {error && (
-          <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
+          <Alert severity="error" sx={{ mb: 3 }} role="alert">
             {error}
           </Alert>
         )}
@@ -321,13 +340,18 @@ export function InvitePage({ token, onAcceptSuccess }: InvitePageProps) {
           fullWidth
           variant="contained"
           size="large"
-          disabled={
-            isAccepting || !formState.name || formState.password.length < 12
-          }
-          sx={{ py: 1.5 }}
+          disabled={isAccepting}
         >
-          {isAccepting ? "Accepting…" : "Accept Invitation"}
+          {isAccepting ? "Creating your account…" : "Create account and join"}
         </Button>
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          component="p"
+          sx={{ mt: 2, textAlign: "center" }}
+        >
+          You can add a passkey (Face ID / fingerprint) in Settings afterwards.
+        </Typography>
       </Box>
     </PublicEntryShell>
   );

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -251,6 +251,8 @@ export type InvitationLookupResponse = {
   invitation: InvitationSummary;
   accountExists: boolean;
   viewer: { email: string; emailMatches: boolean } | null;
+  household: { displayName: string } | null;
+  invitedBy: { name: string } | null;
 };
 
 export type TwoFactorSetup = {

--- a/src/server/db/repositories/users.ts
+++ b/src/server/db/repositories/users.ts
@@ -13,6 +13,16 @@ export async function findUserByEmail(db: D1Database, email: string) {
   return rows[0] ?? null;
 }
 
+export async function findUserById(db: D1Database, id: string) {
+  const rows = await dbForDatabase(db)
+    .select({ id: user.id, email: user.email, name: user.name })
+    .from(user)
+    .where(eq(user.id, id))
+    .limit(1);
+
+  return rows[0] ?? null;
+}
+
 /**
  * Deletes a Better Auth user; accounts, sessions, passkeys and memberships
  * cascade via foreign keys. Only used to compensate for interrupted flows.

--- a/src/server/routes/invitations.ts
+++ b/src/server/routes/invitations.ts
@@ -9,7 +9,11 @@ import {
   getInvitationByTokenHash,
   isInvitationExpired,
 } from "../db/repositories/invitations";
-import { deleteUserById, findUserByEmail } from "../db/repositories/users";
+import {
+  deleteUserById,
+  findUserByEmail,
+  findUserById,
+} from "../db/repositories/users";
 import { acceptInvitationSchema } from "../http/schemas";
 import { logEvent } from "../runtime/log";
 import { RATE_LIMITS, rateLimit } from "../security/rate-limit";
@@ -51,12 +55,19 @@ invitationRoutes.get("/lookup", async (c) => {
   }
 
   const currentUser = c.get("user");
-  const accountExists = Boolean(
-    await findUserByEmail(c.env.DB, invitation.email),
-  );
+  const [existingAccount, household, inviter] = await Promise.all([
+    findUserByEmail(c.env.DB, invitation.email),
+    getHouseholdById(c.env.DB, invitation.householdId),
+    findUserById(c.env.DB, invitation.invitedByUserId),
+  ]);
+  const accountExists = Boolean(existingAccount);
 
   return c.json({
     invitation,
+    // So the page can say who invited you and to what — the first thing a
+    // new family member needs to know.
+    household: household ? { displayName: household.displayName } : null,
+    invitedBy: inviter ? { name: inviter.name } : null,
     // Lets the invite page pick the right flow: create an account, sign in
     // first, or accept as the signed-in user.
     accountExists,

--- a/test/integration/invitation-accept.test.ts
+++ b/test/integration/invitation-accept.test.ts
@@ -121,6 +121,9 @@ describe("invitation acceptance (end-to-end against D1)", () => {
     await expect(lookup.json()).resolves.toMatchObject({
       accountExists: true,
       viewer: { email: "kid@example.com", emailMatches: true },
+      // The page greets newcomers with who invited them and to what.
+      household: { displayName: expect.any(String) },
+      invitedBy: { name: expect.any(String) },
     });
 
     const response = await SELF.fetch(

--- a/test/invite-page.test.tsx
+++ b/test/invite-page.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const signOut = vi.fn();
+vi.mock("@server/auth/client", () => ({
+  authClient: { signOut: (...args: unknown[]) => signOut(...args) },
+}));
+
+import { InvitePage } from "../src/client/components/InvitePage";
+import type { InvitationLookupResponse } from "../src/client/types";
+import { renderClient, screen, userEvent, waitFor } from "./client-test-utils";
+
+const base: InvitationLookupResponse = {
+  invitation: {
+    id: "inv-1",
+    email: "kari@example.com",
+    name: "Kari",
+    role: "member",
+    status: "pending",
+    invitedByUserId: "u-anders",
+    acceptedByUserId: null,
+    expiresAt: "2099-01-01T00:00:00.000Z",
+    acceptedAt: null,
+    cancelledAt: null,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    providers: [],
+  },
+  accountExists: false,
+  viewer: null,
+  household: { displayName: "Familien Olsen" },
+  invitedBy: { name: "Anders" },
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function mockLookup(
+  response: Partial<InvitationLookupResponse> | { error: string },
+  status = 200,
+) {
+  const calls: Array<{ url: string; method: string; body?: string }> = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      calls.push({
+        url,
+        method: init?.method ?? "GET",
+        body: init?.body as string | undefined,
+      });
+      if (url.endsWith("/api/invitations/lookup")) {
+        return "error" in response
+          ? json(response, status)
+          : json({ ...base, ...response });
+      }
+      if (url.endsWith("/api/invitations/accept")) {
+        return json({ household: { slug: "olsen" } });
+      }
+      return json({ error: "unhandled" }, 404);
+    }),
+  );
+  return calls;
+}
+
+describe("InvitePage", () => {
+  beforeEach(() => signOut.mockReset());
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("tells a newcomer who invited them, to what, and what the app is", async () => {
+    mockLookup({});
+    renderClient(<InvitePage token="t" onAcceptSuccess={vi.fn()} />, {
+      initialEntries: ["/invite/t"],
+    });
+
+    expect(
+      await screen.findByRole("heading", {
+        level: 1,
+        name: "Anders invited you to Familien Olsen",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/login codes for the services it shares/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/As a member you'll see the login codes/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Create account and join" }),
+    ).toBeEnabled();
+  });
+
+  it("validates inline instead of disabling the button silently", async () => {
+    const calls = mockLookup({});
+    const onAcceptSuccess = vi.fn();
+    renderClient(<InvitePage token="t" onAcceptSuccess={onAcceptSuccess} />, {
+      initialEntries: ["/invite/t"],
+    });
+    const user = userEvent.setup();
+    const button = await screen.findByRole("button", {
+      name: "Create account and join",
+    });
+
+    await user.click(button);
+    expect(screen.getByText("Tell us what to call you.")).toBeInTheDocument();
+    expect(screen.getByText(/Use at least 12 characters/)).toBeInTheDocument();
+    expect(calls.filter((c) => c.url.endsWith("/accept"))).toHaveLength(0);
+
+    await user.type(screen.getByLabelText(/Your name/), "Kari Olsen");
+    await user.type(screen.getByLabelText(/Choose a password/), "short");
+    expect(screen.getByText(/7 more to go/)).toBeInTheDocument();
+    await user.type(
+      screen.getByLabelText(/Choose a password/),
+      "-but-now-long",
+    );
+    await user.click(button);
+
+    await waitFor(() => expect(onAcceptSuccess).toHaveBeenCalledWith("olsen"));
+    const accept = calls.find((c) => c.url.endsWith("/accept"));
+    expect(JSON.parse(accept?.body ?? "{}")).toEqual({
+      name: "Kari Olsen",
+      password: "short-but-now-long",
+    });
+  });
+
+  it("offers a real sign-out when signed in as the wrong account", async () => {
+    mockLookup({ viewer: { email: "jonas@example.com", emailMatches: false } });
+    signOut.mockResolvedValue({});
+    renderClient(<InvitePage token="t" onAcceptSuccess={vi.fn()} />, {
+      initialEntries: ["/invite/t"],
+    });
+
+    await screen.findByRole("heading", { level: 1, name: /different account/ });
+    await userEvent
+      .setup()
+      .click(screen.getByRole("button", { name: "Sign out and continue" }));
+    await waitFor(() => expect(signOut).toHaveBeenCalledTimes(1));
+  });
+
+  it("lets the invited person accept directly when already signed in as them", async () => {
+    mockLookup({
+      viewer: { email: "kari@example.com", emailMatches: true },
+      accountExists: true,
+    });
+    const onAcceptSuccess = vi.fn();
+    renderClient(<InvitePage token="t" onAcceptSuccess={onAcceptSuccess} />, {
+      initialEntries: ["/invite/t"],
+    });
+
+    await screen.findByRole("heading", {
+      level: 1,
+      name: "Join Familien Olsen",
+    });
+    await userEvent
+      .setup()
+      .click(screen.getByRole("button", { name: "Accept invitation" }));
+    await waitFor(() => expect(onAcceptSuccess).toHaveBeenCalledWith("olsen"));
+  });
+
+  it("explains an expired or used link", async () => {
+    mockLookup({ error: "This invitation has expired" }, 410);
+    renderClient(<InvitePage token="t" onAcceptSuccess={vi.fn()} />, {
+      initialEntries: ["/invite/t"],
+    });
+    expect(
+      await screen.findByRole("heading", { level: 1, name: /isn't available/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("This invitation has expired")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Go to sign in" }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #188 (part of #169, Phase 3).

## What
**Server** — `GET /api/invitations/lookup` also returns `household: { displayName }` and `invitedBy: { name }` (new `findUserById`). Integration test asserts the shape.

**Client** — `InvitePage` rewritten:
- Title: "**Anders** invited you to **Familien Olsen**"; one sentence on what the app is; the role explained in plain words (member vs owner).
- `PasswordField` with a live "at least 12 characters (n more to go)" helper; inline errors on submit; the CTA is never silently disabled.
- Loading state inside the entry card; expired/used links explained with a "Go to sign in" action.
- Wrong-account branch: real **Sign out and continue** (`authClient.signOut()` then re-lookup) + "Stay signed in" escape.
- Signed-in-as-invitee: "Join {household}" → "Accept invitation".

## Tests
`test/invite-page.test.tsx` (5, jsdom): newcomer copy, inline validation + successful accept payload, sign-out branch, direct accept, expired link. `npm run ci` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)