### PR TITLE
feat(client): create household & setup — address derived from the name, live preview, plain copy, inline validation

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1826,6 +1826,7 @@ export function App() {
           element={
             setupStatus?.needsSetup ? (
               <SetupPage
+                emailDomain={setupStatus?.emailDomain ?? null}
                 setupError={setupError}
                 onSetupError={setSetupError}
                 onSetupComplete={async () => {
@@ -1879,6 +1880,7 @@ export function App() {
   if (households.length === 0) {
     return (
       <CreateHouseholdPage
+        emailDomain={setupStatus?.emailDomain ?? null}
         onCreated={(household) => {
           setHouseholds([household]);
           navigate(buildHouseholdPath(household.slug, "/inbox"), {
@@ -1915,6 +1917,7 @@ export function App() {
             path="/new-household"
             element={
               <CreateHouseholdPage
+                emailDomain={setupStatus?.emailDomain ?? null}
                 onCreated={(household) => {
                   setHouseholds((current) => [...current, household]);
                   setStatusMessage(

--- a/src/client/components/CreateHouseholdPage.tsx
+++ b/src/client/components/CreateHouseholdPage.tsx
@@ -1,35 +1,55 @@
 import { Alert, Box, Button, TextField } from "@mui/material";
 import { type FormEvent, useState } from "react";
 import type { CreateHouseholdFormState, HouseholdSummary } from "../types";
-import { fetchJson } from "../utils";
+import { fetchJson, suggestHouseholdSlug } from "../utils";
+import {
+  describeSlugProblem,
+  HouseholdAddressField,
+} from "./HouseholdAddressField";
 import { PublicEntryShell } from "./PublicEntryShell";
 
 interface CreateHouseholdPageProps {
   onCreated: (household: HouseholdSummary) => void;
+  emailDomain?: string | null;
 }
 
-export function CreateHouseholdPage({ onCreated }: CreateHouseholdPageProps) {
+export function CreateHouseholdPage({
+  onCreated,
+  emailDomain = null,
+}: CreateHouseholdPageProps) {
   const [formState, setFormState] = useState<CreateHouseholdFormState>({
     displayName: "",
     slug: "",
   });
+  // Once the user edits the address by hand we stop deriving it from the name.
+  const [slugEdited, setSlugEdited] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
 
+  const nameProblem = formState.displayName.trim()
+    ? null
+    : "Give your household a name.";
+  const slugProblem = describeSlugProblem(formState.slug);
+
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    setSubmitted(true);
     setError(null);
-    setIsCreating(true);
+    if (nameProblem || slugProblem) return;
 
+    setIsCreating(true);
     try {
       const response = await fetchJson<{ household: HouseholdSummary }>(
         "/api/households",
         {
           method: "POST",
-          body: JSON.stringify(formState),
+          body: JSON.stringify({
+            displayName: formState.displayName.trim(),
+            slug: formState.slug,
+          }),
         },
       );
-
       onCreated(response.household);
     } catch (submitError) {
       setError(
@@ -44,42 +64,51 @@ export function CreateHouseholdPage({ onCreated }: CreateHouseholdPageProps) {
 
   return (
     <PublicEntryShell
-      eyebrow="Create your household"
-      title="You need a household to continue."
-      description="Pick the household name your members will see and the immutable slug used in URLs and inbound email addresses."
+      eyebrow="New household"
+      title="Name your household"
+      description="A household is the family (or group) that shares streaming and other accounts. Its name becomes the email address where login codes arrive — give that address to Netflix & co. and the codes show up here for everyone you invite."
     >
       <Box component="form" onSubmit={handleSubmit} noValidate>
         <TextField
           margin="normal"
           required
           fullWidth
+          autoFocus
           label="Household name"
+          placeholder="e.g. The Olsens"
           value={formState.displayName}
-          onChange={(e) =>
-            setFormState((current) => ({
-              ...current,
-              displayName: e.target.value,
-            }))
+          error={submitted && Boolean(nameProblem)}
+          helperText={
+            submitted && nameProblem
+              ? nameProblem
+              : "What your family will see in the app."
           }
+          onChange={(e) => {
+            const displayName = e.target.value;
+            setFormState((current) => ({
+              displayName,
+              slug: slugEdited
+                ? current.slug
+                : suggestHouseholdSlug(displayName),
+            }));
+          }}
         />
-        <TextField
+        <HouseholdAddressField
           margin="normal"
           required
           fullWidth
-          label="Household slug"
-          helperText="2–40 lowercase letters, numbers, and hyphens; also the inbound address local part (slug@your-domain). Cannot be changed later."
           value={formState.slug}
-          onChange={(e) =>
-            setFormState((current) => ({
-              ...current,
-              slug: e.target.value.toLowerCase(),
-            }))
-          }
+          emailDomain={emailDomain}
+          showError={submitted}
+          onChange={(slug) => {
+            setSlugEdited(true);
+            setFormState((current) => ({ ...current, slug }));
+          }}
           sx={{ mb: 3 }}
         />
 
         {error && (
-          <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
+          <Alert severity="error" sx={{ mb: 3 }} role="alert">
             {error}
           </Alert>
         )}
@@ -89,12 +118,7 @@ export function CreateHouseholdPage({ onCreated }: CreateHouseholdPageProps) {
           fullWidth
           variant="contained"
           size="large"
-          disabled={
-            isCreating ||
-            !formState.displayName.trim() ||
-            !formState.slug.trim()
-          }
-          sx={{ py: 1.5 }}
+          disabled={isCreating}
         >
           {isCreating ? "Creating household…" : "Create household"}
         </Button>

--- a/src/client/components/HouseholdAddressField.tsx
+++ b/src/client/components/HouseholdAddressField.tsx
@@ -1,0 +1,78 @@
+import { InputAdornment, TextField, type TextFieldProps } from "@mui/material";
+import {
+  HOUSEHOLD_SLUG_MAX_LENGTH,
+  HOUSEHOLD_SLUG_MIN_LENGTH,
+  RESERVED_HOUSEHOLD_SLUGS,
+  validateHouseholdSlug,
+} from "@server/domain/household-slug";
+
+/** Plain-language version of the slug rules, for inline validation. */
+export function describeSlugProblem(slug: string): string | null {
+  if (!slug) return "Choose an address for your household's inbox.";
+  const check = validateHouseholdSlug(slug);
+  if (check.ok) return null;
+  if (RESERVED_HOUSEHOLD_SLUGS.has(slug)) {
+    return "That one's reserved — try a different address.";
+  }
+  if (
+    slug.length < HOUSEHOLD_SLUG_MIN_LENGTH ||
+    slug.length > HOUSEHOLD_SLUG_MAX_LENGTH
+  ) {
+    return `Use between ${HOUSEHOLD_SLUG_MIN_LENGTH} and ${HOUSEHOLD_SLUG_MAX_LENGTH} characters.`;
+  }
+  return "Use lowercase letters, numbers and hyphens only (no spaces), starting and ending with a letter or number.";
+}
+
+interface HouseholdAddressFieldProps
+  extends Omit<TextFieldProps, "value" | "onChange" | "error" | "helperText"> {
+  value: string;
+  onChange: (value: string) => void;
+  emailDomain: string | null | undefined;
+  /** Show the validation message (after the user has submitted or touched). */
+  showError?: boolean;
+}
+
+/**
+ * The household's inbox address: `value@domain`. The slug doubles as the URL
+ * segment, but to a family it is simply "the email address codes arrive at".
+ */
+export function HouseholdAddressField({
+  value,
+  onChange,
+  emailDomain,
+  showError = false,
+  ...props
+}: HouseholdAddressFieldProps) {
+  const problem = describeSlugProblem(value);
+  const domain = emailDomain ?? "your-domain";
+  return (
+    <TextField
+      {...props}
+      label="Inbox address"
+      value={value}
+      onChange={(e) =>
+        onChange(e.target.value.toLowerCase().replace(/\s+/g, "-"))
+      }
+      error={showError && Boolean(problem)}
+      helperText={
+        showError && problem
+          ? problem
+          : value
+            ? `Login codes will arrive at ${value}@${domain}. This can't be changed later.`
+            : `Login codes will arrive at this address @${domain}. This can't be changed later.`
+      }
+      slotProps={{
+        input: {
+          endAdornment: (
+            <InputAdornment position="end">@{domain}</InputAdornment>
+          ),
+        },
+        htmlInput: {
+          autoCapitalize: "none",
+          autoCorrect: "off",
+          spellCheck: false,
+        },
+      }}
+    />
+  );
+}

--- a/src/client/components/SetupPage.tsx
+++ b/src/client/components/SetupPage.tsx
@@ -1,49 +1,89 @@
-import { Alert, Box, Button, TextField, Typography } from "@mui/material";
+import {
+  Alert,
+  Box,
+  Button,
+  Divider,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
 import { type FormEvent, useState } from "react";
 import type { SetupFormState } from "../types";
-import { fetchJson } from "../utils";
+import { fetchJson, suggestHouseholdSlug } from "../utils";
+import {
+  describeSlugProblem,
+  HouseholdAddressField,
+} from "./HouseholdAddressField";
 import { PublicEntryShell } from "./PublicEntryShell";
+import { PasswordField } from "./ui";
 
 interface SetupPageProps {
   onSetupComplete: () => void;
   onSetupError: (error: string) => void;
   setupError: string | null;
+  emailDomain?: string | null;
 }
+
+const MIN_PASSWORD_LENGTH = 12;
+const EMPTY_FORM: SetupFormState = {
+  email: "",
+  name: "",
+  password: "",
+  householdName: "",
+  householdSlug: "",
+  setupSecret: "",
+};
 
 export function SetupPage({
   onSetupComplete,
   onSetupError,
   setupError,
+  emailDomain = null,
 }: SetupPageProps) {
-  const [setupFormState, setSetupFormState] = useState<SetupFormState>({
-    email: "",
-    name: "",
-    password: "",
-    householdName: "",
-    householdSlug: "",
-    setupSecret: "",
-  });
+  const [form, setForm] = useState<SetupFormState>(EMPTY_FORM);
+  const [slugEdited, setSlugEdited] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
   const [isCompletingSetup, setIsCompletingSetup] = useState(false);
+
+  const problems = {
+    householdName: form.householdName.trim()
+      ? null
+      : "Give your household a name.",
+    householdSlug: describeSlugProblem(form.householdSlug),
+    email: /\S+@\S+\.\S+/.test(form.email.trim())
+      ? null
+      : "Enter the owner email address (the OWNER_EMAIL you configured).",
+    name: form.name.trim() ? null : "Enter your name.",
+    password:
+      form.password.length >= MIN_PASSWORD_LENGTH
+        ? null
+        : `Use at least ${MIN_PASSWORD_LENGTH} characters — a short sentence works well.`,
+    setupSecret: form.setupSecret ? null : "Enter the setup secret.",
+  };
+  const hasProblems = Object.values(problems).some(Boolean);
+  const show = (key: keyof typeof problems) =>
+    submitted && problems[key] ? problems[key] : undefined;
+
+  const update = (patch: Partial<SetupFormState>) =>
+    setForm((current) => ({ ...current, ...patch }));
 
   const handleSetupComplete = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    setSubmitted(true);
+    if (hasProblems) return;
     setIsCompletingSetup(true);
 
     try {
       await fetchJson<{ member: { email: string } }>("/api/setup/complete", {
         method: "POST",
-        body: JSON.stringify(setupFormState),
+        body: JSON.stringify({
+          ...form,
+          email: form.email.trim(),
+          name: form.name.trim(),
+          householdName: form.householdName.trim(),
+        }),
       });
-
-      setSetupFormState({
-        email: "",
-        name: "",
-        password: "",
-        householdName: "",
-        householdSlug: "",
-        setupSecret: "",
-      });
-
+      setForm(EMPTY_FORM);
       onSetupComplete();
     } catch (error) {
       onSetupError(
@@ -57,135 +97,120 @@ export function SetupPage({
   return (
     <PublicEntryShell
       eyebrow="First-run setup"
-      title="Finish setting up your household inbox."
-      description="Create the initial owner account after your Cloudflare deployment completes. This screen closes automatically after the first successful setup."
+      title="Set up your household inbox"
+      description="One-time setup for this deployment: name the household, create the owner account, and confirm with the setup secret you configured."
     >
-      <Alert severity="info" sx={{ mb: 4, borderRadius: 2 }}>
-        <Typography variant="subtitle2" sx={{ fontWeight: "bold", mb: 0.5 }}>
-          What you need
-        </Typography>
-        <Box component="ul" sx={{ m: 0, pl: 2 }}>
-          <li>
-            <Typography variant="body2">
-              The owner email configured as <code>OWNER_EMAIL</code>
-            </Typography>
-          </li>
-          <li>
-            <Typography variant="body2">
-              Your one-time <code>SETUP_SECRET</code>
-            </Typography>
-          </li>
-          <li>
-            <Typography variant="body2">
-              A strong password for the initial owner account
-            </Typography>
-          </li>
-        </Box>
-      </Alert>
-
       <Box component="form" onSubmit={handleSetupComplete} noValidate>
-        <TextField
+        <Stack spacing={1}>
+          <Typography variant="h5" component="h2">
+            Your household
+          </Typography>
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            autoFocus
+            label="Household name"
+            placeholder="e.g. The Olsens"
+            value={form.householdName}
+            error={Boolean(show("householdName"))}
+            helperText={
+              show("householdName") ?? "What your family will see in the app."
+            }
+            onChange={(e) => {
+              const householdName = e.target.value;
+              setForm((current) => ({
+                ...current,
+                householdName,
+                householdSlug: slugEdited
+                  ? current.householdSlug
+                  : suggestHouseholdSlug(householdName),
+              }));
+            }}
+          />
+          <HouseholdAddressField
+            margin="normal"
+            required
+            fullWidth
+            value={form.householdSlug}
+            emailDomain={emailDomain}
+            showError={submitted}
+            onChange={(householdSlug) => {
+              setSlugEdited(true);
+              update({ householdSlug });
+            }}
+          />
+        </Stack>
+
+        <Divider sx={{ my: 3 }} />
+
+        <Stack spacing={1}>
+          <Typography variant="h5" component="h2">
+            Your account
+          </Typography>
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            type="email"
+            inputMode="email"
+            autoComplete="email"
+            label="Owner email"
+            value={form.email}
+            error={Boolean(show("email"))}
+            helperText={
+              show("email") ??
+              "Must match the OWNER_EMAIL configured for this deployment."
+            }
+            onChange={(e) => update({ email: e.target.value })}
+          />
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            autoComplete="name"
+            label="Your name"
+            value={form.name}
+            error={Boolean(show("name"))}
+            helperText={show("name")}
+            onChange={(e) => update({ name: e.target.value })}
+          />
+          <PasswordField
+            margin="normal"
+            required
+            fullWidth
+            autoComplete="new-password"
+            label="Choose a password"
+            value={form.password}
+            error={Boolean(show("password"))}
+            helperText={
+              show("password") ??
+              `At least ${MIN_PASSWORD_LENGTH} characters — a short sentence works well.`
+            }
+            onChange={(e) => update({ password: e.target.value })}
+          />
+        </Stack>
+
+        <Divider sx={{ my: 3 }} />
+
+        <PasswordField
           margin="normal"
           required
           fullWidth
-          id="setup-household-name"
-          label="Household name"
-          name="setup-household-name"
-          value={setupFormState.householdName}
-          onChange={(e) =>
-            setSetupFormState((current) => ({
-              ...current,
-              householdName: e.target.value,
-            }))
-          }
-        />
-        <TextField
-          margin="normal"
-          required
-          fullWidth
-          id="setup-household-slug"
-          label="Household slug"
-          name="setup-household-slug"
-          helperText="Lowercase letters, numbers, and hyphens only."
-          value={setupFormState.householdSlug}
-          onChange={(e) =>
-            setSetupFormState((current) => ({
-              ...current,
-              householdSlug: e.target.value.toLowerCase(),
-            }))
-          }
-        />
-        <TextField
-          margin="normal"
-          required
-          fullWidth
-          id="setup-email"
-          label="Owner email"
-          name="setup-email"
-          autoComplete="email"
-          value={setupFormState.email}
-          onChange={(e) =>
-            setSetupFormState((current) => ({
-              ...current,
-              email: e.target.value,
-            }))
-          }
-        />
-        <TextField
-          margin="normal"
-          required
-          fullWidth
-          id="setup-name"
-          label="Owner display name"
-          name="setup-name"
-          autoComplete="name"
-          value={setupFormState.name}
-          onChange={(e) =>
-            setSetupFormState((current) => ({
-              ...current,
-              name: e.target.value,
-            }))
-          }
-        />
-        <TextField
-          margin="normal"
-          required
-          fullWidth
-          name="setup-password"
-          label="Password"
-          type="password"
-          id="setup-password"
-          autoComplete="new-password"
-          value={setupFormState.password}
-          onChange={(e) =>
-            setSetupFormState((current) => ({
-              ...current,
-              password: e.target.value,
-            }))
-          }
-          slotProps={{ htmlInput: { minLength: 12 } }}
-        />
-        <TextField
-          margin="normal"
-          required
-          fullWidth
-          name="setup-secret"
-          label="Setup secret"
-          type="password"
-          id="setup-secret"
           autoComplete="off"
-          value={setupFormState.setupSecret}
-          onChange={(e) =>
-            setSetupFormState((current) => ({
-              ...current,
-              setupSecret: e.target.value,
-            }))
+          label="Setup secret"
+          value={form.setupSecret}
+          error={Boolean(show("setupSecret"))}
+          helperText={
+            show("setupSecret") ??
+            "The SETUP_SECRET you set when deploying. It is only used once."
           }
+          onChange={(e) => update({ setupSecret: e.target.value })}
           sx={{ mb: 3 }}
         />
 
         {setupError && (
-          <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
+          <Alert severity="error" sx={{ mb: 3 }} role="alert">
             {setupError}
           </Alert>
         )}
@@ -196,9 +221,8 @@ export function SetupPage({
           variant="contained"
           size="large"
           disabled={isCompletingSetup}
-          sx={{ py: 1.5 }}
         >
-          {isCompletingSetup ? "Creating owner…" : "Complete setup"}
+          {isCompletingSetup ? "Setting up…" : "Complete setup"}
         </Button>
       </Box>
     </PublicEntryShell>

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -224,6 +224,7 @@ export type SetupStatus = {
   setupLocked: boolean;
   isConfigured: boolean;
   status: "pending" | "in_progress" | "complete";
+  emailDomain?: string | null;
 };
 
 export type SetupFormState = {

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -214,3 +214,18 @@ export function parseSender(fromHeader: string | null | undefined): {
   }
   return { name: raw, address: raw.includes("@") ? raw : null };
 }
+
+/**
+ * Suggest an inbox address (household slug) from a household name:
+ * "Familien Olsen" → "familien-olsen", "Casa Ramírez" → "casa-ramirez".
+ */
+export function suggestHouseholdSlug(name: string): string {
+  return name
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40)
+    .replace(/-+$/g, "");
+}

--- a/src/server/routes/setup.ts
+++ b/src/server/routes/setup.ts
@@ -34,12 +34,15 @@ function mapInstallationStatus(
   const isConfigured = Boolean(env.OWNER_EMAIL && env.SETUP_SECRET);
   const needsSetup = isConfigured && row.status !== "complete";
 
-  // Deliberately no owner email here: this endpoint is public.
+  // Deliberately no owner email here: this endpoint is public. The inbox
+  // domain is not secret (every household address ends with it) and lets
+  // the client preview "name@domain" while a household is being named.
   return {
     needsSetup,
     setupLocked: row.status === "complete",
     isConfigured,
     status: row.status,
+    emailDomain: env.EMAIL_DOMAIN?.trim() || null,
   };
 }
 

--- a/test/create-household-page.test.tsx
+++ b/test/create-household-page.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CreateHouseholdPage } from "../src/client/components/CreateHouseholdPage";
+import { describeSlugProblem } from "../src/client/components/HouseholdAddressField";
+import { SetupPage } from "../src/client/components/SetupPage";
+import { suggestHouseholdSlug } from "../src/client/utils";
+import { renderClient, screen, userEvent, waitFor } from "./client-test-utils";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("suggestHouseholdSlug", () => {
+  it("derives a usable inbox address from a household name", () => {
+    expect(suggestHouseholdSlug("Familien Olsen")).toBe("familien-olsen");
+    expect(suggestHouseholdSlug("Casa Ramírez!")).toBe("casa-ramirez");
+    expect(suggestHouseholdSlug("  The   Smiths ")).toBe("the-smiths");
+    expect(suggestHouseholdSlug("x".repeat(60))).toHaveLength(40);
+    expect(suggestHouseholdSlug("")).toBe("");
+  });
+
+  it("explains slug problems in plain language", () => {
+    expect(describeSlugProblem("familien-olsen")).toBeNull();
+    expect(describeSlugProblem("")).toMatch(/Choose an address/);
+    expect(describeSlugProblem("inbox")).toMatch(/reserved/);
+    expect(describeSlugProblem("a")).toMatch(/between 2 and 40/);
+    expect(describeSlugProblem("bad_name")).toMatch(
+      /lowercase letters, numbers and hyphens/,
+    );
+  });
+});
+
+describe("CreateHouseholdPage", () => {
+  it("derives the address from the name, previews it, and submits both", async () => {
+    const calls: Array<{ url: string; body?: string }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        calls.push({
+          url: String(input),
+          body: init?.body as string | undefined,
+        });
+        return new Response(
+          JSON.stringify({
+            household: {
+              id: "h1",
+              slug: "familien-olsen",
+              displayName: "Familien Olsen",
+              role: "owner",
+            },
+          }),
+          { status: 201, headers: { "content-type": "application/json" } },
+        );
+      }),
+    );
+    const onCreated = vi.fn();
+    renderClient(
+      <CreateHouseholdPage onCreated={onCreated} emailDomain="example.com" />,
+      { initialEntries: ["/new-household"] },
+    );
+    const user = userEvent.setup();
+
+    await user.type(screen.getByLabelText(/Household name/), "Familien Olsen");
+    const address = screen.getByLabelText(/Inbox address/) as HTMLInputElement;
+    expect(address.value).toBe("familien-olsen");
+    expect(
+      screen.getByText(/Login codes will arrive at familien-olsen@example.com/),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Create household" }));
+    await waitFor(() => expect(onCreated).toHaveBeenCalledTimes(1));
+    expect(JSON.parse(calls[0]?.body ?? "{}")).toEqual({
+      displayName: "Familien Olsen",
+      slug: "familien-olsen",
+    });
+  });
+
+  it("keeps a hand-edited address and validates inline", async () => {
+    vi.stubGlobal("fetch", vi.fn());
+    renderClient(
+      <CreateHouseholdPage onCreated={vi.fn()} emailDomain="example.com" />,
+      { initialEntries: ["/new-household"] },
+    );
+    const user = userEvent.setup();
+
+    await user.type(screen.getByLabelText(/Inbox address/), "inbox");
+    await user.type(screen.getByLabelText(/Household name/), "Our home");
+    expect(
+      (screen.getByLabelText(/Inbox address/) as HTMLInputElement).value,
+    ).toBe("inbox");
+
+    await user.click(screen.getByRole("button", { name: "Create household" }));
+    expect(screen.getByText(/reserved/)).toBeInTheDocument();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("SetupPage", () => {
+  it("groups the form, derives the address, and shows the password rule up front", async () => {
+    renderClient(
+      <SetupPage
+        onSetupComplete={vi.fn()}
+        onSetupError={vi.fn()}
+        setupError={null}
+        emailDomain="example.com"
+      />,
+      { initialEntries: ["/setup"] },
+    );
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Your household" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Your account" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/At least 12 characters/)).toBeInTheDocument();
+
+    await userEvent
+      .setup()
+      .type(screen.getByLabelText(/Household name/), "Casa Ramírez");
+    expect(
+      (screen.getByLabelText(/Inbox address/) as HTMLInputElement).value,
+    ).toBe("casa-ramirez");
+    expect(screen.getByText(/casa-ramirez@example.com/)).toBeInTheDocument();
+  });
+
+  it("does not submit while required fields are missing; errors show inline", async () => {
+    vi.stubGlobal("fetch", vi.fn());
+    renderClient(
+      <SetupPage
+        onSetupComplete={vi.fn()}
+        onSetupError={vi.fn()}
+        setupError={null}
+      />,
+      { initialEntries: ["/setup"] },
+    );
+    await userEvent
+      .setup()
+      .click(screen.getByRole("button", { name: "Complete setup" }));
+    expect(screen.getByText("Give your household a name.")).toBeInTheDocument();
+    expect(screen.getByText("Enter the setup secret.")).toBeInTheDocument();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #189 (part of #169, Phase 3).

## What
- `GET /api/setup/status` also returns `emailDomain` (not secret — every household address ends with it) so the client can preview addresses.
- New `HouseholdAddressField`: the slug presented as what it is to a family — the **inbox address** — with an `@domain` adornment, a live "Login codes will arrive at `familien-olsen@example.com`. This can't be changed later." helper, and plain-language validation built on the shared `@server/domain/household-slug` rules ("That one's reserved", "Use lowercase letters, numbers and hyphens…").
- `suggestHouseholdSlug()` derives the address from the household name ("Casa Ramírez" → `casa-ramirez`) until the user edits it by hand.
- `CreateHouseholdPage`: "Name your household" + one paragraph on what a household is and why the address matters; inline errors on submit (no silently disabled CTA).
- `SetupPage`: grouped into **Your household** / **Your account**, `PasswordField` with the 12-character rule shown up front, setup secret explained, autoFocus, inline validation.

## Tests
`test/create-household-page.test.tsx` (6, jsdom): slug derivation + diacritics + length, plain-language problems, create flow payload + preview, hand-edited address kept + reserved error, setup grouping/derivation, setup inline errors. `npm run ci` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)