### PR TITLE
docs: design spec, parity reference and plan for the Go backend migration

### DIFF
--- a/docs/superpowers/plans/2026-09-04-go-backend-migration.md
+++ b/docs/superpowers/plans/2026-09-04-go-backend-migration.md
@@ -1,0 +1,384 @@
+# Go Backend Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Cloudflare Workers backend with a single static Go binary (stdlib `net/http`, Limen auth, pgx + sqlc + goose, embedded Vite SPA, distroless multi-arch image published by GoReleaser) at feature parity minus passkeys, with a Mailgun inbound webhook replacing Email Routing and SMTP replacing the Workers send binding, landed as a sequence of small PRs to `main`.
+
+**Architecture:** Spec-first: `openapi/mi-casa.yaml` drives oapi-codegen (Go strict server) and openapi-typescript (SPA client). `cmd/mi-casa` is the sole composition root building a `Deps` struct; `internal/api` never reads the environment. Dispatch modes, tenancy middleware, advisory-lock migration and cron semantics are copied from Pjokk. The Workers app in `src/` stays untouched and deployable until the cutover PR.
+
+**Tech Stack:** Go 1.27, `github.com/thecodearcher/limen` (+ credential-password, two-factor plugins), pgx/v5, sqlc, goose, oapi-codegen v2, kin-openapi nethttp-middleware, `github.com/emersion/go-message`, robfig/cron/v3, openapi-typescript + openapi-fetch, npm `limen-auth`, TanStack Router, Playwright, Mailpit, GoReleaser, svu, cosign, syft, mise, Bun.
+
+**Spec:** `docs/superpowers/specs/2026-09-04-go-backend-migration-design.md`
+**Parity contract:** `docs/superpowers/plans/2026-09-04-go-migration-reference.md` (cited as REF §…). `src/server/**` is ground truth when REF is ambiguous.
+**Template repo:** `/home/anders/projects/refsdal/pjokk` (Pjokk). When a task says "as Pjokk's X", open that file and copy the shape, renaming `pjokk` → `mi-casa`, `refsdal/pjokk` → `andersro93/mi-casa-su-casa`.
+
+## Global Constraints
+
+- Toolchain: `mise install` at the repo root provides Go, Bun, sqlc, oapi-codegen, goose, goreleaser, svu, cosign, syft. Run every go/bun/codegen command through `mise exec -- <cmd>` or after `eval "$(mise activate bash)"`. Node is also provided by mise (memory: no global node).
+- Go module path `github.com/andersro93/mi-casa-su-casa/server` rooted at `apps/server/`.
+- Tests run against a real Postgres: `docker compose -f docker-compose.test.yml up -d` → `TEST_DATABASE_URL` default `postgres://micasa:micasa@127.0.0.1:55433/micasa_test`. Run Go tests with `go test -p 1 -count=1 ./...` (packages share one database).
+- Error envelope on every API error: `{"error": string}` plus optional `fields` / `code` exactly as REF §A1. Status codes and messages verbatim from REF §A2.
+- Every domain query is household-scoped: no handler touches a household table without `household_id` from the resolved membership (REF §A1 guards).
+- Postgres rules: `timestamptz` everywhere; unique violations by SQLSTATE 23505 (`pgconn.PgError.Code`); `"users"` quoted in hand-written SQL; ids are app-generated UUID strings.
+- Only `internal/auth` imports Limen packages. Pin Limen modules to exact versions in go.mod (REF §B0).
+- Never store a raw client IP: rate-limit keys and session metadata use `sha256(AUTH_SECRET + "mi-casa/ip" + ip)` hex (REF §A1).
+- Conventional Commits (`feat(server): …`, `feat(client): …`, `ci: …`, `docs: …`); every commit compiles and its tests pass.
+- Codegen is committed: after editing `openapi/mi-casa.yaml` or `internal/db/queries/*.sql`, run `cd apps/server && go generate ./...` and commit the output.
+- Biome formats TypeScript, YAML is hand-formatted, Go is `gofmt`. `go vet ./...` clean.
+- One PR per phase (P1…P12). Each PR: branch from fresh `main`, all CI green (`ci.yml`, and until cutover the existing Cloudflare `CI`), squash-merge with `Closes #<issue>`, then next. Create the GitHub issue for a phase before opening its PR (memory: `gh issue create` prints the URL; capture it).
+- The Workers app (`src/`, `wrangler.jsonc`, `migrations/`, existing workflows) is not modified before P12 except where a task says so (root `package.json` scripts and Biome config in P1, `vitest.config.ts` paths in P8).
+
+---
+
+## Phase P1 — Toolchain, Go skeleton, config, health, test workflow
+
+### Task 1: Toolchain pins and repo scripts
+
+**Files:**
+- Create: `.mise.toml`, `docker-compose.test.yml`, `apps/server/go.mod`, `apps/server/cmd/mi-casa/main.go` (usage stub)
+- Modify: `biome.json` (exclude `apps/server`, `dist`, `e2e/playwright-report`), `.gitignore` (add `dist/server`, `dist/goreleaser`, `apps/server/internal/web/dist/*` except placeholder, `e2e/playwright-report`, `e2e/test-results`)
+
+**Interfaces:**
+- Produces: `mise run test`, `mise run check`, `mise run artifacts`, `mise run image`, `mise run e2e`, `mise run snapshot` tasks (later tasks fill the scripts they call).
+
+- [ ] **Step 1:** Write `.mise.toml` copying Pjokk's, with tools `go = "1.27.0"`, `bun = "1.4"`, `node = "22"`, the three `go:` codegen tools, `aqua:goreleaser/goreleaser`, `aqua:caarlos0/svu`, `aqua:sigstore/cosign`, `aqua:anchore/syft`, and tasks:
+  ```toml
+  [tasks.test]
+  run = ["cd apps/server && go vet ./... && go test -p 1 -count=1 ./...", "bun run test"]
+  [tasks.check]
+  run = ["bun run check", "goreleaser check"]
+  [tasks.artifacts]
+  run = "bash scripts/build-artifacts.sh"
+  [tasks.image]
+  run = "bash scripts/build-image.sh"
+  [tasks.snapshot]
+  run = """
+  trap 'bash scripts/restore-embed-overlay.sh' EXIT
+  goreleaser release --snapshot --clean --skip=sign
+  """
+  [tasks.e2e]
+  run = """
+  trap 'bash scripts/e2e-stack.sh down' EXIT
+  bash scripts/e2e-stack.sh up
+  cd e2e && bunx playwright test
+  """
+  ```
+  Until P9/P10 exist, `goreleaser check` and the scripts are absent; `mise run test` must work from this task on.
+- [ ] **Step 2:** Write `docker-compose.test.yml` as Pjokk's with `POSTGRES_USER=micasa`, `POSTGRES_PASSWORD=micasa`, `POSTGRES_DB=micasa_test`, port `127.0.0.1:55433:5432`, tmpfs data, healthcheck.
+- [ ] **Step 3:** `mkdir -p apps/server/cmd/mi-casa && cd apps/server && go mod init github.com/andersro93/mi-casa-su-casa/server` (edit `go 1.27`). `main.go` prints usage and exits 2 for now.
+- [ ] **Step 4:** `mise install`; `cd apps/server && go build ./... && go vet ./...` passes.
+- [ ] **Step 5:** Commit `chore: pin the Go/Bun toolchain with mise and add the Go module skeleton`.
+
+### Task 2: Config loader
+
+**Files:**
+- Create: `apps/server/internal/config/config.go`
+- Test: `apps/server/internal/config/config_test.go`
+
+**Interfaces:**
+- Produces: `type Config struct { DatabaseURL, AppURL, AppName, AuthSecret, SetupSecret, OwnerEmail, EmailDomain, MailgunSigningKey, SMTPURL, OutboundFrom, Environment, LogLevel string; Port, TrustedProxyHops int }`, `func Load(env map[string]string) (*Config, error)`, `func FromOS() (*Config, error)`, `func (c *Config) IsDevelopmentLike() bool`.
+
+- [ ] **Step 1:** Write failing tests: minimal valid config loads; each required variable missing is reported by name; ALL problems reported in one error (assert the message mentions every bad key); `AUTH_SECRET` shorter than 32 rejected with `"must be at least 32 characters (openssl rand -hex 32)"`; `APP_URL` must be absolute; `APP_URL` `http://` rejected unless `ENVIRONMENT` is `development`/`test` (`"must use https outside development"`); `OWNER_EMAIL` must look like an email and is lower-cased; `EMAIL_DOMAIN` must match the hostname regex from REF §A4; `SMTP_URL` must parse with scheme `smtp` or `smtps` and a host; `OUTBOUND_EMAIL_FROM` must be an email; `PORT` default 3000, rejects `abc`/`0`; `TRUSTED_PROXY_HOPS` default 0, rejects `-1`; `APP_NAME` default `"Mi Casa Su Casa"`; `ENVIRONMENT` default `production`, rejects `staging`; `LOG_LEVEL` default `info`.
+- [ ] **Step 2:** `go test ./internal/config/` — FAIL (undefined).
+- [ ] **Step 3:** Implement: read the map, accumulate `problems []string` formatted `"KEY: message"`, return `fmt.Errorf("invalid configuration:\n  %s", strings.Join(problems, "\n  "))`. Pure stdlib (`net/url`, `net/mail`, `regexp`).
+- [ ] **Step 4:** `go test ./internal/config/` — PASS.
+- [ ] **Step 5:** Commit `feat(server): validate configuration at startup, reporting every problem at once`.
+
+### Task 3: Pool, migrations runner, first migration (app + Limen tables), sqlc scaffold
+
+**Files:**
+- Create: `apps/server/internal/db/db.go` (`New(ctx, url) (*pgxpool.Pool, error)`), `apps/server/internal/db/migrate.go`, `apps/server/internal/db/migrations.go` (`//go:embed migrations/*.sql`, `LatestMigrationVersion()`), `apps/server/internal/db/migrations/00001_init.sql`, `apps/server/sqlc.yaml`, `apps/server/generate.go`, `apps/server/internal/db/queries/installation.sql`, `apps/server/internal/db/gen/*` (generated)
+- Test: `apps/server/internal/db/migrate_test.go`
+
+**Interfaces:**
+- Produces: `db.ApplyMigrations(ctx, databaseURL) error` under advisory lock `MigrationLockKey = 72450002` (fixed forever; comment as Pjokk's); `db.New`; `gen.Queries` with `GetInstallation`, `EnsureInstallation`, `BeginInstallationSetup(staleBefore)`, `CompleteInstallationSetup`, `ResetInstallationSetup`, `RecordRetentionRun`.
+
+- [ ] **Step 1:** Write `00001_init.sql` (goose `Up`/`Down`) with every table in REF §A5 and §B4, indexes and checks included, plus `INSERT INTO app_installation (id, status) VALUES (1, 'pending')`.
+- [ ] **Step 2:** Write `migrate.go` as Pjokk's (`sql.Open("pgx")`, single connection, `pg_advisory_lock`, goose provider on embedded FS, unlock).
+- [ ] **Step 3:** Failing test: `ApplyMigrations` creates `households` and `users` (`to_regclass`); idempotent second call; the advisory lock blocks a concurrent migrator (hold the lock on another conn, start ApplyMigrations in a goroutine, poll `pg_stat_activity` for a waiting backend, release, assert completion). Test start: `DROP SCHEMA public CASCADE; CREATE SCHEMA public`.
+- [ ] **Step 4:** `sqlc.yaml` as Pjokk's (`emit_exact_table_names: true`, `emit_pointers_for_null_types: true`); `generate.go` with `//go:generate sqlc generate` and the two oapi-codegen lines (spec added in Task 6, so add those lines then). Write `installation.sql` queries; `go generate ./...`.
+- [ ] **Step 5:** `docker compose -f docker-compose.test.yml up -d && go test -p 1 ./internal/db/` — PASS.
+- [ ] **Step 6:** Commit `feat(server): Postgres schema, advisory-lock migrator and sqlc scaffold`.
+
+### Task 4: testrig (Postgres rig)
+
+**Files:**
+- Create: `apps/server/internal/testrig/rig.go`
+- Test: `apps/server/internal/testrig/rig_test.go`
+
+**Interfaces:**
+- Produces: `testrig.DatabaseURL()`, `testrig.Setup(t) *Rig{Pool, Q}` (applies migrations once per process under a mutex, truncates every public table except `goose_db_version`, re-seeds `app_installation` row 1 as pending).
+
+- [ ] **Step 1:** Failing test: two consecutive `Setup` calls see an empty `households` table; `app_installation` row 1 exists with status pending.
+- [ ] **Step 2:** Implement as Pjokk's `rig.go` (`ensureMigrated`, `truncateAll`, then `EnsureInstallation`).
+- [ ] **Step 3:** `go test -p 1 ./internal/testrig/` — PASS. Commit `test(server): Postgres test rig`.
+
+### Task 5: Health handler, web embed placeholder, server shell, dispatch skeleton
+
+**Files:**
+- Create: `apps/server/internal/api/api.go` (`Deps`, `NewHandler`), `apps/server/internal/api/respond/respond.go` (`JSON`, `Error(w, status, msg)`, `ErrorFields`, `ErrorCode`), `apps/server/internal/api/system.go` (`/healthz`, `/readyz`), `apps/server/internal/web/web.go`, `apps/server/internal/web/dist/index.html` (placeholder `<!doctype html><title>Mi Casa Su Casa</title><p>SPA build missing — run scripts/build-artifacts.sh</p>`), `apps/server/cmd/mi-casa/main.go` (full dispatch table: default/server/worker/migrate/cron/healthcheck; cron and worker wired in P7 — until then `cron` prints usage and exits 2)
+- Test: `apps/server/internal/api/system_test.go`, `apps/server/internal/web/web_test.go`, `apps/server/cmd/mi-casa/main_test.go` (parseArgs table)
+
+**Interfaces:**
+- Produces: `api.Deps{Pool, Q, Now func() time.Time, AppURL, AppName, EmailDomain, TrustedProxyHops int, IPDigest func(string) string, …}` (fields added by later tasks), `api.NewHandler(deps) http.Handler` (mux: `/healthz`, `/readyz`, JSON 404 for other `/api/*`), `web.Handler(api http.Handler) http.Handler` (SPA fallback + security headers from REF §A1; probe paths and `/api/` bypass), `respond.Error`.
+
+- [ ] **Step 1:** Failing tests: `GET /healthz` → 200 `{"ok":true}` without touching the pool (nil pool); `GET /readyz` → 200 `{ok:true,status:"ready",setupConfigured:true,retention:{lastRunAt:null,stale:true}}`, → 503 `{ok:false,error}` with a closed pool; `GET /api/nope` → 404 `{"error":"Not found"}` JSON; web: `/` and `/casa/inbox` serve `text/html` with the CSP, HSTS, `X-Frame-Options`, `Referrer-Policy: no-referrer`, `X-Content-Type-Options`; `/healthz` has no CSP; `/robots.txt` → `Disallow: /`; hashed asset path gets `Cache-Control: public, max-age=31536000, immutable`, `index.html` gets `no-cache`.
+- [ ] **Step 2:** Implement `respond`, `system.go` (readiness reads `GetInstallation` for `last_retention_run_at`, stale when null or older than 48 h per REF §A2), `web.go` (Pjokk's shape, headers from REF §A1), `main.go` (Pjokk's `run`/`parseArgs`/`serveMode`/`healthcheckMode`/`migrateMode`/`serveUntilSignal`; `_ "time/tzdata"`).
+- [ ] **Step 3:** Tests PASS; `go run ./cmd/mi-casa migrate` against the compose DB applies; `go run ./cmd/mi-casa` serves `/healthz`.
+- [ ] **Step 4:** Commit `feat(server): health probes, embedded SPA shell and dispatch modes`.
+
+### Task 6: OpenAPI skeleton and codegen wiring
+
+**Files:**
+- Create: `openapi/mi-casa.yaml` (info, `/healthz`, `/readyz`, `components.schemas.Error {error, fields?, code?}`), `apps/server/internal/api/gen/cfg-types.yaml`, `cfg-server.yaml`, generated `types.gen.go`, `server.gen.go`, `apps/server/internal/api/mi-casa.yaml` (copy), `apps/server/internal/api/spec_sync_test.go`
+- Modify: `apps/server/generate.go`, `apps/server/internal/api/api.go` (load embedded spec, mount strict handlers, kin-openapi request validator with `ExcludeRequestBody:false`, JSON error shape via `ErrorHandler` producing REF §A1 validation envelope)
+
+- [ ] **Step 1:** Failing test `spec_sync_test.go`: embedded copy equals `../../../openapi/mi-casa.yaml` byte for byte; generated files are up to date (run `oapi-codegen` into a temp dir and diff) — skip when the binary is absent with `t.Skip` **only** outside CI (`CI` env set → hard fail).
+- [ ] **Step 2:** Write the spec skeleton, `generate.go`, run `go generate ./...`; move `/healthz` `/readyz` onto the strict server.
+- [ ] **Step 3:** Tests PASS. Commit `feat(server): OpenAPI spec as source of truth with committed codegen`.
+
+### Task 7: test.yml workflow and root scripts
+
+**Files:**
+- Create: `.github/workflows/test.yml` (reusable; Pjokk's with `micasa` Postgres creds on port 5432 and `TEST_DATABASE_URL=postgres://micasa:micasa@127.0.0.1:5432/micasa_test`; steps: mise-action `go bun`, Go cache, `bun install --frozen-lockfile`, `bun run check`, `goreleaser check` (added in P9 — add the step then), `bun run test`, `go vet`, `go test -p 1`), `.github/workflows/go-ci.yml` (`on: pull_request` calling `test.yml`; renamed to `ci-go.yml` and extended in P9)
+- Modify: root `package.json`: add `"workspaces": ["apps/frontend"]` (folder created in P8; until then keep the array empty), scripts `check` (`biome check .` + `tsc --noEmit`), keep every existing npm script working. Add `bun.lock` by running `bun install`.
+
+- [ ] **Step 1:** `bun install` produces `bun.lock`; `bun run check` and `npm run ci` both pass locally.
+- [ ] **Step 2:** Commit `ci: run the Go suite against Postgres on every pull request`.
+- [ ] **Step 3:** Open issue "P1: Go toolchain, config, health and test workflow", branch `go/p1-skeleton`, PR, wait for both `CI` and the new workflow, squash-merge.
+
+---
+
+## Phase P2 — Domain ports and repositories
+
+### Task 8: Pure domain ports with the TS test cases
+
+**Files:**
+- Create: `apps/server/internal/domain/slug.go`, `slug_test.go`; `internal/domain/extract.go`, `extract_test.go`; `internal/domain/verdict.go` (`Authentication{SPF, DKIM, DMARC *string}`, `Verdict(auth *Authentication, source Source) (trusted bool, reason string)`), `verdict_test.go`; `internal/mail/html.go` (`StripHTML`, `DecodeEntities`), `html_test.go`; `internal/mail/authresults.go` (`ParseAuthenticationResults([]string) *domain.Authentication`), `authresults_test.go`; `internal/security/compare.go` (`SecretsEqual(a, b string) bool` via SHA-256 + `subtle.ConstantTimeCompare`), `compare_test.go`; `internal/security/tokens.go` (`NewInvitationToken() (token, hash string)`, `HashInvitationToken`), `tokens_test.go`; `internal/security/ip.go` (`ClientIP(xff, remote string, hops int)`, `Digest(secret) func(ip string) string`), `ip_test.go`
+
+- [ ] **Step 1:** Port each test file's cases: `test/household-slug.test.ts`, `test/extract-code.test.ts` (table in REF §A3, all 19 rows + the `stripHtml` case), `test/classify-email.test.ts` verdict cases (`dmarc=fail` untrusted; header source with dkim pass trusted; header without → reason text; envelope with spf pass; envelope without → reason; nil auth trusted), `test/parse-email.test.ts` `parseAuthenticationResults` cases, `test/secrets-compare.test.ts`, Pjokk's `ratelimit_test.go` ClientIP cases (0 hops → socket; 1 hop → last XFF entry; 2 hops → second-last; empty → "unknown").
+- [ ] **Step 2:** FAIL, implement each file (REF §A3 rules verbatim; the lookbehind split as a rune loop), PASS.
+- [ ] **Step 3:** Commit `feat(server): port slug, code extraction, sender verdict and security helpers`.
+
+### Task 9: sqlc queries and repositories
+
+**Files:**
+- Create: `apps/server/internal/db/queries/{users,households,memberships,providers,sender_rules,messages,quarantine,invitations,audit,ratelimit,sessions}.sql`, regenerate `internal/db/gen`
+- Create: `apps/server/internal/repo/repo.go` (`type Repo struct{ pool, q }`, `InTx(ctx, fn)`), `households.go`, `providers.go`, `messages.go`, `invitations.go`, `audit.go`, `ratelimit.go` — thin Go wrappers only where a repository function in `src/server/db/repositories/*.ts` did more than one statement (createHousehold, acceptInvitation, reviewQuarantine release, createInvitation with providers, purge loop, grant/revoke access)
+- Test: `apps/server/internal/repo/*_test.go` using `testrig.Setup`
+
+**Interfaces (produces, exact names later tasks call):**
+- `repo.ListHouseholdsForUser(ctx, userID) ([]HouseholdSummary, error)`; `GetHouseholdBySlug`, `GetHouseholdByID`, `CreateHousehold(ctx, slug, displayName, ownerUserID) (Household, error)` (tx: household + owner membership), `UpdateHouseholdDisplayName`, `MembershipForSlug(ctx, userID, slug) (*Membership{HouseholdID, Slug, Role}, error)`, `GetMembership(ctx, userID, householdID)`, `CountOwners`, `RemoveMember`, `SetMemberRole`, `ProvidersBelong(ctx, householdID, ids []string) (bool, error)`.
+- `repo.ListProviderConfigurations`, `ListSenderRules`, `GetProviderByKey`, `GetProviderByID`, `CreateProvider`, `UpdateProvider`, `DeleteProvider`, `CreateSenderRule`, `UpdateSenderRule`, `DeleteSenderRule`, `GetSenderRuleByID`, `FindProviderMatch(ctx, householdID, candidates []Candidate) (*Match, error)` (exact then domain, REF §A3), `UserHasProviderAccess`, `ListMembers`, `ListMemberProviderAccess`, `ListProviders`, `GrantProviderAccess`, `RevokeProviderAccess`.
+- `repo.InsertMessage(ctx, parsed, householdID, providerID, code, reason, now) (id string, err)` (ON CONFLICT DO NOTHING), `InsertQuarantine`, `ListMessagesForProvider(ctx, householdID, key, Page) (Page[InboxMessage])`, `ListProviderSummariesForUser`, `CountUnreviewedQuarantine`, `ListQuarantine`, `UpdateMessageStatus`, `FindMessageByID`, `ReviewQuarantine(ctx, householdID, id, action, providerID) (*Review, error)`, `PurgeExpired(ctx, now, batch) (PurgeResult, error)`, `NormalizePage(limit int, before string) Page`.
+- `repo.CreateInvitation(ctx, in) (id, err)`, `ListInvitations`, `GetInvitationByTokenHash`, `GetInvitationByID`, `CancelInvitation`, `AcceptInvitation(ctx, in)`, `RefreshExpiredInvitations(ctx, now, householdID *string)`, `IsInvitationExpired`.
+- `repo.RecordAudit(ctx, in)` (never returns an error to callers; logs), `ListAuditEvents(ctx, householdID, limit)`.
+- `repo.FindUserByEmail`, `FindUserByID`, `DeleteUser`, `GetUserProfile`, `UpdateUserProfile`, `ListUserSessions`, `DeleteSession`, `DeleteOtherSessions`.
+- `repo.RateLimitHit(ctx, key, windowSeconds) (count int, err)`, `RateLimitSweep`.
+
+- [ ] **Step 1:** For each repository test in `test/integration/*repository*.test.ts`, `provider-rules.test.ts`, `pagination.test.ts`, `invitation-expiry.test.ts`, `retention.test.ts`, `tenant-isolation.test.ts` write the Go counterpart against the rig first (same scenarios: pagination cursor; duplicate message swallowed; domain rule matches subdomain and longest wins; exact beats domain; purge batches; expired invitations flip status; access rows cascade on membership delete; a household never sees another's rows).
+- [ ] **Step 2:** Write SQL, `go generate`, implement wrappers, PASS.
+- [ ] **Step 3:** Commit `feat(server): sqlc queries and household-scoped repositories`. Issue "P2: domain ports and repositories", PR, merge.
+
+---
+
+## Phase P3 — Auth (Limen), setup, invitations
+
+### Task 10: Limen service
+
+**Files:**
+- Create: `apps/server/internal/auth/auth.go`, `core_plugin.go` (Pjokk's), `session.go`
+- Test: `apps/server/internal/auth/auth_test.go` (rig-backed)
+
+**Interfaces:**
+- Produces: `auth.Config{AppURL, AppName, Secret string; Pool; SendPasswordReset func(ctx, to, name, url string) error}`, `auth.New(cfg) (Service, error)`, `type Session struct{ UserID, Email, Name, Token string; TwoFactorEnabled bool; SessionID string }`, `Service` interface: `Handler() http.Handler`, `SessionFromRequest(r) (*Session, error)` (nil,nil when none), `CreateUser(ctx, name, email, password) (userID string, err)`, `SignIn(ctx, w, r, userID string) error` (sets cookie via core.CreateSession), `RevokeAllSessions`, `RevokeSession(ctx, token)`, `DeleteUser(ctx, userID)`, `HashedIPDigest func(string) string`.
+- Produces: `auth.BasePath = "/api/auth"`, `auth.CookieName = "mi_casa_session"`.
+
+- [ ] **Step 1:** Failing tests through Limen's HTTP handler mounted in a test mux: `POST /api/auth/signup/credential` → 404 (disabled); `CreateUser` then `POST /signin/credential` `{credential, password}` → 200 with `Set-Cookie mi_casa_session`; `GET /me` with the cookie → 200 containing the email; wrong password → 401; short password on `CreateUser` → error; `POST /passwords/request-reset` calls `SendPasswordReset` with a URL `APP_URL/reset-password?token=…` and the user's name; `POST /passwords/reset` with that token → subsequent sign-in with the new password works and the old session is revoked; two-factor: `initiate-setup` → `{uri}`, generate a TOTP from the secret in the URI (use `github.com/pquerna/otp/totp` in tests), `finalize-setup` → user `two_factor_enabled`; sign-in now returns `{"two_factor_required":true}` and no session cookie; `/two-factor/verify` `{code}` → cookie; `GET /backup-codes` → 10 codes; verify with a backup code works once; `disable` with password → sign-in issues a cookie directly. Session metadata stores an IP digest, never `127.0.0.1`.
+- [ ] **Step 2:** Implement per REF §B1–B3 (copy Pjokk's `auth.go` structure; `disabledRouteIDs` from REF §B3).
+- [ ] **Step 3:** PASS. Commit `feat(server): Limen-backed auth with password, reset and two-factor`.
+
+### Task 11: Middleware chain, rate limiter, request logging
+
+**Files:**
+- Create: `apps/server/internal/api/middleware/middleware.go` (`Session(d)`, `RequireSession`, `RequireHousehold(d)` (slug from path), `RequireOwner`, `SameSite(appURL)`, `LogFailures`, `RateLimit(store, rule, ipFn)`), `apps/server/internal/ratelimit/ratelimit.go` (Pjokk's `Store` + `Postgres` + rules `Setup{5,15m}`, `Invitations{20,10m}`, `HouseholdCreate{10,1h}`), `apps/server/internal/log/log.go` (`Event(level, event string, fields map[string]any)` JSON line via `log/slog`)
+- Test: `middleware_test.go`, `ratelimit_test.go`
+
+**Interfaces:**
+- Produces: `middleware.UserFrom(r) *auth.Session`, `middleware.HouseholdFrom(r) Household{ID, Slug, Role}`, `middleware.ClientKey(r) string` (digest).
+
+- [ ] **Step 1:** Failing tests from `test/origin-policy.test.ts` (each same-site rule in REF §A1, including Referer-only and `Sec-Fetch-Site: cross-site` with matching Origin allowed), `test/integration/rate-limit.test.ts` (6th setup call in 15 min → 429 with `Retry-After`), `request-logging.test.ts` (a 404 produces one `api_request_failed` line with method, path, status, durationMs; a 200 produces none), household guards (non-member 403, member ok, owner-only 403 for member).
+- [ ] **Step 2:** Implement; PASS. Commit `feat(server): session, tenancy, same-site and rate-limit middleware`.
+
+### Task 12: HTTP test rig, setup and invitation routes
+
+**Files:**
+- Create: `apps/server/internal/testrig/http.go` (`testrig.App(t) *AppRig{Rig, Deps, Handler, Mail *RecordingSender}`, `Do(method, path, body, opts...)`, `SignIn(email) cookie`, `CreateOwner()` (completes setup), `CreateMember(...)`)
+- Create: `apps/server/internal/api/setup.go`, `invitations_public.go`, `apps/server/internal/mail/sender.go` (`Sender` interface `Send(ctx, Message) error`; `RecordingSender`), `internal/mail/templates.go` (`PasswordReset(to, name, url) Message`, `Invitation(in) Message` — REF §A3 outbound texts)
+- Modify: `openapi/mi-casa.yaml` (setup and invitations paths with schemas from REF §A4), regenerate
+- Test: `setup_test.go`, `invitations_public_test.go`, `templates_test.go`
+
+- [ ] **Step 1:** Port `test/integration/setup-route.test.ts`, `setup-recovery.test.ts`, `invitation-accept.test.ts`, `invitation-service.test.ts` (every status and message in REF §A2 setup/invitations rows; the cookie is set on 201; orphan owner cleanup; in-progress reclaim after 10 minutes using `Deps.Now`; signed-in mismatch 403; `ACCOUNT_EXISTS` 409; expired 410; token in header only — a query-string token is ignored).
+- [ ] **Step 2:** Implement; PASS. Commit `feat(server): first-run setup and invitation acceptance`. Issue "P3: Limen auth, setup, invitations", PR, merge.
+
+---
+
+## Phase P4 — Households, admin, settings
+
+### Task 13: Households and settings routes
+
+**Files:** `apps/server/internal/api/households.go`, `settings.go`; spec paths; tests porting `household-creation.test.ts`, `membership-removal.test.ts` (leave), `settings-route.test.ts`, `two-factor.test.ts` (profile shows `twoFactorEnabled`), `auth.test.ts` (sessions list, revoke one, revoke others → the other cookie stops working).
+
+- [ ] Steps: failing tests → implement per REF §A2 → PASS → commit `feat(server): households and account settings routes`.
+
+### Task 14: Admin routes (providers, rules, members, invitations, settings, audit)
+
+**Files:** `apps/server/internal/api/admin_providers.go`, `admin_members.go`, `admin_invitations.go`, `admin_settings.go`, `internal/domain/invite.go` (`InviteMember`, `ResendInvitation` per REF §A3 with `mail.Sender`); spec paths; tests porting `provider-rules.test.ts`, `provider-summaries.test.ts`, `invitations-repository.test.ts` (route level), `audit-log.test.ts` (each action in REF §A6 recorded with actor and household), `membership-removal.test.ts` (last owner 409, self 400), `error-handling.test.ts` (duplicate rule → 409 with the column message; invalid JSON → 400 `"Invalid JSON body"`; field errors envelope), `tenant-isolation.test.ts` (owner of A cannot read/modify B by id).
+
+- [ ] Steps: tests → implement → PASS → commit `feat(server): owner administration routes`. Issue "P4: households, admin and settings", PR, merge.
+
+---
+
+## Phase P5 — Inbox and quarantine
+
+### Task 15: Inbox routes
+
+**Files:** `apps/server/internal/api/inbox.go`; spec; tests porting `inbox-routes.test.ts`, `pagination.test.ts` (route level), `messages-repository.test.ts` (release path), `security-headers.test.ts` (API responses carry `X-Content-Type-Options` and no CSP is required; SPA has CSP).
+
+- [ ] Steps as above; commit `feat(server): inbox and quarantine routes`. Issue "P5: inbox", PR, merge.
+
+---
+
+## Phase P6 — Mail: Mailgun inbound, MIME parsing, SMTP outbound
+
+### Task 16: MIME parsing and classification
+
+**Files:**
+- Create: `apps/server/internal/mail/parse.go` (`Parse(raw []byte, envelopeFrom, envelopeTo string) (*Parsed, error)` using `github.com/emersion/go-message/mail`; REF §A3 email parsing incl. synthetic Message-ID, truncation, HTML fallback, Mailgun headers → authentication), `internal/domain/classify.go` (`Classify(ctx, repo, parsed) (Classification, error)`)
+- Test: `parse_test.go` (port `test/parse-email.test.ts` fully: html fallback, empty body placeholder, truncation flag, synthetic id determinism, `Authentication-Results` parsing, `X-Mailgun-Spf: Pass` → `spf=pass`, multipart alternative prefers text, quoted-printable and base64 bodies decode, charset ISO-8859-1 decodes), `classify_test.go` (port `test/classify-email.test.ts` against the rig)
+
+- [ ] Steps: tests → implement → PASS → commit `feat(server): parse inbound MIME and classify against sender rules`.
+
+### Task 17: Mailgun webhook handler and SMTP sender
+
+**Files:**
+- Create: `apps/server/internal/mail/mailgun.go` (`VerifySignature(key, timestamp, token, signature string, now time.Time) error`, replay set), `apps/server/internal/api/inbound.go` (handler per REF §A3 inbound + Part C; mounted outside the OpenAPI strict server, before the same-site middleware), `apps/server/internal/mail/smtp.go` (`NewSMTPSender(smtpURL, from string) (Sender, error)` using `net/smtp` with STARTTLS for `smtp://`, implicit TLS for `smtps://`, PLAIN auth from the URL userinfo, RFC 5322 message with text and HTML alternative parts)
+- Modify: `cmd/mi-casa/main.go` (build the SMTP sender and the webhook key into `Deps`)
+- Test: `mailgun_test.go` (valid signature accepted; wrong key 401; stale timestamp 401; replayed token 401), `inbound_test.go` (rig: matched → 200 stored + row in `messages` with code; unmatched → 200 quarantined; unknown recipient → 406; > 2 MiB → 406; quarantine full (seed 200 rows) → 406; unparseable → 406; missing `body-mime` → 406; Mailgun SPF fail on an envelope match → quarantined with the verdict reason), `smtp_test.go` (start an in-process SMTP server on a random port using `github.com/emersion/go-smtp`'s backend in the test, assert the received DATA contains the subject and both parts; STARTTLS negotiation with a self-signed cert)
+
+- [ ] Steps: tests → implement → PASS → commit `feat(server): Mailgun inbound webhook and SMTP outbound mail`. Issue "P6: mail", PR, merge.
+
+---
+
+## Phase P7 — Retention job, cron, dispatch modes
+
+### Task 18: Jobs and scheduler
+
+**Files:** `apps/server/internal/jobs/retention.go` (`Run(ctx, Deps, now) (Result, error)` per REF §A3), `internal/cron/cron.go` (Pjokk's shape; `Jobs = ["retention"]`, schedule `0 3 * * *`, UTC, `StartScheduler(deps) stop func`, also sweeps `rate_limit` and Limen `rate_limits` expired rows), `cmd/mi-casa/main.go` (`cron <job>`, `worker`, default mode starts the scheduler)
+- Test: port `retention.test.ts` (expired message and quarantine rows purged in batches, unexpired kept, pending invitation past expiry flips, `last_retention_run_at` recorded, `/readyz` reports `stale:false` afterwards); `cron_test.go` (unknown job error; schedule parses; scheduler location is UTC).
+
+- [ ] Steps: tests → implement → PASS → commit `feat(server): retention job, UTC scheduler and worker/cron modes`. Issue "P7: jobs and dispatch", PR, merge.
+
+---
+
+## Phase P8 — Frontend: move, TanStack Router, Limen client, typed API
+
+### Task 19: Move `src/client` to `apps/frontend` (mechanical)
+
+**Files:**
+- Move: `src/client/**` → `apps/frontend/src/**`, `src/client/index.html` → `apps/frontend/index.html`, `src/client/public` → `apps/frontend/public`; client tests `test/*.test.tsx`, `test/client-utils.test.ts`, `test/theme.test.ts`, `test/pwa-manifest.test.ts`, `test/client-test-utils.tsx`, `test/ui-primitives.test.tsx` → `apps/frontend/test/`
+- Create: `apps/frontend/package.json` (`@mi-casa/frontend`, scripts `dev`, `build`, `test` (vitest), `typecheck`), `apps/frontend/vite.config.ts` (outDir `../../dist/client`, alias `@` → `src`, dev proxy `/api`, `/healthz`, `/readyz` → `http://localhost:3000`), `apps/frontend/vitest.config.ts` (jsdom project), `apps/frontend/tsconfig.json`
+- Modify: root `package.json` workspaces `["apps/frontend"]`; root `vite.config.ts`/`vitest.config.ts` keep building the Workers app from `apps/frontend` (alias `@client` → `apps/frontend/src`) so `npm run build` and the Cloudflare deploy keep working until P12; `src/client` import of `@server/auth/client` becomes a path alias resolvable from both configs.
+
+- [ ] **Step 1:** `git mv`; update imports; `bun run --filter @mi-casa/frontend test`, `bun run typecheck`, `npm run ci` all pass.
+- [ ] **Step 2:** Commit `refactor(client): move the SPA to apps/frontend`.
+
+### Task 20: TanStack Router
+
+**Files:**
+- Create: `apps/frontend/src/router.tsx` (code-based routes per spec §Frontend: root with providers, public routes, authed `/settings`, `/new-household`, `/$slug` shell with children `inbox`, `inbox/$providerKey`, `quarantine`, `members`, `providers`, `settings`; `/` redirect), `apps/frontend/src/lib/guards.ts` (`beforeLoad` helpers: `requireSession`, `requireSetupDone`, `requireHousehold(slug)`, `requireOwner`), `apps/frontend/src/lib/session.ts` (query options for `/api/setup/status`, `/api/settings/households`)
+- Modify: `main.tsx` (RouterProvider), `App.tsx` (deleted; its state moves to the shell route and guards), `Layout.tsx`, `InboxPage.tsx`, `ServiceList.tsx`, `NeedsReviewPage.tsx`, `InvitePage.tsx`, `LoginPage.tsx`, `ForgotPasswordPage.tsx`, `ResetPasswordPage.tsx`, `TwoFactorPage.tsx` (`Link`/`useNavigate`/`useParams`/`useSearchParams` → `@tanstack/react-router`), `test/client-test-utils.tsx` (render inside a memory-history router with a catch-all route), the four tests that use `MemoryRouter`
+- Remove: `react-router-dom` dependency
+
+- [ ] **Step 1:** Update `layout.test.tsx`, `inbox-page.test.tsx`, `password-reset-pages.test.tsx`, `two-factor-page.test.tsx` to the new test utils; add `router.test.tsx`: unauthenticated `/casa/inbox` redirects to `/login`; `needsSetup` redirects to `/setup`; member visiting `/casa/members` redirects to `/casa/inbox`; `/` with one household → `/casa/inbox`; `/` with none → `/new-household`.
+- [ ] **Step 2:** FAIL → implement → PASS; `bun run build` succeeds; manual check with the screenshot harness (memory `mi-casa-screenshot-harness`) that inbox, members and settings render.
+- [ ] **Step 3:** Commit `feat(client): TanStack Router with route guards`.
+
+### Task 21: Limen auth client and typed API client
+
+**Files:**
+- Create: `apps/frontend/src/lib/auth-client.ts` (REF §B5), `apps/frontend/src/lib/api.ts` (openapi-fetch client + `unwrap` as Pjokk's), `apps/frontend/src/lib/api-schema.d.ts` (generated; root script `gen:client` as Pjokk's `bunx --package openapi-typescript@7.13.0 …`)
+- Modify: every `queries/*.ts` (`fetchJson` → `unwrap(client.GET(...))`), `utils.ts` (remove `fetchJson`, keep helpers), `LoginPage.tsx` (email + password only; `two_factor_required` → navigate `/two-factor`; passkey autofill removed), `TwoFactorPage.tsx` (`twoFactor.verify`), `ForgotPasswordPage.tsx`, `ResetPasswordPage.tsx`, `settings/PasswordSection.tsx`, `settings/TwoStepSection.tsx` (initiate → QR from `uri` → finalize → show backup codes from `getBackupCodes`), `settings/AccountSettingsPage.tsx` (drop `PasskeysSection`), `DevicesSection.tsx` (`ipAddress` shown as "hidden"), `types.ts` (`SessionData` from Limen shape), tests mocking `@server/auth/client` → mock `@/lib/auth-client`
+- Remove: `src/server/auth/client.ts` import from the client, `PasskeysSection.tsx`, `better-auth` client usage, `qrcode` stays
+- Delete dependency: `@better-auth/passkey` from the frontend workspace (root keeps it for the Workers app until P12)
+
+- [ ] **Step 1:** Update tests (`login-page.test.tsx`: no passkey button; 2FA redirect on `two_factor_required`; `two-factor-page.test.tsx`; `account-settings-page.test.tsx`: no passkeys section, two-step enrolment flow shows QR then backup codes) → FAIL → implement → PASS.
+- [ ] **Step 2:** Add `apps/frontend/test/api-client.test.ts`: `unwrap` throws `ApiError` with the server's `error` message and `code`.
+- [ ] **Step 3:** Commit `feat(client): Limen auth client and OpenAPI-typed API client; passkeys removed`. Issue "P8: frontend on TanStack Router, Limen and openapi-fetch", PR, merge.
+
+---
+
+## Phase P9 — Build, image, CI image job, release
+
+### Task 22: Artifact scripts and Dockerfile
+
+**Files:** `scripts/spa-embed-overlay.sh`, `scripts/restore-embed-overlay.sh`, `scripts/build-artifacts.sh`, `scripts/build-image.sh` (Pjokk's, single embed dir `apps/server/internal/web/dist`, binary `mi-casa`), `Dockerfile` (Pjokk's minus `/data`; `COPY ${BINARY_ROOT}/${TARGETPLATFORM}/mi-casa /app/mi-casa`, HEALTHCHECK `["/app/mi-casa","healthcheck"]`), `.dockerignore`, `docker-compose.yml` (build from source: `postgres:17-alpine` + app built via `scripts/build-artifacts.sh` then `docker build`), `docker-compose.selfhost.yml` (Pjokk's shape with `DATABASE_URL`, `APP_URL`, `AUTH_SECRET`, `SETUP_SECRET`, `OWNER_EMAIL`, `EMAIL_DOMAIN`, `MAILGUN_WEBHOOK_SIGNING_KEY`, `SMTP_URL`, `OUTBOUND_EMAIL_FROM`, `TRUSTED_PROXY_HOPS`; no data volume).
+
+- [ ] **Step 1:** `mise run artifacts` produces both binaries with the real SPA embedded (`strings dist/server/linux/amd64/mi-casa | grep -c 'id="root"'` ≥ 1) and leaves `git status` clean.
+- [ ] **Step 2:** `docker build -t mi-casa:dev .` then run against the compose DB; `curl /readyz` ok; `curl /` returns the SPA; image size under 40 MB (`docker images mi-casa:dev`).
+- [ ] **Step 3:** Commit `build: native artifacts, COPY-only distroless image and compose files`.
+
+### Task 23: CI image job and GoReleaser release
+
+**Files:** `.github/workflows/ci-go.yml` (Pjokk's `ci.yml`: test → build artifacts → build image → smoke test (migrate, serve, `/readyz`, `/` is HTML, webhook bad signature → 401) → push `<next>-pr.<N>` and `<next>-pr.<N>.<sha>` to `ghcr.io/andersro93/mi-casa-su-casa` when not a fork), `.github/workflows/release.yml` (Pjokk's verbatim with names changed; environment `production` url from a repo variable), `.goreleaser.yaml` (Pjokk's with one before hook, `dockers_v2` image `ghcr.io/andersro93/mi-casa-su-casa`, no `extra_files`), `test.yml` gains `goreleaser check`.
+
+- [ ] **Step 1:** `goreleaser check` passes; `mise run snapshot` builds archives and a local image.
+- [ ] **Step 2:** Commit `ci: image smoke test with PR preview images, and merging-is-releasing via GoReleaser`. Issue "P9: build, image, release", PR (the image job runs on this PR itself), merge. The merge triggers `release.yml`; verify `v0.1.0` appears with a signed image.
+
+---
+
+## Phase P10 — Playwright end-to-end suite
+
+### Task 24: E2E stack and suite
+
+**Files:**
+- Create: `scripts/e2e-stack.sh` (Pjokk's plus a `axllent/mailpit` container; app env: `SMTP_URL=smtp://mailpit:1025`, `OUTBOUND_EMAIL_FROM=noreply@e2e.test`, `EMAIL_DOMAIN=e2e.test`, `MAILGUN_WEBHOOK_SIGNING_KEY=e2e-signing-key`, `OWNER_EMAIL=owner@e2e.test`, `SETUP_SECRET=e2e-setup-secret`, `ENVIRONMENT=test`, `APP_URL=http://127.0.0.1:3300`; publishes Mailpit's API on 8025), `e2e/playwright.config.ts` (Pjokk's; `workers: 1`, mobile Chromium profile plus one desktop project for the inbox layout), `e2e/tsconfig.json`, `e2e/helpers.ts` (`completeSetup(request)`, `signIn(page, email, password)`, `mailpit.lastMessageTo(email)` + link extraction, `postInbound(request, {to, from, subject, text, spf})` building a signed Mailgun form with `body-mime`, `totpFrom(uri)` using `otpauth`), `e2e/fixtures.ts`
+- Specs: `setup.spec.ts` (first run: `/` redirects to `/setup`, wrong secret rejected, success lands in the inbox, `/setup` locked after), `auth.spec.ts` (sign-in, wrong password, sign-out, session revocation from account settings), `two-factor.spec.ts` (enrol with QR URI → TOTP, backup codes shown, sign-in challenged, TOTP accepted, backup code accepted once, disable), `password-reset.spec.ts` (request → Mailpit link → new password works → old session gone), `invite.spec.ts` (invite by email → Mailpit link → create account → member sees only scoped services; invite by link copy; resend; cancel), `services.spec.ts` (create service + exact and domain senders, rename, delete), `inbox.spec.ts` (post inbound mail → code visible with copy button → mark used; SPF fail lands in Needs review), `quarantine.spec.ts` (release to a service, dismiss), `members.spec.ts` (grant/revoke access, promote, remove; last owner cannot leave), `household.spec.ts` (rename, copyable address `slug@e2e.test`, create second household as owner).
+- Modify: root `package.json` devDependency `@playwright/test`, `otpauth`; `typecheck` includes `tsc --noEmit -p e2e`; `ci-go.yml` adds `bunx playwright install --with-deps chromium` and `cd e2e && bunx playwright test` after the smoke test with the report uploaded on failure (the stack in CI reuses the smoke-test image and adds Mailpit).
+
+- [ ] **Step 1:** Write the helpers and the setup spec first; `mise run e2e` green.
+- [ ] **Step 2:** Add the remaining specs one by one, each green locally.
+- [ ] **Step 3:** Commit `test(e2e): Playwright suite against the real image with Mailpit`. Issue "P10: end-to-end tests", PR (CI runs the suite), merge.
+
+---
+
+## Phase P11 — README and docs
+
+### Task 25: README rewrite and operator docs
+
+**Files:** `README.md` (spec §README; structure and tone of Pjokk's README: badges, logo, pitch, screenshots, "Run it" quick start, Self-hosting guide with the env table from spec §config, image tags and pinning ladder, reverse proxy, Mailgun receiving setup, SMTP, first-run setup, upgrades, backups, verifying signatures with `cosign verify-blob --bundle` and `cosign verify`, Development section (`mise install`, `bun install`, compose test DB, `mise run test`, `mise run e2e`, `mise run artifacts`, `mise run image`, `mise run snapshot`), Release model, Architecture at a glance, Contributing, Licence), `docs/email-routing.md` → `docs/inbound-mail.md` (Mailgun: receiving domain, MX records, route, signing key, testing with curl, troubleshooting), `docs/operations.md` (container logs, health, alerts), `docs/runbook.md` (roll back by image tag, Postgres backup/restore with `pg_dump`, migrations, lost owner, rotate secrets, inbound mail stopped), `docs/ci-cd-architecture.md` (replace with the new pipeline), `CONTRIBUTING.md` (commands), `SECURITY.md` (new, as Pjokk's), `DECISIONS.md` (new: record the decisions listed in the spec table plus those made during implementation), `.github/dependabot.yml` (gomod, npm, github-actions, docker).
+
+Keep the Cloudflare sections in the README under a clearly marked "Legacy Cloudflare deployment (removed in the next release)" heading until P12 removes them.
+
+- [ ] Steps: write → `bun run check` (Biome also formats Markdown? no — leave) → commit `docs: self-hosting guide, operations and runbook for the container`. Issue "P11: docs", PR, merge.
+
+---
+
+## Phase P12 — Cutover
+
+### Task 26: Remove the Workers app
+
+**Files:**
+- Delete: `src/`, `wrangler.jsonc`, `migrations/`, `drizzle.config.ts`, `requests/`, root `vite.config.ts`, root `vitest.config.ts`, `test/` (server tests already ported; integration tests superseded), `.github/workflows/ci.yml`, `preview-deploy.yml`, `production-deploy.yml`, `production-d1-migrate.yml`, `docs/ci-cd-architecture.md` legacy parts, `.dev.vars.example`
+- Modify: root `package.json` (drop Workers deps: `hono`, `better-auth`, `@better-auth/*`, `drizzle-*`, `postal-mime`, `wrangler`, `@cloudflare/*`; scripts reduced to `dev`, `dev:server`, `build`, `check`, `test`, `typecheck`, `gen:client`), rename `ci-go.yml` → `ci.yml`, `README.md` (drop the legacy section, description "Self-hosted shared verification inbox for families"), `package.json` description, `codeql-analysis.yml` languages `go, javascript-typescript`.
+
+- [ ] **Step 1:** `mise run check && mise run test && mise run artifacts && mise run e2e` green.
+- [ ] **Step 2:** Commit `chore!: remove the Cloudflare Workers backend` (breaking change → minor bump under `--v0`). Issue "P12: cutover", PR, merge. Confirm the release publishes.
+- [ ] **Step 3:** Update memory `mi-casa-delivery-flow` (tests now `mise run test`, e2e `mise run e2e`) and `mi-casa-ux-redesign-status` (router is now TanStack).
+
+---
+
+## Self-review notes
+
+- Spec coverage: every spec section maps to a phase: architecture/layout (P1), config/db (P1–P2), auth (P3), api (P3–P5), mail (P6), jobs/cron/web (P7, P1), frontend (P8), build/release/self-host (P9), e2e (P10), README/docs (P11), cutover (P12).
+- Names used across tasks: `api.Deps`, `api.NewHandler`, `web.Handler`, `testrig.Setup`, `testrig.App`, `auth.Service`, `mail.Sender`, `repo.*` as listed in Task 9, `ratelimit.Store`, `middleware.*` as listed in Task 11, `jobs.Run`, `cron.StartScheduler`.

--- a/docs/superpowers/plans/2026-09-04-go-migration-reference.md
+++ b/docs/superpowers/plans/2026-09-04-go-migration-reference.md
@@ -1,0 +1,707 @@
+# Go Migration Reference — Backend Inventory & Limen Integration
+
+This document is the **parity contract** for the Go rewrite of Mi Casa Su
+Casa. Part A is a verified inventory of the TypeScript Workers backend as of
+commit `114d96b` (`src/server`, `src/index.ts`). Part B is a source-verified
+integration guide for Limen (the Go auth library) and its TypeScript client.
+Part C records the Mailgun inbound contract. Implementation tasks in
+`2026-09-04-go-backend-migration.md` cite sections of this file as REF §…;
+when in doubt the TypeScript source is ground truth and this file is the map
+to it.
+
+Passkeys are **dropped** in the rewrite (design spec). Inventory entries that
+mention passkeys document today's behaviour; the plan removes them.
+
+---
+
+# Part A — TypeScript Backend Inventory
+
+## A1. HTTP surface and middleware order (`src/index.ts`)
+
+1. Security headers on every response (SPA, assets and API):
+   - `Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; worker-src 'self'; manifest-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests`
+   - `Strict-Transport-Security: max-age=63072000; includeSubDomains`
+   - `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`,
+     `X-Content-Type-Options: nosniff`,
+     `Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()`
+   - Hono's secureHeaders also sets `X-XSS-Protection: 0`,
+     `Cross-Origin-Opener-Policy: same-origin`,
+     `Cross-Origin-Resource-Policy: same-origin`, `X-DNS-Prefetch-Control: off`,
+     `X-Download-Options: noopen`, `X-Permitted-Cross-Domain-Policies: none`.
+     Go: set the first list; the second is nice-to-have and covered by a test
+     only for `X-Content-Type-Options`, `X-Frame-Options`, CSP, HSTS,
+     `Referrer-Policy`.
+2. CORS on `/api/*` for `APP_URL` origin only (and `http://localhost`/
+   `127.0.0.1` when `ENVIRONMENT=development`). Go: **no CORS middleware**
+   (same-origin SPA). Test that a foreign `Origin` on a GET gets no
+   `Access-Control-Allow-Origin` header.
+3. `rejectCrossSiteMutations` on `/api/*` (`src/server/security/origin.ts`):
+   for non-GET/HEAD/OPTIONS, reject with `403 {"error":"Cross-site request
+   rejected"}` when (a) `Sec-Fetch-Site` is present and not `same-origin`/
+   `none` and `Origin` is absent or not the app origin; or (b) `Origin` is
+   present and not the app origin; or (c) `Origin` absent but `Referer`
+   present with a foreign origin. Requests with none of the headers pass.
+4. `logFailedApiRequests`: one JSON log line per API response with status
+   ≥ 400: `{event:"api_request_failed", level:"warn"|"error"(≥500), method,
+   path, status, durationMs, ray}`. Go: same fields, `ray` becomes a
+   per-request id (`X-Request-Id` if present, else random).
+5. Env guard on `/api/*` except `/api/health/live`: `503 {error:
+   "misconfigured", problems:[{key,message}]}`. Go: config is validated at
+   boot, so this middleware does not exist; `/readyz` reports readiness.
+6. `loadAuthSession` on `/api/inbox/*`, `/api/admin/*`, `/api/households/*`,
+   `/api/settings/*` (and inside `/api/invitations`): resolves the session
+   and sets `user = {id, email, name (falls back to email), role, households:
+   HouseholdSummary[]}`, `session = {id, userId}`.
+7. Auth handler on `/api/auth/*` (Better Auth; Go: Limen, see Part B).
+8. Route groups: `/api/health`, `/api/households`, `/api/inbox`,
+   `/api/admin`, `/api/invitations`, `/api/settings`, `/api/setup`.
+9. Unmatched `/api/*` → `404 {"error":"Not found"}` (never the SPA).
+10. Everything else → static assets with SPA fallback to `index.html`.
+11. Error handler (`src/server/http/errors.ts`): unique violations →
+    `409 {"error":"A record with the same <column> already exists"}` (column
+    from the constraint name's last dotted segment, underscores → spaces);
+    HTTPException → its status and message; anything else → log
+    `unhandled_error` and `500 {"error":"Internal error"}`.
+
+**Error envelope**: `{ "error": string }`, optionally `"fields":
+{field: message}` on validation errors and `"code": "ACCOUNT_EXISTS"` on one
+invitation error. Go keeps exactly this shape.
+
+**Validation** (`src/server/http/validation.ts`): invalid JSON →
+`400 {"error":"Invalid JSON body"}`; schema failure → `400 {error: "<summary>",
+fields: {path: firstMessage}}` where summary joins `"<path>: <message>"` (or
+just the message when it already starts with the path) with `"; "`. Go: the
+same envelope, produced from kin-openapi validation errors plus hand
+validation for cross-field rules (sender rule shape, slug rules).
+
+### Auth guards (`src/server/auth/middleware.ts`)
+
+- `requireAuthenticatedUser`: no user → `401 {"error":"Unauthorized"}`.
+- `requireHouseholdContext`: no user → 401; missing slug → 400 `"Household
+  slug is required"`; user not a member of `:slug` → `403 {"error":
+  "Forbidden"}`; else sets `household = {id, slug, role}`.
+- `requireOwner`: `household.role !== "owner"` → `403 {"error":"Forbidden"}`.
+
+### Rate limiting (`src/server/security/rate-limit.ts`)
+
+Fixed window per `app:<rule>:<client>` key in table `rate_limit`
+(`key` unique, `count`, `last_request` epoch ms). Over limit → `429
+{"error":"Too many requests. Please try again later."}` with `Retry-After`
+seconds. Rules: `setup` 5 per 15 min; `invitations` 20 per 10 min (both
+lookup and accept); `household-create` 10 per hour. Client = trusted client
+address (Go: `ratelimit.ClientIP(xForwardedFor, remoteAddr, TRUSTED_PROXY_HOPS)`
+digested with SHA-256 keyed by `AUTH_SECRET` + `"mi-casa/ip"`; never stored raw).
+
+## A2. Routes
+
+Every handler below runs after the middleware in A1. `:slug` routes require
+membership; owner-only routes are marked **owner**. Response bodies are
+verbatim from the TS source; snake_case keys are deliberate (the SPA reads
+them).
+
+### Health (`src/server/routes/health.ts`)
+
+| Method | Path (TS → Go) | Response |
+|---|---|---|
+| GET | `/api/health/live` → `/healthz` | TS: `{status:"ok"}`; Go: `{ok:true}` (Pjokk convention; SPA does not call it) |
+| GET | `/api/health/ready` → `/readyz` | 200 `{ok:true, status:"ready", setupConfigured:bool, retention:{lastRunAt: string|null, stale: bool}}`; `stale` = no run recorded or older than 48 h. 503 `{ok:false, error}` when `SELECT 1` fails |
+
+### Setup (`src/server/routes/setup.ts`) — public
+
+| Method | Path | Behaviour |
+|---|---|---|
+| GET | `/api/setup/status` | `{needsSetup, setupLocked, isConfigured, status, emailDomain}`. `isConfigured` = OWNER_EMAIL and SETUP_SECRET set (always true in Go, both required); `needsSetup` = configured and status ≠ complete; `setupLocked` = status = complete; `emailDomain` = EMAIL_DOMAIN. |
+| POST | `/api/setup/complete` | rate `setup`. Body `{email, name, password, householdName, householdSlug, setupSecret}` (schemas A4). Order: 409 `"Setup has already been completed"` if complete; 503 if unconfigured (never in Go); validate; 403 `"Invalid setup secret"` (constant-time compare); 403 `"Setup email must match OWNER_EMAIL"` (case-insensitive); claim via `beginInstallationSetup` else 409 `"Setup is already in progress or has been completed"`; if a user with OWNER_EMAIL exists: owner of ≥1 household → complete installation, 409 `"Setup has already been completed for this owner. Sign in with your owner account."`; else delete the orphan user. Then create user (sign-up), create household with owner membership, complete installation (`owner_user_id`, `owner_email`), audit `installation.setup_completed` (target `installation`/`"1"`, details `{householdSlug}`), respond `201 {member:{id,email,name,role:"owner"}, household}` **with the session cookie set**. On failure: delete the created user, `resetInstallationSetup`, 409 `"A household with that slug already exists"` on unique violation, else the auth error's status/message, else 500 `"Unable to complete setup"`. |
+
+Installation state (`app_installation`, singleton id=1, seeded `pending` on
+first read): `beginInstallationSetup` moves pending→in_progress, or reclaims
+an in_progress older than 10 minutes; `completeInstallationSetup` sets
+complete + owner; `resetInstallationSetup` in_progress→pending only when
+`owner_user_id IS NULL`; `recordRetentionRun` sets `last_retention_run_at`.
+
+### Households (`src/server/routes/households.ts`) — session required
+
+| Method | Path | Behaviour |
+|---|---|---|
+| GET | `/api/households/me` | `{households: HouseholdSummary[]}` ordered by lower(displayName). `HouseholdSummary = {id, slug, displayName, role}` |
+| POST | `/api/households` | rate `household-create`. Body `{slug, displayName}`. May create when: installation owner, or user has zero memberships (TS also allows `user.role === "admin"`; Go has no such role). Else 403 `"Only the installation owner can create additional households. Ask them to create it and invite you."`. Slug taken → 409 `"Household slug already exists"`. Creates household + owner membership atomically, audit `household.created` (details `{slug}`), `201 {household: {...HouseholdSummary-with-createdAt/updatedAt, role:"owner"}}` |
+| POST | `/api/households/:slug/leave` | member. Sole owner → 409 `"You are the only owner of this household. Make another member an owner first."`. Removes membership (provider access cascades), log `member_left`, audit `member.left` (target user), `{ok:true}` |
+
+### Inbox (`src/server/routes/inbox.ts`) — member of `:slug`
+
+| Method | Path | Behaviour |
+|---|---|---|
+| GET | `/api/inbox/:slug/providers` | `{providers: ProviderSummaryRow[]}` — providers the user may see (owner: all; member: those with provider access), each `{household_slug, provider_key, display_name, message_count, new_count, latest_received_at, latest_message_id, latest_subject, latest_code, latest_status}` ordered by latest activity desc then display_name |
+| GET | `/api/inbox/:slug/providers/:providerKey?limit&before` | member without access → 403; unknown provider → 404 `"Provider not found"`. `{provider:{providerKey, displayName}, messages: InboxMessageRow[], page:{limit, nextBefore}}`. Keyset pagination: `limit` 1..200 default 50, `before` ISO timestamp; fetch limit+1 to compute `nextBefore` = last item's `received_at`. `InboxMessageRow = {id, household_slug, provider_key, provider_display_name, subject, from_header, text_body, extracted_code, status, received_at}` |
+| PATCH | `/api/inbox/:slug/messages/:messageId/status` | 404 `"Message not found"`; member without access to the message's provider → 403; body `{status: new|used|expired}`; `{message: InboxMessageRow}` |
+| GET | `/api/inbox/:slug/quarantine?limit&before` | **owner**. `{messages: QuarantineMessageRow[], page}`; rows unreviewed only; `QuarantineMessageRow = {id, household_slug, provider_key:"quarantine", provider_display_name:"Quarantine", subject, from_header, envelope_from, text_body, extracted_code, status:"new", quarantine_reason, received_at}` |
+| POST | `/api/inbox/:slug/quarantine/:messageId/review` | **owner**. Body `{action: dismiss|release, providerKey?}`. release without providerKey → 400 `"providerKey is required to release a message"`; unknown provider → 404 `"Provider not found"`; unknown or already reviewed message → 404 `"Quarantine message not found"`. Release inserts a copy into `messages` (status new, classification_reason `"Released from quarantine by owner review. Original reason: <reason>"`, same received_at/delete_after, `ON CONFLICT DO NOTHING` on (household_id, message_id)) and marks reviewed, in one transaction. Response `{reviewedAt, releasedMessage: InboxMessageRow|null}`. Audit `quarantine.dismiss`/`quarantine.release` (target quarantine_message, details `{providerKey}` when present) |
+
+### Admin (`src/server/routes/admin/*`) — **owner** of `:slug`
+
+| Method | Path | Behaviour |
+|---|---|---|
+| GET | `/api/admin/:slug/audit` | `{events: AuditEventRecord[]}` newest 100; `{id, actorUserId, householdId, action, targetType, targetId, details (parsed JSON or null), createdAt}` |
+| GET | `/api/admin/:slug/settings` | `{household: {slug, displayName, emailAddress}}`; `emailAddress = slug@EMAIL_DOMAIN` |
+| PATCH | `/api/admin/:slug/settings` | body `{displayName}`; updates, audit `household.settings_updated` (details `{displayName}`); same response |
+| GET | `/api/admin/:slug/providers` | `{providers: ProviderConfigurationRow[], rules: SenderRuleRow[]}`; providers `{id, household_id, provider_key, display_name, created_at, rule_count}` by display_name; rules `{id, household_id, provider_id, match_type, match_value, created_at}` by created_at, match_value |
+| POST | `/api/admin/:slug/providers` | body `{providerKey, displayName}`; key taken → 409 `"Provider key already exists"`; `201 {provider: ProviderRow}`; audit `provider.created` |
+| PATCH | `/api/admin/:slug/providers/:providerId` | 404 `"Provider not found"`; key conflict with another → 409; `{provider}`; audit `provider.updated` |
+| DELETE | `/api/admin/:slug/providers/:providerId` | 404; cascades rules, messages, access; `{ok:true}`; audit `provider.deleted` |
+| POST | `/api/admin/:slug/provider-rules` | body `{providerId, matchType, matchValue}`; provider not in household → 404 `"Provider not found"`; `201 {rule}`; duplicate (household, type, value) → 409 via error handler; audit `sender_rule.created` |
+| PATCH | `/api/admin/:slug/provider-rules/:ruleId` | 404 provider / 404 `"Sender rule not found"`; `{rule}`; audit `sender_rule.updated` |
+| DELETE | `/api/admin/:slug/provider-rules/:ruleId` | 404; `{ok:true}`; audit `sender_rule.deleted` |
+| GET | `/api/admin/:slug/members` | `{members: [{id, householdRole, email, name, role, createdAt, updatedAt, providerAccess:[{providerKey, displayName}]}], providers: ProviderRow[]}`; members ordered by user created_at. (`role` duplicates `householdRole`; the TS `role` column is Better Auth's global role — Go returns `householdRole` in both) |
+| POST | `/api/admin/:slug/members` | body `{email, name, role}` → same as creating an invitation with no provider scope (below) |
+| DELETE | `/api/admin/:slug/members/:userId` | self → 400 `"Use 'Leave household' to remove yourself."`; not a member → 404 `"Member not found"`; last owner → 409 `"A household must keep at least one owner."`; remove; log `member_removed`; audit `member.removed`; `{ok:true}` |
+| PATCH | `/api/admin/:slug/members/:userId/role` | self → 403 `"Cannot change your own role. Ask another admin."`; body `{role}`; 404; update; audit `member.role_changed` (details `{role}`); `{ok:true}` |
+| POST | `/api/admin/:slug/members/:userId/provider-access` | body `{providerKey}`; 404 provider / 404 member; grant (idempotent); audit `member.provider_access_granted`; `{ok:true}` |
+| DELETE | `/api/admin/:slug/members/:userId/provider-access/:providerKey` | (TS also accepted a JSON body without the path param; Go: path param only, spec-validated); 404s; revoke; audit `member.provider_access_revoked`; `{ok:true}` |
+| GET | `/api/admin/:slug/invitations` | first expires pending invitations past `expires_at` for this household; `{invitations: Invitation[]}` newest first; `Invitation = {id, householdId, email, name, role, status, invitedByUserId, acceptedByUserId, expiresAt, acceptedAt, cancelledAt, createdAt, updatedAt, providers:[{id, provider_key, display_name}]}` |
+| POST | `/api/admin/:slug/invitations` | body `{email, name, role="member", providerIds=[]}`; any providerId outside the household → 400 `"One or more selected providers do not belong to this household"`; creates (A3 invitations); `201 {invitation, inviteUrl, emailSent, emailError?}`; audit `invitation.created` (details `{email, role, emailSent}`) |
+| POST | `/api/admin/:slug/invitations/:invitationId/resend` | expires stale first; not pending → 404 `"Invitation not found or not resendable"`; cancels old, creates new with same email/name/role/providers; `200 {invitation, inviteUrl, emailSent, emailError?}`; audit `invitation.resent` (details `{email, replaces, emailSent}`) |
+| DELETE | `/api/admin/:slug/invitations/:invitationId` | 404 `"Invitation not found"`; sets cancelled; audit `invitation.cancelled`; `{ok:true}` |
+
+### Invitations (`src/server/routes/invitations.ts`) — public, rate `invitations`
+
+Token travels in header `X-Invitation-Token` (never in the URL). Missing →
+`400 {"error":"Invitation token header is required"}`. Lookup by SHA-256 hex
+of the token.
+
+| Method | Path | Behaviour |
+|---|---|---|
+| GET | `/api/invitations/lookup` | not pending → 404 `"Invitation not found or no longer valid"`; expired → 410 `"This invitation has expired"`; `{invitation, household:{displayName}|null, invitedBy:{name}|null, accountExists, viewer: {email, emailMatches}|null}` |
+| POST | `/api/invitations/accept` | same 404/410. Signed-in user: email mismatch (case-insensitive) → 403 `"You are signed in as a different account. Sign out and accept the invitation with the invited email address."`; else accept as that user → `200 {member:{id,email,name,role}, household}`. Anonymous: body `{name, password}` required (400 with `"<path>: <message>"` on failure, `"Invalid JSON body"` on bad JSON); account for the email exists → `409 {error:"An account with the invited email already exists. Sign in with it, then open the invitation link again.", code:"ACCOUNT_EXISTS"}`; else create user, accept → `201 {member, household}` **with session cookie**. Failure after user creation deletes the user; auth errors pass through with their status; else 500 `"Unable to accept invitation"` |
+
+`acceptInvitation` (repository): upsert membership with the invitation's
+role, mark invitation accepted (`accepted_by_user_id`, `accepted_at`), copy
+invitation provider scope into `household_member_provider_access`
+(idempotent) — one transaction.
+
+### Settings (`src/server/routes/settings.ts`) — session required
+
+| Method | Path | Behaviour |
+|---|---|---|
+| GET | `/api/settings` | `{profile: {id, email, name, image, role, twoFactorEnabled, households: HouseholdSummary[]}, sessions: [{id, isCurrent, expiresAt, ipAddress, userAgent, createdAt, updatedAt, impersonatedBy}]}` newest session first. Go: `role` is `null`, `impersonatedBy` is `null`, `ipAddress` is the stored digest (opaque) |
+| GET | `/api/settings/households` | `{households: HouseholdSummary[]}` |
+| PATCH | `/api/settings/profile` | body `{name, image?}` (image "" → null); `{profile}` |
+| DELETE | `/api/settings/sessions/others` | revokes every other session; audit `session.revoked_others` (no household); `{ok:true}` |
+| DELETE | `/api/settings/sessions/:sessionId` | revokes that session if it belongs to the user (silently no-op otherwise); audit `session.revoked` (target session); `{ok:true}` |
+
+### Inbound mail (Go only)
+
+| Method | Path | Behaviour |
+|---|---|---|
+| POST | `/api/inbound/mailgun/mime` | Part C. Not in the OpenAPI spec (multipart form from a third party); mounted directly and excluded from the same-site check (Mailgun sends no Origin). |
+
+## A3. Domain rules
+
+### Household slug (`src/server/domain/household-slug.ts`)
+
+Lower-case, 2..40 chars, `^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$`, not in the
+reserved set: `api admin assets cdn-cgi favicon.ico forgot-password health
+households household inbox invite invitations login logout members
+new-household postmaster providers quarantine reset-password settings setup
+static two-factor abuse noreply no-reply hostmaster webmaster`. Go adds
+`healthz readyz`. Error messages: `"slug is required"`, `"slug must be
+between 2 and 40 characters"`, `"slug may only contain lowercase letters,
+numbers, and hyphens, and must start and end with a letter or number"`,
+`"\"<slug>\" is reserved and cannot be used as a household slug"`.
+
+### Invitations (`src/server/domain/invitations.ts`)
+
+- Token = random UUID; stored as SHA-256 hex (`token_hash`, unique).
+- TTL 7 days; `invite URL = APP_URL(without trailing slash)/invite/<token>`.
+- Email delivery failure is **not** an error: `{emailSent:false, emailError}`
+  plus log `invitation_email_failed`; the owner shares the link manually.
+- Resend = cancel + create with the same email, name, role, providers.
+
+### Classification (`src/server/domain/classify-email.ts`)
+
+`classifyEmail(parsed)`:
+1. `code = extractVerificationCode(textBody)` (always computed).
+2. No `householdSlug` → quarantine `{householdId:null, reason:"No household
+   slug could be resolved from the recipient address."}`.
+3. Slug not found → quarantine `{householdId:null, reason:"No household
+   matched the inbound recipient address."}`.
+4. `findProviderMatch(householdId, candidates)` where candidates are
+   `[fromAddress (source "header") if present, envelopeFrom (source
+   "envelope")]`, trimmed, lower-cased, de-duplicated. Exact rules first
+   (any candidate, in order), then domain rules (domain equals or candidate
+   domain ends with `.` + rule value; longest rule wins). No match →
+   quarantine `"No sender rule matched the inbound email within the
+   addressed household."`.
+5. `authenticationVerdict(auth, matchedSource)`: `auth == nil` → trusted;
+   `dmarc=fail` → untrusted `"dmarc=fail"`; header source needs
+   `dkim=pass` or `dmarc=pass` else `"From header not authenticated
+   (dkim=<v|none>, dmarc=<v|none>)"`; envelope source needs `spf=pass` else
+   `"envelope sender not authenticated (spf=<v|none>)"`. Untrusted →
+   quarantine `"Sender <addr> matched provider <key> but sender
+   authentication failed: <reason>."`.
+6. Matched → `{kind:"matched", householdId, householdSlug, providerId,
+   providerKey, code, reason}` with reason `"Sender matched a configured rule
+   and a likely verification code was found."` when code ≠ null else
+   `"Sender matched a configured rule."`.
+
+### Code extraction (`src/server/domain/extract-code.ts`)
+
+Port verbatim, including the regexes:
+- keyword pattern (case-insensitive, word-bounded):
+  `(?:(?:verification|verify|security|one[- ]?time|login|log-?in|sign[- ]?in|access|confirmation|auth(?:entication|orization)?|2fa|two[- ]factor)\s+(?:code|pin|passcode|password|otp)|passcode|otp|pin\s+code|code|kode|c[oó]digo|codice)`
+- window: 80 chars after each keyword; token scan `[A-Za-z0-9][A-Za-z0-9 -]*[A-Za-z0-9]|[A-Za-z0-9]`;
+  a token is rejected when the 2 chars before it end with `#$€£+%` or `&#`.
+- a token run is split at digit/non-digit boundaries on space or hyphen,
+  each piece tried, then each single sub-token.
+- `codeFromChunk`: `^(\d{3,4})[ -](\d{3,4})$` → joined; all digits → 4..8
+  long and not `19xx`/`20xx`; `^[A-Z0-9]{5,10}$` with ≥1 digit and ≥1
+  uppercase letter → itself; else null.
+- fallback without keyword: collect distinct `\b(\d{3}[ -]\d{3}|\d{6})\b`
+  (normalised, not year-like, not symbol-preceded); exactly one → it.
+- Go regexp has no lookbehind: implement the split with a small loop over
+  runes instead of the `(?<=…)` regex.
+
+Test cases (`test/extract-code.test.ts`), all must pass in Go:
+
+| input | expected |
+|---|---|
+| `Your verification code is 654321` | `654321` |
+| `Your verification code is valid for 10 minutes: 482913` | `482913` |
+| `Your verification code will expire soon.\n\n482913` | `482913` |
+| `Enter the security code below to continue\n\n771122` | `771122` |
+| `Your code: 123-456` | `123456` |
+| `Your code is 123 456` | `123456` |
+| `Ihr Code lautet 123456` | `123456` |
+| `Tu código de verificación es 998877` | `998877` |
+| `OTP: 4821` | `4821` |
+| `Your one-time passcode is 7K3PQ2` | `7K3PQ2` |
+| `Sign-in code\n\n445566\n\nThis code expires in 5 minutes.` | `445566` |
+| `Use this PIN code 2468 to unlock` | `2468` |
+| `Use 112233 to finish signing in` | `112233` |
+| `Welcome back, there is nothing to verify here.` | null |
+| `© 2024 Netflix, Inc. 100 Winchester Circle, Los Gatos, CA 95032` | null |
+| `Order #123456 has shipped. Track it at 555 0100 ext 4433` | null |
+| `Two codes 111111 and 222222 are both in here` | null |
+| `Your code is valid until 2026. Thanks!` | null |
+| `Promo code SUMMER applies; nothing numeric` | null |
+
+### Email parsing (`src/server/email/parse.ts`)
+
+`ParsedIncomingEmail = {envelopeFrom, envelopeTo, householdSlug (local part
+of envelopeTo lower-cased if it matches ^[a-z0-9-]+$ else null), fromHeader
+(raw From header), fromAddress (lower-cased address from From, or null),
+authentication {spf,dkim,dmarc}|null, subject|null, messageId (Message-ID
+header or synthetic `<synthetic-<first 32 hex of sha256(from\0to\0date\0subject\0body)>@mi-casa-su-casa>`),
+dateHeader|null, textBody, textBodyTruncated, rawSize}`.
+
+- textBody = trimmed text part, else `stripHtml(html)`, else
+  `"[empty email body]"`; cut at 65536 chars with `"\n[truncated]"` appended.
+- `stripHtml`: remove comments and `style|script|head|title` blocks, tags →
+  space, decode entities (`&nbsp;`→space, `&amp; &lt; &gt; &quot; &apos;
+  &#39;`, numeric and hex), collapse whitespace, trim.
+- `parseAuthenticationResults(values)`: first `spf=|dkim=|dmarc=<word>`
+  per mechanism across all `Authentication-Results` headers, lower-cased;
+  null when there are no such headers.
+- Go adds Mailgun headers (Part C) as the primary source of spf/dkim.
+
+### Message storage (`src/server/db/repositories/messages.ts`)
+
+- `received_at` = server clock (never the Date header); `delete_after` =
+  received_at + 30 days; `date_header` = parsed Date header as ISO or null.
+- Insert is idempotent on `(household_id, message_id)`: a duplicate is
+  swallowed (ON CONFLICT DO NOTHING).
+- Retention purge: delete rows with `delete_after <= now` in batches of 500
+  per table; returns `{messages, quarantine, batches}`.
+
+### Retention job (`src/server/jobs/retention.ts`)
+
+`purgeExpired`, `refreshExpiredInvitations(now)` (all households), then
+`recordRetentionRun(nowIso)`; log `retention_completed {scheduledFor,
+messagesPurged, quarantinePurged, batches, durationMs}` or
+`retention_failed`. Schedule `0 3 * * *` UTC.
+
+### Inbound handler (`src/server/email/handler.ts`)
+
+- `rawSize > 2 MiB` → reject `"Message too large"` (log `email_rejected
+  reason=too_large`).
+- parse failure → reject `"Message could not be parsed"` (log
+  `email_parse_failed`).
+- quarantine with unknown household → reject `"Unknown recipient"` (log
+  `email_rejected reason=unknown_recipient`).
+- unreviewed quarantine count ≥ 200 → reject `"Mailbox quarantine is full"`
+  (log `email_rejected reason=quarantine_full`).
+- else insert quarantine (log `email_quarantined`) or message (log
+  `email_stored {householdId, providerKey, codeFound, truncated}`).
+- unexpected error → log `email_ingest_failed`, propagate (temporary failure).
+
+Go mapping: reject → HTTP 406; stored/quarantined → 200 `{ok:true,
+outcome:"stored"|"quarantined"}`; unexpected → 500.
+
+### Outbound mail (`src/server/email/sender.ts`)
+
+Two messages, text and HTML bodies verbatim:
+- Password reset: subject `Reset your Mi Casa Su Casa password`; text lines
+  `Hi <name|there>,` / blank / `We received a request to reset your Mi Casa
+  Su Casa password.` / `Use this link to choose a new password: <url>` /
+  blank / `If you did not request this, you can safely ignore this email.`
+- Invitation: subject `<inviterName> invited you to Mi Casa Su Casa`; text
+  `Hi <inviteeName>,` / blank / `<inviterName> (<inviterEmail>) invited you
+  to join Mi Casa Su Casa as a <Owner|Member>.` / `Accept the invitation
+  here: <url>` / `This invite expires on <expiresAt>.`
+HTML versions escape every interpolated value.
+
+## A4. Request schemas (`src/server/http/schemas.ts`)
+
+| Schema | Rules |
+|---|---|
+| email | trim, lower-case, 3..254, `^[^\s@]+@[^\s@]+\.[^\s@]+$` |
+| password | 12..128 (not trimmed) |
+| role | `owner|member` (`admin` accepted and mapped to owner) |
+| householdSlug | trim, lower-case, slug rules (A3) |
+| householdSettings | `{displayName: trimmed 1..80}` |
+| createHousehold | `{slug, displayName}` |
+| provider | `{providerKey: trim, lower, 1..40, ^[a-z0-9][a-z0-9-]*$, displayName 1..80}` |
+| senderRule | `{providerId 1..64, matchType exact|domain, matchValue trim lower 1..254}`; domain: strip leading `@`, must match hostname regex `^(?=.{1,253}$)([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$` else `"matchValue must be a domain like netflix.com"`; exact: must be a valid email else `"matchValue must be a full email address"` |
+| invitation | `{email, name 1..80, role default member, providerIds string[] ≤50 default []}` |
+| createMember | `{email, name, role default member}` |
+| roleChange | `{role}` |
+| providerAccess | `{providerKey 1..40 lower}` |
+| profile | `{name 1..80, image?: "" or http(s) URL ≤2048}` → image null when empty |
+| setup | `{email, name, password, householdName 1..80, householdSlug, setupSecret non-empty}` |
+| acceptInvitation | `{name, password}` |
+| quarantineReview | `{action dismiss|release, providerKey? 1..40 lower}` |
+| messageStatus | `{status new|used|expired}` |
+
+Messages: `"<field> is required"`, `"<field> must be at most N characters"`,
+`"password must be at least 12 characters"`, `"role must be owner or member"`,
+`"matchType must be exact or domain"`, `"action must be dismiss or release"`,
+`"status must be new, used or expired"`, `"email must be a valid email
+address"`, `"providerKey may only contain lowercase letters, numbers and
+hyphens"`, `"image must be an http(s) URL"`.
+
+## A5. Schema (Postgres translation of `migrations/*.sql`)
+
+All ids are `text` UUIDs generated by the app. Timestamps become
+`timestamptz` (TS stored ISO text / epoch ms). JSON details become `jsonb`.
+
+Limen-owned (see B4): `users`, `sessions`, `accounts`, `verifications`,
+`rate_limits`, `two_factors`; plus our columns on `users`: `name text NOT
+NULL DEFAULT ''`, `image text`, `two_factor_enabled boolean NOT NULL DEFAULT
+false`.
+
+App tables:
+
+```
+households(id pk, slug text unique, display_name text, created_at, updated_at)
+household_memberships(id pk, household_id fk cascade, user_id fk users cascade,
+  role text check in (owner, member), created_at, updated_at,
+  unique(household_id, user_id), idx household_id, idx user_id)
+providers(id pk, household_id fk cascade, provider_key text, display_name text,
+  created_at, unique(household_id, provider_key), idx household_id)
+household_member_provider_access(id pk, household_membership_id fk cascade,
+  provider_id fk cascade, created_at, unique(membership, provider), idx both)
+sender_rules(id pk, household_id fk cascade, provider_id fk cascade,
+  match_type check in (exact, domain), match_value text, created_at,
+  unique(household_id, match_type, match_value), idx(household_id, match_type, match_value))
+messages(id pk, message_id text, household_id fk cascade, provider_id fk cascade,
+  envelope_from, envelope_to, from_header null, subject null, text_body,
+  extracted_code null, status check in (new, used, expired) default new,
+  classification_reason, raw_size int, date_header timestamptz null,
+  received_at timestamptz, delete_after timestamptz, created_at,
+  unique(household_id, message_id), idx(household_id, provider_id, received_at),
+  idx(household_id, received_at), idx(delete_after))
+quarantine_messages(id pk, message_id, household_id fk cascade, envelope_from,
+  envelope_to, from_header, subject, text_body, extracted_code, quarantine_reason,
+  raw_size, date_header, received_at, delete_after, reviewed_at null, created_at,
+  unique(household_id, message_id), idx(household_id, received_at), idx(delete_after))
+audit_events(id pk, actor_user_id null, household_id null, action, target_type,
+  target_id null, details jsonb null, created_at, idx(household_id, created_at))
+app_installation(id int pk check id=1, status check in (pending, in_progress, complete),
+  owner_user_id null, owner_email null, completed_at null, created_at, updated_at,
+  last_retention_run_at null)
+household_invitations(id pk, household_id fk cascade, email, name, role check,
+  token_hash unique, status check in (pending, accepted, cancelled, expired),
+  invited_by_user_id fk users cascade, accepted_by_user_id fk users set null,
+  expires_at timestamptz, accepted_at, cancelled_at, created_at, updated_at,
+  idx household_id, idx email, idx status, idx expires_at)
+household_invitation_provider_access(id pk, invitation_id fk cascade,
+  provider_id fk cascade, created_at, unique(invitation_id, provider_id))
+rate_limit(key text pk, count int default 0, expires_at timestamptz, idx expires_at)
+```
+
+`rate_limit` follows Pjokk's shape (key/count/expires_at with a `Hit`
+upsert) instead of the TS `last_request` layout; behaviour is the same fixed
+window.
+
+## A6. Audit actions
+
+`installation.setup_completed`, `household.created`, `household.settings_updated`,
+`member.left`, `member.removed`, `member.role_changed`,
+`member.provider_access_granted`, `member.provider_access_revoked`,
+`provider.created`, `provider.updated`, `provider.deleted`,
+`sender_rule.created`, `sender_rule.updated`, `sender_rule.deleted`,
+`invitation.created`, `invitation.resent`, `invitation.cancelled`,
+`quarantine.dismiss`, `quarantine.release`, `session.revoked_others`,
+`session.revoked`. Audit writes never fail the request (log
+`audit_write_failed`).
+
+## A7. Log events (`docs/operations.md`)
+
+One JSON line per event: `{"event", "level", ...fields}` on stdout/stderr.
+Events: `api_request_failed`, `unhandled_error`, `env_misconfigured` (boot
+only in Go), `email_rejected`, `email_parse_failed`, `email_quarantined`,
+`email_stored`, `email_ingest_failed`, `invitation_email_failed`,
+`password_reset_email_failed`, `member_left`, `member_removed`,
+`setup_recovered_existing_owner`, `setup_orphan_user_removed`,
+`setup_failed`, `setup_cleanup_failed`, `invitation_accept_failed`,
+`retention_completed`, `retention_failed`, `audit_write_failed`. Never log
+message bodies or codes.
+
+## A8. Auth behaviour to preserve
+
+- Password 12..128; sessions 30 days, refreshed at most daily; password reset
+  revokes other sessions; sign-up disabled on the public surface.
+- Two-factor: TOTP enrolment needs the password; backup codes; verifying a
+  TOTP or backup code completes a challenged sign-in; disable needs the
+  password.
+- Rate limits on auth routes: sign-in 5/min, request reset 3/5 min, reset
+  5/5 min, TOTP verify 5/min, backup-code verify 5/min, everything else
+  60/min.
+- Client IP: never stored raw (Go: keyed digest).
+
+---
+
+# Part B — Limen Integration (source-verified)
+
+Versions in the module cache on this machine (pin these in go.mod):
+- `github.com/thecodearcher/limen v0.2.2-0.20260813001613-c6a34aa6dcb4`
+- `github.com/thecodearcher/limen/adapters/sql` (same pseudo-version line)
+- `github.com/thecodearcher/limen/plugins/credential-password v0.2.1-0.20260813001613-c6a34aa6dcb4`
+- `github.com/thecodearcher/limen/plugins/two-factor v0.2.1-0.20260813001613-c6a34aa6dcb4`
+- npm `limen-auth` ^0.1.1 (`limen-auth/react`, `limen-auth/plugins`).
+
+If `go get` resolves newer tagged versions, take them and re-verify the
+route IDs in B3.
+
+## B1. Construction
+
+```go
+sqlDB := stdlib.OpenDBFromPool(pool)
+secret := sha256.Sum256([]byte(cfg.AuthSecret))
+instance, err := limen.New(&limen.Config{
+    BaseURL:  cfg.AppURL,
+    Database: sqladapter.NewPostgreSQL(sqlDB),
+    Secret:   secret[:],
+    Schema: limen.NewDefaultSchemaConfig(
+        limen.WithSchemaIDGenerator(uuidGenerator{}),   // text uuids
+        limen.WithSchemaUser(limen.WithUserAdditionalFields(func() map[string]limen.ColumnType { ... name, image })),
+    ),
+    Session: limen.NewDefaultSessionConfig(
+        limen.WithSessionDuration(30*24*time.Hour),
+        limen.WithSessionUpdateAge(24*time.Hour),
+        limen.WithSessionIPAddressExtractor(ipDigest),
+    ),
+    HTTP: limen.NewDefaultHTTPConfig(
+        limen.WithHTTPBasePath("/api/auth"),
+        limen.WithHTTPSessionCookieName("mi_casa_session"),
+        limen.WithHTTPCookieSecure(strings.HasPrefix(cfg.AppURL, "https://")),
+        limen.WithHTTPDisabledPaths(disabledRouteIDs()),
+        limen.WithHTTPRateLimiter(
+            limen.WithRateLimiterKeyGenerator(ipDigest),
+            limen.WithRateLimiterCustomRule("/signin/credential", 5, time.Minute),
+            limen.WithRateLimiterCustomRule("/passwords/request-reset", 3, 5*time.Minute),
+            limen.WithRateLimiterCustomRule("/passwords/reset", 5, 5*time.Minute),
+            limen.WithRateLimiterCustomRule("/two-factor/verify", 5, time.Minute),
+        ),
+    ),
+    Plugins: []limen.Plugin{
+        credentialpassword.New(
+            credentialpassword.WithPasswordMinLength(12),
+            credentialpassword.WithAutoSignInOnSignUp(false),
+            credentialpassword.WithSendPasswordResetEmail(func(email, token string) { ... }),
+            credentialpassword.WithOnPasswordResetSuccess(func(ctx, user) { revoke all sessions }),
+        ),
+        twofactor.New(
+            twofactor.WithSecret(cfg.AuthSecret),
+            twofactor.WithTOTP(twofactor.WithTOTPIssuer(cfg.AppName)),
+            twofactor.WithOTP(twofactor.WithOTPEnabled(false)),
+            twofactor.WithBackupCodes(twofactor.WithBackupCodesCount(10)),
+            twofactor.WithRevokeOtherSessionsOnStateChange(true),
+        ),
+        core, // our plugin capturing *limen.LimenCore (as Pjokk's core_plugin.go)
+    },
+})
+mux.Handle("/api/auth/", instance.Handler())
+```
+
+Exact option names in the two-factor and credential packages are listed in
+the module cache (`config.go` in each); the `sha256` of `AUTH_SECRET` is
+Limen's 32-byte requirement. `WithSchemaUser`/`WithUserAdditionalFields`
+signatures must be checked against `schema_config.go` when wiring (Pjokk's
+`auth.go` compiles against the same version and is the working example).
+
+## B2. Server-side APIs
+
+- `instance.GetSession(r) (*limen.ValidatedSession, error)` →
+  `{User *limen.User, Session *limen.Session, Refreshed *SessionResult}`.
+  `User.ID any` (string with our generator), `User.Email`, `User.Raw()` for
+  `name`, `image`, `two_factor_enabled`.
+- `instance.RevokeSession(ctx, token)`, `RevokeAllSessions(ctx, userID)`,
+  `ListSessions(ctx, userID) ([]limen.Session, error)`.
+- Credential plugin (`credentialpassword.Use(instance)`):
+  `SignUpWithCredentialAndPassword(ctx, &limen.User{Email, Password:&pw}, map[string]any{"name": name})`
+  (returns `*AuthenticationResult` with `.User`), `RequestPasswordReset(ctx,
+  email)`, `ResetPassword(ctx, token, newPassword)`, `UpdatePassword(ctx,
+  user, current, new, revokeOthers)`.
+- Core (from our capturing plugin): `core.CreateSession(ctx, r, w,
+  &limen.AuthenticationResult{User: u})` sets the session cookie on `w` —
+  used by `/api/setup/complete` and `/api/invitations/accept` to sign the new
+  user in. `core.DBAction.FindUserByEmail(ctx, email)` /
+  `FindUserByID(ctx, id)`; `limen.ErrRecordNotFound` when absent.
+- Two-factor plugin (`twofactor.Use(instance)`): `FindTwoFactorByUserID`,
+  `InitiateTwoFactorSetup(ctx, *UserWithTwoFactor, password)`,
+  `FinalizeTwoFactorSetup`, `DisableTwoFactor(ctx, userID, password)`.
+  HTTP handles the SPA's needs; the Go API is only for tests.
+- User deletion: no Limen API — `DELETE FROM users WHERE id = $1` (cascades).
+
+## B3. HTTP routes (IDs for `WithHTTPDisabledPaths`)
+
+Core: `GET /me` (`me`), `GET /sessions` (`list-sessions`), `POST /signout`
+(`signout`), `POST /revoke-sessions` (`revoke-sessions`), `verify-email`,
+`email-verifications`.
+Credential: `POST /signin/credential` (`signin`, body `{credential,
+password, rememberMe?}`), `POST /signup/credential` (`signup`), `POST
+/passwords/request-reset` (`passwords-request-reset`, `{email}`), `POST
+/passwords/reset` (`passwords-reset`, `{token, newPassword}`), `POST
+/passwords/change` (`passwords-change`, `{currentPassword, newPassword,
+revokeOtherSessions}`), `PUT /passwords` (`passwords-set`), `POST
+/usernames/check` (`usernames-check`).
+Two-factor (base `/two-factor`): `POST /initiate-setup` (`{password}` →
+`{uri}` otpauth URI), `POST /finalize-setup` (`{code}`), `POST /disable`
+(`{password}`), `POST /verify` (`{code, method?: "totp"|"otp"}`; a backup
+code is passed as `code` with method `totp` — the plugin detects the
+backup-code shape), `GET /totp/uri`, `GET /backup-codes`, `PUT
+/backup-codes` (regenerate), `POST /otp/send` (disabled).
+
+Sign-in with 2FA enabled: the plugin's after-hook on `signin` revokes the
+issued session, sets a challenge cookie and answers `200
+{"two_factor_required": true}`; the client then calls `/two-factor/verify`.
+
+**Allowed** in Mi Casa: `signin`, `signout`, `me`, `list-sessions`,
+`revoke-sessions`, `passwords-request-reset`, `passwords-reset`,
+`passwords-change`, and every two-factor route except `otp-send`.
+**Disabled**: `signup`, `passwords-set`, `usernames-check`, `verify-email`,
+`email-verifications`, `otp-send`.
+
+## B4. Schema
+
+Limen does not auto-migrate. Tables (Postgres DDL as in Pjokk's
+`00001_init.sql`, minus organizations):
+
+```sql
+CREATE TABLE "users" (
+  "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  "public_id" text NOT NULL DEFAULT gen_random_uuid()::text,
+  "first_name" text, "last_name" text,
+  "email" text NOT NULL, "password" text, "email_verified_at" timestamptz,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  "deleted_at" timestamptz,
+  "name" text NOT NULL DEFAULT '', "image" text,
+  "two_factor_enabled" boolean NOT NULL DEFAULT false,
+  CONSTRAINT "users_email_unique" UNIQUE ("email"),
+  CONSTRAINT "users_public_id_unique" UNIQUE ("public_id"));
+CREATE TABLE "sessions" (id, user_id fk cascade, token unique, created_at, expires_at, last_access, metadata text);
+CREATE TABLE "accounts" (id, user_id fk cascade, provider, provider_account_id, access_token, refresh_token, id_token, access_token_expires_at, refresh_token_expires_at, scope, created_at, updated_at, unique(provider, provider_account_id));
+CREATE TABLE "verifications" (id, identifier, value, expires_at, created_at, updated_at; idx identifier);
+CREATE TABLE "rate_limits" (id, key unique, count int default 0, expires_at);
+CREATE TABLE "two_factors" (
+  "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  "user_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "secret" text NOT NULL, "backup_codes" text NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "two_factors_user_unique" UNIQUE ("user_id"));
+```
+
+Session metadata is a JSON string holding `ip_address` (our digest) and
+`user_agent`; `/api/settings` reads them from there.
+
+## B5. TS client (`limen-auth`)
+
+```ts
+import { createAuthClient } from "limen-auth/react";
+import { credentialPasswordPlugin, twoFactorPlugin } from "limen-auth/plugins";
+
+export const authClient = createAuthClient({
+  baseURL: "",            // same origin
+  basePath: "/api/auth",
+  plugins: [
+    credentialPasswordPlugin(),
+    twoFactorPlugin({ onTwoFactorRedirect: () => {} }), // LoginPage routes itself
+  ],
+});
+// authClient.useSession()                          → { data: {user}, isPending, refetch }
+// authClient.signIn.credential({credential, password})
+// authClient.signout()
+// authClient.password.requestReset({email}); authClient.password.reset({token, newPassword});
+// authClient.password.change({currentPassword, newPassword})
+// authClient.twoFactor.initiateSetup({password}) → {uri}
+// authClient.twoFactor.finalizeSetup({code}); authClient.twoFactor.disable({password})
+// authClient.twoFactor.verify({code, method:"totp"})
+// authClient.twoFactor.getBackupCodes(); authClient.twoFactor.regenerateBackupCodes()
+```
+
+Exact method names come from each plugin's `RouteDescriptor.as` (listed in
+`node_modules/limen-auth/dist/plugins/*/index.d.mts`); confirm at install
+time. The session payload has **no** `user.id` — Limen exposes `public_id`.
+Screens that need the row id read it from `GET /api/settings` (`profile.id`).
+
+Mapping from today's Better Auth calls:
+
+| Better Auth | Limen client |
+|---|---|
+| `signIn.email({email,password})` | `signIn.credential({credential: email, password})`; response `two_factor_required` → navigate to `/two-factor` |
+| `signOut()` | `signout()` |
+| `requestPasswordReset({email, redirectTo})` | `password.requestReset({email})` (link built server-side) |
+| `resetPassword({newPassword, token})` | `password.reset({token, newPassword})` |
+| `changePassword({currentPassword,newPassword,revokeOtherSessions})` | `password.change({...})` |
+| `twoFactor.enable({password})` → totpURI + backupCodes | `twoFactor.initiateSetup({password})` → `{uri}`, then `twoFactor.getBackupCodes()` after `finalizeSetup` |
+| `twoFactor.verifyTotp({code})` (enrolment) | `twoFactor.finalizeSetup({code})` |
+| `twoFactor.verifyTotp({code})` / `verifyBackupCode({code})` (sign-in) | `twoFactor.verify({code, method:"totp"})` |
+| `twoFactor.disable({password})` | `twoFactor.disable({password})` |
+| `passkey.*` | removed |
+
+## B6. Known risks
+
+1. Both plugins are pseudo-versions; pin exactly and cover every used route
+   in `testrig` HTTP tests.
+2. Always set `WithHTTPBasePath("/api/auth")`; Limen matches full paths.
+3. Only `internal/auth` imports Limen packages.
+4. `WithSendPasswordResetEmail` receives `(email, token)` only; the reset URL
+   is `APP_URL/reset-password?token=<token>` and the user's name for the
+   greeting is looked up by email.
+
+---
+
+# Part C — Mailgun inbound contract (verified 2026-09-04)
+
+- Route: `match_recipient(".*@<EMAIL_DOMAIN>")` → `forward("https://<APP_URL>/api/inbound/mailgun/mime")`.
+  A URL ending in `mime` makes Mailgun post the raw message in the
+  `body-mime` field instead of the parsed `body-plain`/`body-html`.
+- POST is `multipart/form-data` with at least: `recipient`, `sender`
+  (envelope MAIL FROM), `from` (From header), `subject`, `body-mime`,
+  `timestamp`, `token`, `signature`, `message-headers` (JSON array), and
+  attachments (ignored).
+- Signature: `signature == hex(HMAC-SHA256(key = HTTP webhook signing key,
+  data = timestamp + token))`. Reject when the timestamp is older than 5
+  minutes or the token was seen within the last 10 minutes.
+- Authentication headers on the stored message: `X-Mailgun-Spf` (Pass,
+  Neutral, Fail, SoftFail) and `X-Mailgun-Dkim-Check-Result` (Pass, Fail);
+  only present when Mailgun evaluated them. Lower-case them into
+  `authentication.spf` / `.dkim`; `dmarc` stays null unless an
+  `Authentication-Results` header supplies one.
+- Retry semantics: Mailgun retries non-2xx responses for up to 8 hours,
+  **except 406 Not Acceptable**, which it treats as a permanent rejection.
+- Test with a recorded fixture: a multipart body with the fields above and a
+  signature computed with a known key; Go's handler tests build the same
+  form with `mime/multipart`.

--- a/docs/superpowers/specs/2026-09-04-go-backend-migration-design.md
+++ b/docs/superpowers/specs/2026-09-04-go-backend-migration-design.md
@@ -1,0 +1,465 @@
+# Go backend migration — design
+
+Date: 2026-09-04
+Status: approved; implementation in progress
+
+## Summary
+
+Mi Casa Su Casa leaves Cloudflare Workers. The backend becomes a single static
+Go binary that embeds a pre-built React SPA and runs from a distroless
+container image published to GHCR. Postgres is the only external service.
+Inbound household mail arrives through a Mailgun route webhook; outbound mail
+goes through SMTP. Auth moves from Better Auth to Limen. The frontend keeps
+React 19 and MUI but swaps React Router for TanStack Router and adopts typed
+API and auth clients.
+
+The build, release and self-hosting story is copied from Pjokk
+(github.com/refsdal/pjokk): natively built binaries, a COPY-only Dockerfile,
+GoReleaser driven by svu-computed versions, cosign-signed images, and a
+compose file for self-hosters.
+
+Decisions taken during brainstorming, in the order they were made:
+
+| Question | Decision |
+| --- | --- |
+| Inbound mail | Webhook from a mail provider, not a built-in SMTP receiver |
+| Provider | Mailgun routes |
+| Database | Postgres, like Pjokk (pgx, sqlc, goose) |
+| Auth | Limen; passkeys dropped for now |
+| Frontend | Keep MUI and the redesigned screens; swap router and client layers |
+| Existing data | Fresh start, no D1 import |
+| Landing | Incremental PRs to `main`, new code side by side with `src/` |
+
+## Goals
+
+- One image that runs anywhere Docker runs, as small as practical
+  (distroless static, non-root, no shell).
+- One process serving API, auth, webhook and SPA on one origin.
+- Feature parity with the Workers app except passkeys.
+- The existing test bar: every PR ships with tests; the Go suite runs against
+  a real Postgres.
+- Production on Cloudflare keeps deploying from `src/` until the cutover PR.
+
+## Non-goals
+
+- Importing data from D1. The Go version starts empty; `/setup` runs again.
+- Passkeys. They return as a follow-up once Limen or a custom plugin covers
+  WebAuthn.
+- A built-in SMTP listener or a second inbound provider adapter.
+- A visual redesign. Screens change only where the API or auth shape changes.
+- Kubernetes manifests. Dispatch modes make orchestration possible; the repo
+  ships compose files only.
+
+## Architecture
+
+### One process, one image, one origin
+
+```
+browser ──HTTPS──▶ reverse proxy ──▶ mi-casa (Go, :3000) ──▶ Postgres
+                                        │
+Mailgun route ──POST /api/inbound/mailgun/mime──┘
+mi-casa ──SMTP──▶ relay (Mailgun SMTP or any other)
+```
+
+The binary is also the dispatch table, selected by `argv[1]`:
+
+| Mode | Behaviour |
+| --- | --- |
+| (none) | apply migrations under an advisory lock, then serve HTTP and run the scheduler |
+| `server` | HTTP only; never migrates, never schedules (what replicas run) |
+| `worker` | scheduler only, plus a bare `/healthz` |
+| `migrate` | apply migrations, exit 0/1 |
+| `cron retention` | run the retention job once, exit 0/1; unknown job name exits 2 |
+| `healthcheck` | probe `/healthz` on this container, exit 0/1 (the image's HEALTHCHECK) |
+
+### Repository layout
+
+```
+apps/server/                  Go module github.com/andersro93/mi-casa-su-casa/server
+  cmd/mi-casa/main.go         composition root and dispatch table
+  internal/config             env parsing and validation, all problems at once
+  internal/db                 pgx pool, goose migrations (embedded), sqlc output
+  internal/auth               Limen wiring, session helpers, user provisioning
+  internal/api                generated strict server + handlers, middleware, Deps
+  internal/mail               inbound (Mailgun, MIME parsing, classify, extract) and outbound (SMTP)
+  internal/jobs               retention
+  internal/cron               robfig/cron scheduler, UTC
+  internal/web                go:embed SPA, fallback, security headers
+  internal/testrig            Postgres + in-process HTTP rig for tests
+openapi/mi-casa.yaml          hand-written spec, single source of truth
+apps/frontend/                the SPA (moved from src/client)
+scripts/                      build-artifacts.sh, spa-embed-overlay.sh, restore-embed-overlay.sh, build-image.sh
+Dockerfile                    COPY-only, distroless static, non-root
+.goreleaser.yaml
+.mise.toml                    toolchain pins and tasks
+docker-compose.yml            build from source (contributors)
+docker-compose.selfhost.yml   pull the published image (self-hosters)
+docker-compose.test.yml       Postgres for the Go suite
+src/                          the Workers app; untouched until the cutover PR
+```
+
+### Toolchain
+
+`.mise.toml` pins Go, Bun, sqlc, oapi-codegen, goose, goreleaser, svu, cosign
+and syft. CI installs from the same file. Bun replaces npm for the frontend
+workspace; `bun.lock` is committed. Biome keeps lint and format duties.
+Generated code (oapi-codegen, sqlc) is committed; CI never runs `go generate`
+and a drift test fails when the committed output is stale.
+
+### Spec first
+
+`openapi/mi-casa.yaml` describes every `/api/*` route except Limen's own
+`/api/auth/*` surface. It drives three things:
+
+- `oapi-codegen` generates the strict server interface and types into
+  `internal/api/gen`.
+- `kin-openapi` validates every request against it as middleware.
+- `openapi-typescript` generates `apps/frontend/src/lib/api-schema.d.ts` for
+  `openapi-fetch`.
+
+`internal/api/mi-casa.yaml` is a committed copy of the root spec that exists
+only because `go:embed` cannot reach above the module root; the drift test
+compares the two.
+
+## API surface
+
+The API is a port, not a redesign. Paths, verbs, request and response shapes
+stay as they are in `src/server/routes` so screens change minimally.
+
+| Area | Routes |
+| --- | --- |
+| health | `GET /healthz`, `GET /readyz` (readiness runs a database query and reports retention staleness, as today's `/api/health/ready`) |
+| setup | `GET /api/setup/status`, `POST /api/setup/complete` |
+| households | `GET /api/households/me`, `POST /api/households`, `POST /api/households/:slug/leave` |
+| inbox | `GET /api/inbox/:slug/providers`, `GET /api/inbox/:slug/providers/:providerKey`, `PATCH /api/inbox/:slug/messages/:messageId/status`, `GET /api/inbox/:slug/quarantine`, `POST /api/inbox/:slug/quarantine/:messageId/review` |
+| admin: providers | `GET/POST /api/admin/:slug/providers`, `PATCH/DELETE /api/admin/:slug/providers/:providerId`, `POST /api/admin/:slug/provider-rules`, `PATCH/DELETE /api/admin/:slug/provider-rules/:ruleId` |
+| admin: members | `GET /api/admin/:slug/members`, `POST /api/admin/:slug/members`, `DELETE /api/admin/:slug/members/:userId`, `PATCH /api/admin/:slug/members/:userId/role`, `POST/DELETE /api/admin/:slug/members/:userId/provider-access` |
+| admin: invitations | `GET/POST /api/admin/:slug/invitations`, `POST /api/admin/:slug/invitations/:invitationId/resend`, `DELETE /api/admin/:slug/invitations/:invitationId` |
+| admin: settings | `GET /api/admin/:slug/audit`, `GET/PATCH /api/admin/:slug/settings` |
+| invitations | `GET /api/invitations/lookup`, `POST /api/invitations/accept` |
+| settings | `GET /api/settings`, `GET /api/settings/households`, `PATCH /api/settings/profile`, `DELETE /api/settings/sessions/others`, `DELETE /api/settings/sessions/:sessionId` |
+| inbound | `POST /api/inbound/mailgun/mime` |
+| auth | Limen under `/api/auth/*` (credential sign-in and sign-out, password reset, two-factor, session) |
+
+Two changes from today: the auth routes are Limen's rather than Better
+Auth's, and the inbound email entrypoint is an HTTP route rather than the
+Workers `email()` handler. `/api/health/live` and `/api/health/ready` become
+`/healthz` and `/readyz` to match Pjokk's probes and the image healthcheck.
+
+Unknown `/api/*` paths answer JSON 404 and never fall through to the SPA.
+
+## Backend components
+
+### config
+
+`internal/config` parses the environment once at startup and reports every
+problem together. Nothing else reads `os.Getenv`.
+
+| Variable | Required | Meaning |
+| --- | --- | --- |
+| `DATABASE_URL` | yes | Postgres DSN |
+| `APP_URL` | yes | public origin; must be `https://` unless `ENVIRONMENT` is `development` or `test`; drives cookie Secure and link generation |
+| `AUTH_SECRET` | yes | at least 32 characters; hashed to Limen's 32-byte key |
+| `SETUP_SECRET` | yes | one-time secret for `/setup` |
+| `OWNER_EMAIL` | yes | first owner account created by `/setup` |
+| `EMAIL_DOMAIN` | yes | domain of household inbox addresses |
+| `MAILGUN_WEBHOOK_SIGNING_KEY` | yes | verifies inbound route posts |
+| `SMTP_URL` | yes | `smtp://user:pass@host:587` or `smtps://…`; STARTTLS on `smtp://` |
+| `OUTBOUND_EMAIL_FROM` | yes | sender for invitation and reset mail |
+| `APP_NAME` | no | display name, default "Mi Casa Su Casa" |
+| `ENVIRONMENT` | no | `development`, `test` or `production` (default) |
+| `PORT` | no | default 3000 |
+| `TRUSTED_PROXY_HOPS` | no | default 0; how many `X-Forwarded-For` entries to trust |
+| `LOG_LEVEL` | no | default `info` |
+
+Misconfiguration exits before the listener opens. `/healthz` never depends on
+configuration beyond `PORT`.
+
+### db
+
+- `pgx/v5` pool built once in `cmd/mi-casa`, passed down through `Deps`.
+- `sqlc` generates typed queries from SQL files in `internal/db/queries`.
+- `goose` migrations embedded from `internal/db/migrations`, applied with
+  `pg_advisory_lock` on a single pinned connection so several containers
+  booting together serialise. The lock key is fixed and documented as
+  never-changing.
+- Schema: the current tables translated to Postgres types (`timestamptz`,
+  `text`, `boolean`, `jsonb` where the SQLite schema stored JSON strings):
+  `households`, `household_memberships`, `household_member_provider_access`,
+  `providers`, `sender_rules`, `messages`, `quarantine_messages`,
+  `household_invitations`, `household_invitation_provider_access`,
+  `audit_events`, `app_installation`, `rate_limit` (the app's own counters).
+  Limen owns `users`, `sessions`, `accounts`, `verifications`, its
+  two-factor table and its `rate_limits` table. Foreign keys from our tables
+  to Limen's user table are kept.
+- Ids are text UUIDs generated by the application, as today.
+
+### auth
+
+Limen with:
+
+- `credential-password` plugin: sign-in, sign-out, password change, reset by
+  email. Minimum password length 12, maximum 128. Reset revokes other
+  sessions.
+- `two-factor` plugin: TOTP (issuer `APP_NAME`) and backup codes; email OTP
+  disabled. State changes revoke other sessions.
+- Session: 30 days, refreshed at most daily; cookie Secure when `APP_URL` is
+  https; client address stored as a keyed digest, never raw; `TRUSTED_PROXY_HOPS`
+  decides which forwarded address counts.
+- Limen's built-in rate limiter with the same per-route budgets as today's
+  Better Auth rules (5 sign-ins per minute, 3 reset requests per 5 minutes,
+  5 resets per 5 minutes, 5 TOTP and 5 backup-code verifications per minute).
+- Sign-up disabled on the HTTP surface. Users are created only by `/setup`
+  (owner) and invitation acceptance (member), through Limen's core API from
+  our own handlers.
+- The owner/member role lives in `household_memberships` as today. There is
+  no global admin role; the `user.role` column from Better Auth is dropped.
+- Limen's public user id is different from the row id; our tables key on the
+  row id and the API exposes the row id, as Pjokk does.
+
+### api
+
+- stdlib `net/http` mux plus the generated strict server; no framework.
+- `internal/api` receives a `Deps` struct (pool, queries, auth service, mail
+  sender, clock, logger) and never reads the environment.
+- Middleware order per request: security headers, request id and structured
+  logging of failed API requests, same-site check on mutating `/api/*`
+  requests (`Sec-Fetch-Site` and `Origin` against `APP_URL`), OpenAPI request
+  validation, session loading, household scoping by slug with membership and
+  provider-access checks.
+- No CORS middleware: the SPA is same-origin. A future native client is out
+  of scope.
+- Error responses keep today's `{ "error": "…" }` shape and status codes;
+  validation failures answer 400 with the field problems.
+- The app's own rate limiter (setup: 5 per 15 minutes; invitations: 20 per 10
+  minutes; household creation: 10 per hour) uses the `rate_limit` table keyed
+  on rule name plus address digest.
+
+### mail
+
+Inbound, `POST /api/inbound/mailgun/mime`:
+
+1. Read the multipart form (limit 2 MiB for `body-mime`; larger answers 406).
+2. Verify `signature` = hex HMAC-SHA256(`MAILGUN_WEBHOOK_SIGNING_KEY`,
+   `timestamp` + `token`) with constant-time comparison; reject timestamps
+   older than 5 minutes; reject a `token` seen in the last 10 minutes
+   (in-memory set, bounded). Failures answer 401 and are logged.
+3. Require `body-mime`; parse with `emersion/go-message` into the same
+   `ParsedIncomingEmail` shape as today: envelope sender and recipient,
+   `From` header address, `Message-ID` (or the deterministic synthetic id),
+   date, subject, text body (HTML stripped to text when no text part,
+   truncated at 64 KiB with a flag), and the sender authentication verdicts.
+4. Authentication verdicts come from Mailgun's `X-Mailgun-Spf` (Pass,
+   Neutral, Fail, SoftFail) and `X-Mailgun-Dkim-Check-Result` (Pass, Fail)
+   headers, lower-cased into the existing `{spf, dkim, dmarc}` model; dmarc
+   stays null unless an `Authentication-Results` header supplies one. The
+   existing verdict rules apply unchanged: a `From`-header match needs
+   dkim=pass or dmarc=pass; an envelope match needs spf=pass; dmarc=fail is
+   never trusted.
+5. Resolve the household from the recipient local part, classify against
+   sender rules, extract the one-time code, store or quarantine.
+6. Responses: 200 on stored or quarantined; 406 for permanent rejections
+   (unknown recipient, too large, quarantine full, unparseable), which
+   Mailgun does not retry; 500 for unexpected failures so Mailgun retries.
+
+The classifier (`classify-email.ts`), code extractor (`extract-code.ts`),
+header parsing and HTML-to-text helpers are ported function for function
+with their test fixtures.
+
+Outbound: an `smtp.Sender` over `SMTP_URL` sends the password-reset and
+invitation messages with the same text and HTML bodies as today. Tests use a
+recording sender. A `MailSender` interface sits between handlers and SMTP so
+Limen's reset hook and the invitation handler share one path.
+
+### jobs and cron
+
+`internal/jobs.Retention` purges expired messages and quarantine rows in
+bounded batches, expires pending invitations and records the run in
+`app_installation`, exactly as `retention.ts`. `internal/cron` schedules it
+daily at 03:00 UTC with `robfig/cron/v3` pinned to UTC, in default and
+`worker` modes only. `cron retention` runs it once from the CLI.
+
+### web
+
+`internal/web` embeds `dist/` (a committed placeholder `index.html` keeps
+`go build` and `go test` working without a frontend build; the overlay script
+replaces it for artifacts). Static files are served with long cache headers
+for hashed assets and `no-cache` for `index.html`, `sw.js` and the manifest.
+Every non-API, non-probe path falls back to `index.html`. Security headers
+match today's Hono configuration: the CSP (self, inline styles for Emotion,
+`data:` and `https:` images, `data:` fonts, worker and manifest self,
+frame-ancestors none), HSTS, `X-Frame-Options: DENY`, no-referrer, the
+permissions policy. Probes get no SPA headers.
+
+## Frontend
+
+### Unchanged
+
+React 19, MUI v9, the theme and fonts, every screen and component under
+`src/client/components`, TanStack Query hooks, the PWA manifest and app-shell
+service worker, the Vitest and Testing Library suite.
+
+### Changed
+
+- **Move**: `src/client` becomes `apps/frontend` in one mechanical PR (Vite
+  config, tsconfig paths, test paths) before any behaviour changes.
+- **Router**: TanStack Router in code-based mode, one `router.tsx`:
+  - root: theme provider, query client, toaster
+  - public: `/login`, `/two-factor`, `/forgot-password`, `/reset-password`,
+    `/invite/$token`, `/setup`
+  - authed: `/new-household`, `/settings`, and the household shell
+    `/$slug` with children `inbox`, `inbox/$providerKey`, `quarantine`,
+    `members`, `providers`, `settings`
+  - `/` redirects to the first household's inbox or to `/new-household`
+  - guards move from `App.tsx` into `beforeLoad` with `redirect`: session
+    required, setup completed, household membership, owner-only views.
+- **Auth client**: `limen-auth/react` with the credential and two-factor
+  client plugins replaces the Better Auth client. Login, two-step
+  enrolment, backup codes, reset and the devices list adapt to Limen's
+  payloads. Passkey sections are removed from login and account settings.
+- **API client**: `openapi-fetch` typed from the spec replaces `fetchJson`.
+  Query hooks keep their names so screens change only at the call site.
+
+### Tests
+
+Existing page tests keep running. Tests that render with a React Router
+memory router switch to a TanStack memory history; tests that mock the auth
+client mock the Limen client instead. Build-time checks: typecheck,
+Biome, `vite build`.
+
+## Build, release and self-hosting
+
+### Artifacts
+
+`scripts/build-artifacts.sh` builds the SPA with Vite, overlays `dist/client`
+into `apps/server/internal/web/dist`, cross-compiles `linux/amd64` and
+`linux/arm64` with `CGO_ENABLED=0 -trimpath -ldflags "-s -w"`, and restores
+the placeholder overlay on exit. `time/tzdata` is imported so the scratch-like
+image resolves zones.
+
+### Image
+
+`Dockerfile` is COPY-only onto `gcr.io/distroless/static-debian12:nonroot`
+pinned by digest: the binary for `TARGETPLATFORM`, `PORT=3000`, `EXPOSE 3000`,
+`HEALTHCHECK CMD ["/app/mi-casa", "healthcheck"]`, `ENTRYPOINT
+["/app/mi-casa"]`. No volume is needed: the app stores nothing on disk.
+
+### CI on pull requests
+
+`test.yml` (reusable): Biome, typecheck, frontend tests, `goreleaser check`,
+`go vet`, `go test -p 1 -count=1 ./...` against a Postgres service container.
+`ci.yml`: `test.yml`, then build artifacts, build the image, smoke-test it
+(run `migrate` against a throwaway Postgres, start the default mode, wait for
+`/readyz`, `GET /` returns the SPA, `POST /api/inbound/mailgun/mime` with a
+bad signature returns 401), and push `ghcr.io/andersro93/mi-casa-su-casa:<next>-pr.<N>`
+when the PR is not from a fork.
+
+### Release on merge to main
+
+`release.yml`: svu computes the next version from Conventional Commits since
+the last `v*` tag (`--v0` rule; a manual `allow_major` input permits 1.0.0).
+Unreleasable merges end green without a release. Otherwise the workflow
+re-runs `test.yml`, tags, and GoReleaser publishes: linux archives, checksums,
+SBOMs, keyless cosign signatures over the checksum file and the images, the
+multi-arch image tagged `X.Y.Z`, `X.Y`, `X`, `latest`, `sha-<commit>`, and a
+GitHub Release with the changelog. A failed publish deletes the tag.
+
+### Self-hosting
+
+- `docker-compose.selfhost.yml`: `postgres:17-alpine` plus the published
+  image; secrets and `APP_URL` from the environment; no clone required.
+- `docker-compose.yml`: builds from source via the artifact script.
+- README "Self-hosting" section: Postgres, reverse proxy with TLS and
+  `TRUSTED_PROXY_HOPS`, SMTP credentials, Mailgun receiving domain (MX
+  records for `EMAIL_DOMAIN`), the Mailgun route
+  `match_recipient(".*@EMAIL_DOMAIN")` → `forward("https://APP_URL/api/inbound/mailgun/mime")`,
+  the HTTP webhook signing key, first-run `/setup`, upgrades (`migrate` before
+  rollout), backups (Postgres only), and `cosign verify` instructions.
+- `docs/email-routing.md` is rewritten for Mailgun; `docs/operations.md` and
+  `docs/runbook.md` are updated for container operations.
+
+### README
+
+The README is rewritten in the shape of Pjokk's: logo and one-line pitch,
+screenshots, what it does, a "Run it" quick start (`docker compose -f
+docker-compose.selfhost.yml up -d` with the three secrets), the full
+self-hosting guide (image tags and the pinning ladder, environment variable
+table, reverse proxy, Mailgun receiving, SMTP, first-run setup, upgrades,
+backups, verifying signatures), a development section (`mise install`, `bun
+install`, `docker compose -f docker-compose.test.yml up -d`, `mise run test`,
+`mise run e2e`, `mise run artifacts`, `mise run image`), the release model
+("merging is releasing"), architecture at a glance, and contributing and
+licence pointers. Cloudflare-specific sections are removed at cutover.
+
+## Testing strategy
+
+- Every TypeScript unit test file with a pure port (classifier, extractor,
+  slug, authentication verdict, HTML entities, header parsing, secrets
+  comparison) gets a Go counterpart with the same fixtures before the port
+  is considered done.
+- `internal/testrig` opens `TEST_DATABASE_URL`, applies migrations, truncates
+  between tests, and builds `api.NewHandler` with real auth, a recording mail
+  sender and a fixed clock. Route, invitation, setup, retention, tenant
+  isolation, rate limit, security header and webhook tests drive it with real
+  `http.Request` round trips.
+- Drift tests: spec copy vs root spec; committed oapi-codegen and sqlc
+  output vs fresh generation.
+- Frontend tests stay in Vitest under `apps/frontend/test`.
+- The image smoke test in CI proves the artifact runs, not only compiles.
+- **End-to-end**: a Playwright suite under `e2e/` drives the real container
+  image against a throwaway Postgres (`scripts/e2e-stack.sh up|down`, like
+  Pjokk's), never the Vite dev server. One Chromium worker, mobile profile.
+  Mail is captured rather than sent: the stack runs with `SMTP_URL` pointing
+  at a Mailpit container, and specs read invitation and reset links from
+  Mailpit's API. Inbound mail is exercised by posting a signed Mailgun-shaped
+  form to the webhook with the stack's signing key. Specs cover: first-run
+  setup, sign-in, two-factor enrolment and sign-in with a TOTP generated in
+  the test, backup-code sign-in, password reset, invitation by email and by
+  link, service and sender-rule management, an inbound message landing in
+  the inbox with its code, quarantine review and release, member removal,
+  and session revocation. `mise run e2e` wraps up, test, down; `ci.yml` runs
+  the suite after the smoke test and uploads the Playwright report.
+
+## Delivery order
+
+One issue per PR, tests first, CI green, squash-merge. Each PR leaves `main`
+deployable on Cloudflare.
+
+1. Toolchain and skeleton: `.mise.toml`, Go module, `config`, `/healthz`,
+   embed placeholder, `test.yml`, `docker-compose.test.yml`.
+2. Schema and migrations in Postgres, sqlc queries, `testrig`.
+3. Auth with Limen; `/setup`; invitation lookup and accept.
+4. Households, providers and rules, members, invitations admin, settings,
+   audit.
+5. Inbox and quarantine routes.
+6. Mail: Mailgun inbound, MIME parsing, classifier and extractor ports, SMTP
+   outbound.
+7. Retention job, cron, dispatch modes, `readyz` with retention staleness.
+8. Frontend: move to `apps/frontend`; TanStack Router; limen-auth client and
+   openapi-fetch; passkey UI removed.
+9. Dockerfile, artifact scripts, image job, GoReleaser, `release.yml`,
+   compose files.
+10. Playwright end-to-end suite, e2e stack script, Mailpit in the stack, CI
+    job.
+11. README rewrite and docs (self-hosting guide, Mailgun receiving,
+    operations, runbook).
+12. Cutover: delete `src/`, `wrangler.jsonc`, `migrations/`, the Cloudflare
+    workflows and the Cloudflare sections of the docs; update README and the
+    package description. Rolling the new deployment out and moving MX to
+    Mailgun is an operator step outside the repo.
+
+## Risks and mitigations
+
+- **Limen two-factor plugin is pre-release** (only a pseudo-version exists
+  today). Pin the commit in `go.mod`; the two-factor route tests in `testrig`
+  catch behaviour changes on upgrade.
+- **Mailgun webhook details** were checked against Mailgun's documentation
+  on 2026-09-04: a route URL ending in `mime` yields `body-mime`; posts carry
+  `timestamp`, `token` and `signature` (hex HMAC-SHA256 over timestamp plus
+  token with the HTTP webhook signing key); inbound mail carries
+  `X-Mailgun-Spf` and `X-Mailgun-Dkim-Check-Result`; 406 stops retries. The
+  handler's tests pin these with a recorded fixture.
+- **Parity gaps** are caught by porting tests alongside code; the cutover PR
+  is blocked until every route in the table above has a Go test.
+- **Password hashes do not carry over**; irrelevant under the fresh-start
+  decision.


### PR DESCRIPTION
Design spec, parity contract and implementation plan for moving Mi Casa Su Casa off Cloudflare Workers onto a single static Go binary (Limen auth, Postgres, Mailgun inbound webhook, SMTP outbound, embedded TanStack Router SPA, distroless image released by GoReleaser).

- `docs/superpowers/specs/2026-09-04-go-backend-migration-design.md` — the approved design
- `docs/superpowers/plans/2026-09-04-go-migration-reference.md` — verified inventory of the TS backend and the Limen/Mailgun contracts
- `docs/superpowers/plans/2026-09-04-go-backend-migration.md` — phase-by-phase plan (P1–P12), one PR per phase

Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yS5kEFd3AcfSkVidBs4Fj