### PR TITLE
feat(server): households, owner administration and account settings routes (P4)

### DIFF
--- a/apps/server/internal/api/admin_invitations.go
+++ b/apps/server/internal/api/admin_invitations.go
@@ -1,0 +1,279 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/andersro93/mi-casa-su-casa/server/internal/api/gen"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/api/middleware"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/auth"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/invite"
+)
+
+// Ports src/server/routes/admin/invitations.ts (REF §A2, "Admin"): issuing,
+// listing, reissuing and cancelling invitations.
+//
+// The service underneath is internal/invite, shared with "add a member"
+// because the two ARE the same act: POST /members is an invitation with no
+// provider scope. Nobody in this application is ever handed an account
+// somebody else chose a password for — an owner can only offer a link, and
+// the invitee sets their own credentials when they accept.
+//
+// Delivery is reported, not enforced (REF §A3). A self-hosted installation
+// with no working SMTP still issues usable invitations; `emailSent:false` plus
+// `inviteUrl` is what the owner needs to carry the link across by hand.
+
+// ListInvitations answers the invitations screen.
+//
+// Stale invitations are marked expired first, so the list never shows a
+// pending invitation whose link has already stopped working — the expiry is a
+// timestamp, and nothing else would notice it had passed.
+func (s server) ListInvitations(ctx context.Context, _ gen.ListInvitationsRequestObject) (gen.ListInvitationsResponseObject, error) {
+	_, household, ok := s.adminContext(ctx)
+	if !ok {
+		return gen.ListInvitations403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	if err := s.Repo.RefreshExpiredInvitations(ctx, s.Now(), &household.ID); err != nil {
+		return nil, err
+	}
+	invitations, err := s.Repo.ListInvitations(ctx, household.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	rows := make([]gen.Invitation, 0, len(invitations))
+	for _, invitation := range invitations {
+		rows = append(rows, invitationBody(invitation))
+	}
+	return gen.ListInvitations200JSONResponse{Invitations: rows}, nil
+}
+
+// CreateInvitation invites somebody, optionally scoped to a set of providers.
+func (s server) CreateInvitation(ctx context.Context, request gen.CreateInvitationRequestObject) (gen.CreateInvitationResponseObject, error) {
+	viewer, household, ok := s.adminContext(ctx)
+	if !ok {
+		return gen.CreateInvitation403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	in, problems := normalizeInvitationBody(
+		request.Body.Email, request.Body.Name, request.Body.Role, request.Body.ProviderIds)
+	if len(problems) > 0 {
+		summary, fields := envelopeFor(problems)
+		return gen.CreateInvitation400JSONResponse(errorFieldsBody(summary, fields)), nil
+	}
+
+	// Every provider id must belong to THIS household. Without the check an
+	// owner could scope an invitation to somebody else's provider, and the
+	// accept would copy that scope into a real access grant.
+	belong, err := s.Repo.ProvidersBelong(ctx, household.ID, in.ProviderIDs)
+	if err != nil {
+		return nil, err
+	}
+	if !belong {
+		return gen.CreateInvitation400JSONResponse(errorBody(
+			"One or more selected providers do not belong to this household")), nil
+	}
+
+	result, err := s.issueInvitation(ctx, viewer, household, in)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, errInvitationVanished
+	}
+	return gen.CreateInvitation201JSONResponse(invitationResultBody(*result)), nil
+}
+
+// CreateMember is "add a member", which is an invitation with no provider
+// scope — the same handler body as CreateInvitation minus the scope, and the
+// same `invitation.created` audit entry, exactly as the TypeScript had it.
+func (s server) CreateMember(ctx context.Context, request gen.CreateMemberRequestObject) (gen.CreateMemberResponseObject, error) {
+	viewer, household, ok := s.adminContext(ctx)
+	if !ok {
+		return gen.CreateMember403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	in, problems := normalizeInvitationBody(request.Body.Email, request.Body.Name, request.Body.Role, nil)
+	if len(problems) > 0 {
+		summary, fields := envelopeFor(problems)
+		return gen.CreateMember400JSONResponse(errorFieldsBody(summary, fields)), nil
+	}
+
+	result, err := s.issueInvitation(ctx, viewer, household, in)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, errInvitationVanished
+	}
+	return gen.CreateMember201JSONResponse(invitationResultBody(*result)), nil
+}
+
+// ResendInvitation reissues a pending invitation with a new token.
+func (s server) ResendInvitation(ctx context.Context, request gen.ResendInvitationRequestObject) (gen.ResendInvitationResponseObject, error) {
+	viewer, household, ok := s.adminContext(ctx)
+	if !ok {
+		return gen.ResendInvitation403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	// Expiring stale invitations first is what makes "not resendable" true of
+	// an invitation whose deadline has passed: the service only reissues a
+	// pending one.
+	if err := s.Repo.RefreshExpiredInvitations(ctx, s.Now(), &household.ID); err != nil {
+		return nil, err
+	}
+
+	result, err := invite.Resend(ctx, s.inviteDeps(), household.ID, inviterOf(viewer), request.InvitationId)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		// One message for "no such invitation" and for "not pending", so the
+		// route cannot be used to learn which invitation ids exist.
+		return gen.ResendInvitation404JSONResponse(errorBody("Invitation not found or not resendable")), nil
+	}
+
+	s.audit(ctx, viewer, household, "invitation.resent", "invitation", &result.Invitation.ID, map[string]any{
+		"email":     result.Invitation.Email,
+		"replaces":  request.InvitationId,
+		"emailSent": result.EmailSent,
+	})
+
+	return gen.ResendInvitation200JSONResponse(invitationResultBody(*result)), nil
+}
+
+// CancelInvitation makes an invitation's link stop working.
+func (s server) CancelInvitation(ctx context.Context, request gen.CancelInvitationRequestObject) (gen.CancelInvitationResponseObject, error) {
+	viewer, household, ok := s.adminContext(ctx)
+	if !ok {
+		return gen.CancelInvitation403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	invitation, err := s.Repo.GetInvitationByID(ctx, household.ID, request.InvitationId)
+	if err != nil {
+		return nil, err
+	}
+	if invitation == nil {
+		return gen.CancelInvitation404JSONResponse(errorBody("Invitation not found")), nil
+	}
+
+	if err := s.Repo.CancelInvitation(ctx, household.ID, request.InvitationId); err != nil {
+		return nil, err
+	}
+	s.audit(ctx, viewer, household, "invitation.cancelled", "invitation", &request.InvitationId, nil)
+
+	return gen.CancelInvitation200JSONResponse(okBody()), nil
+}
+
+// errInvitationVanished is the TypeScript's `!result` branch: the invitation
+// was written and then could not be read back, one statement later, from the
+// same household. Nothing removes rows in between, so this is a "cannot
+// happen" that must still not be silently successful — it becomes REF §A1 item
+// 11's logged 500 rather than the TypeScript's bespoke one, because an
+// unreachable branch does not earn a response shape of its own in the spec.
+var errInvitationVanished = errors.New("api: invitation disappeared immediately after it was created")
+
+// issueInvitation is the half CreateInvitation and CreateMember share: mint
+// the invitation, mail it, and record that it happened.
+//
+// nil, nil is the TypeScript's `!result` branch — the record vanished between
+// being written and being read back — which each caller answers itself.
+func (s server) issueInvitation(ctx context.Context, viewer *auth.Session, household *middleware.Household, in invite.Input) (*invite.Result, error) {
+	result, err := invite.Create(ctx, s.inviteDeps(), household.ID, inviterOf(viewer), in)
+	if err != nil || result == nil {
+		return nil, err
+	}
+
+	// `emailSent` is part of the trail on purpose: when somebody says they
+	// never got an invitation, the first question is whether it was ever
+	// handed to a transport.
+	s.audit(ctx, viewer, household, "invitation.created", "invitation", &result.Invitation.ID, map[string]any{
+		"email":     result.Invitation.Email,
+		"role":      result.Invitation.Role,
+		"emailSent": result.EmailSent,
+	})
+	return result, nil
+}
+
+// inviteDeps assembles the invitation service's collaborators from this
+// server's own.
+func (s server) inviteDeps() invite.Deps {
+	return invite.Deps{Repo: s.Repo, Mail: s.Mail, Now: s.Now, AppURL: s.AppURL}
+}
+
+// inviterOf is the caller as the invitation mail needs to name them.
+func inviterOf(viewer *auth.Session) invite.Inviter {
+	return invite.Inviter{ID: viewer.UserID, Name: viewer.Name, Email: viewer.Email}
+}
+
+// maxInvitationProviders is REF §A4's cap on an invitation's provider scope.
+// It is a sanity bound rather than a policy: a household with more than fifty
+// providers is not a household.
+const maxInvitationProviders = 50
+
+// normalizeInvitationBody applies REF §A4's `invitation` schema (and, with a
+// nil scope, its `createMember` schema, which is the same minus providerIds).
+func normalizeInvitationBody(rawEmail, rawName string, rawRole *string, rawProviderIDs *[]string) (invite.Input, []problem) {
+	in := invite.Input{
+		Email:       normalizeEmail(rawEmail),
+		Name:        strings.TrimSpace(rawName),
+		ProviderIDs: []string{},
+	}
+
+	var problems []problem
+	// As in validateSetupBody: the shape check runs only on an address that
+	// survived the length rule, so one empty input does not produce two
+	// messages on one control.
+	if emailProblems := appendTextProblems(nil, "email", in.Email, 254); len(emailProblems) > 0 {
+		problems = append(problems, emailProblems...)
+	} else if !emailPattern.MatchString(in.Email) {
+		problems = append(problems, problem{field: "email", message: "email must be a valid email address"})
+	}
+	problems = appendTextProblems(problems, "name", in.Name, 80)
+
+	role, roleProblems := normalizeRole(rawRole)
+	problems = append(problems, roleProblems...)
+	in.Role = role
+
+	if rawProviderIDs != nil {
+		if len(*rawProviderIDs) > maxInvitationProviders {
+			problems = append(problems, problem{
+				field:   "providerIds",
+				message: "at most " + itoa(maxInvitationProviders) + " providers can be scoped",
+			})
+		} else {
+			for _, id := range *rawProviderIDs {
+				trimmed := strings.TrimSpace(id)
+				// Each id is bounded exactly as REF §A4 bounds it. Anything
+				// outside those bounds could not name a provider anyway, so
+				// this only changes WHICH refusal the owner sees — a message
+				// against the control they used, rather than "does not belong
+				// to this household".
+				if entryProblems := appendTextProblems(nil, "providerIds", trimmed, 64); len(entryProblems) > 0 {
+					problems = append(problems, entryProblems...)
+					break
+				}
+				in.ProviderIDs = append(in.ProviderIDs, trimmed)
+			}
+		}
+	}
+
+	return in, problems
+}
+
+// invitationResultBody maps the service's result onto the wire shape.
+// `emailError` is omitted rather than sent empty when delivery succeeded, so
+// its presence alone means something went wrong.
+func invitationResultBody(result invite.Result) gen.InvitationResult {
+	body := gen.InvitationResult{
+		Invitation: invitationBody(result.Invitation),
+		InviteUrl:  result.InviteURL,
+		EmailSent:  result.EmailSent,
+	}
+	if result.EmailError != "" {
+		body.EmailError = ptr(result.EmailError)
+	}
+	return body
+}

--- a/apps/server/internal/api/admin_invitations_test.go
+++ b/apps/server/internal/api/admin_invitations_test.go
@@ -1,0 +1,373 @@
+package api_test
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	applog "github.com/andersro93/mi-casa-su-casa/server/internal/log"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/testrig"
+)
+
+// Ports test/integration/invitation-service.test.ts and the route-level half
+// of invitations-repository.test.ts: issuing, listing, reissuing and
+// cancelling invitations through the owner's routes.
+
+// inviteURLPattern is REF §A3's link shape: the app URL, /invite/, and the
+// plaintext token — which is a UUID and appears nowhere else.
+var inviteURLPattern = regexp.MustCompile(`^http://127\.0\.0\.1/invite/[0-9a-f-]{36}$`)
+
+// (inviteeEmail is declared in invitations_public_test.go.)
+
+func TestCreateInvitationMintsALinkMailsItAndKeepsTheProviderScope(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	netflix := createProvider(t, app, cookie, slug, "netflix", "Netflix")
+
+	rec := app.Do(t, http.MethodPost, adminPath(slug, "/invitations"), map[string]any{
+		"email": inviteeEmail, "name": "Kid", "role": "member", "providerIds": []string{netflix},
+	}, testrig.WithCookie(cookie))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	body := app.JSON(t, rec)
+
+	if body["emailSent"] != true {
+		t.Errorf("emailSent = %v", body["emailSent"])
+	}
+	if _, present := body["emailError"]; present {
+		t.Errorf("emailError = %v, want it absent on a successful delivery", body["emailError"])
+	}
+	inviteURL, _ := body["inviteUrl"].(string)
+	if !inviteURLPattern.MatchString(inviteURL) {
+		t.Errorf("inviteUrl = %q", inviteURL)
+	}
+
+	invitation, _ := body["invitation"].(map[string]any)
+	if invitation["email"] != inviteeEmail || invitation["role"] != "member" || invitation["status"] != "pending" {
+		t.Errorf("invitation = %v", invitation)
+	}
+	providers, _ := invitation["providers"].([]any)
+	if len(providers) != 1 {
+		t.Fatalf("providers = %v", invitation["providers"])
+	}
+	if scoped, _ := providers[0].(map[string]any); scoped["provider_key"] != "netflix" {
+		t.Errorf("scoped provider = %v", providers[0])
+	}
+	// The invitation record carries neither the token nor its hash: only the
+	// link does, and the database holds the SHA-256 alone.
+	for _, key := range []string{"token", "tokenHash", "token_hash"} {
+		if value, present := invitation[key]; present {
+			t.Errorf("invitation[%q] = %v, want it absent", key, value)
+		}
+	}
+
+	sent := app.Mail.Sent()
+	if len(sent) != 1 || sent[0].To != inviteeEmail || !strings.Contains(sent[0].Subject, "invited") {
+		t.Fatalf("sent = %+v", sent)
+	}
+	if !strings.Contains(sent[0].Text, inviteURL) {
+		t.Errorf("mail body carried no invite link: %q", sent[0].Text)
+	}
+
+	if got := app.Count(t, "audit_events", `"action" = 'invitation.created'`); got != 1 {
+		t.Errorf("invitation.created audits = %d, want 1", got)
+	}
+}
+
+// REF §A3: a failed delivery is not a failed invitation. The record stands and
+// the owner gets the link plus the reason, so they can share it by hand.
+func TestCreateInvitationReportsAFailedDeliveryWithoutLosingTheInvitation(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	app.Mail.Fail = errors.New("binding down")
+
+	logs := &bytes.Buffer{}
+	applog.SetOutput(logs)
+	t.Cleanup(func() { applog.SetOutput(nil) })
+
+	rec := app.Do(t, http.MethodPost, adminPath(slug, "/invitations"),
+		map[string]any{"email": inviteeEmail, "name": "Kid", "role": "owner"},
+		testrig.WithCookie(cookie))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	body := app.JSON(t, rec)
+	if body["emailSent"] != false || body["emailError"] != "binding down" {
+		t.Errorf("delivery = %v / %v", body["emailSent"], body["emailError"])
+	}
+	if inviteURL, _ := body["inviteUrl"].(string); !inviteURLPattern.MatchString(inviteURL) {
+		t.Errorf("inviteUrl = %q, want a usable link even so", inviteURL)
+	}
+	if got := app.Count(t, "household_invitations", "TRUE"); got != 1 {
+		t.Errorf("invitations = %d, want 1", got)
+	}
+	if !bytes.Contains(logs.Bytes(), []byte(`"event":"invitation_email_failed"`)) {
+		t.Errorf("logs = %s, want an invitation_email_failed event", logs.String())
+	}
+	// The trail records that the mail did not get out, which is the first
+	// question when somebody says the invitation never arrived.
+	if got := app.Count(t, "audit_events",
+		`"action" = 'invitation.created' AND "details" ->> 'emailSent' = 'false'`); got != 1 {
+		t.Errorf("audit did not record the failed delivery (%d rows)", got)
+	}
+}
+
+func TestCreateInvitationRefusesProvidersFromAnotherHousehold(t *testing.T) {
+	app := testrig.App(t)
+	ownerCookie, slug := app.CompleteSetup(t)
+	_, otherCookie := signUp(t, app, "other@example.com", "Other")
+	if rec := createHousehold(t, app, otherCookie, "otra"); rec.StatusCode != http.StatusCreated {
+		t.Fatalf("second household: %d", rec.StatusCode)
+	}
+	theirs := createProvider(t, app, otherCookie, "otra", "netflix", "Netflix")
+
+	rec := app.Do(t, http.MethodPost, adminPath(slug, "/invitations"), map[string]any{
+		"email": inviteeEmail, "name": "Kid", "providerIds": []string{theirs},
+	}, testrig.WithCookie(ownerCookie))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	want := "One or more selected providers do not belong to this household"
+	if got := app.JSON(t, rec)["error"]; got != want {
+		t.Errorf("error = %q", got)
+	}
+	if got := app.Count(t, "household_invitations", "TRUE"); got != 0 {
+		t.Errorf("invitations = %d, want 0", got)
+	}
+}
+
+func TestCreateInvitationValidatesTheBody(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+
+	for _, tc := range []struct {
+		name, email, memberName, field, message string
+	}{
+		{"empty email", "  ", "Kid", "email", "email is required"},
+		{"malformed email", "not-an-address", "Kid", "email", "email must be a valid email address"},
+		{"empty name", inviteeEmail, "   ", "name", "name is required"},
+		{"long name", inviteeEmail, strings.Repeat("k", 81), "name", "name must be at most 80 characters"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := app.Do(t, http.MethodPost, adminPath(slug, "/invitations"),
+				map[string]any{"email": tc.email, "name": tc.memberName},
+				testrig.WithCookie(cookie))
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+			}
+			fields, _ := app.JSON(t, rec)["fields"].(map[string]any)
+			if got := fields[tc.field]; got != tc.message {
+				t.Errorf("fields[%q] = %v, want %q", tc.field, got, tc.message)
+			}
+		})
+	}
+}
+
+// "Add a member" is an invitation with no provider scope — not an account this
+// route creates. Nobody is handed a password somebody else chose.
+func TestCreateMemberIsAnInvitationWithNoProviderScope(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	createProvider(t, app, cookie, slug, "netflix", "Netflix")
+
+	rec := app.Do(t, http.MethodPost, adminPath(slug, "/members"),
+		map[string]any{"email": inviteeEmail, "name": "Kid"}, testrig.WithCookie(cookie))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	body := app.JSON(t, rec)
+	invitation, _ := body["invitation"].(map[string]any)
+	// The role defaults to member when the property is absent (REF §A4).
+	if invitation["role"] != "member" || invitation["status"] != "pending" {
+		t.Errorf("invitation = %v", invitation)
+	}
+	if providers, _ := invitation["providers"].([]any); len(providers) != 0 {
+		t.Errorf("providers = %v, want none", providers)
+	}
+	if body["emailSent"] != true {
+		t.Errorf("emailSent = %v", body["emailSent"])
+	}
+	// No account and no membership yet: the invitee makes both when they
+	// accept.
+	if got := app.Count(t, "household_memberships", "TRUE"); got != 1 {
+		t.Errorf("memberships = %d, want 1", got)
+	}
+	if got := app.Count(t, "audit_events", `"action" = 'invitation.created'`); got != 1 {
+		t.Errorf("invitation.created audits = %d, want 1", got)
+	}
+}
+
+// The list marks stale invitations expired before it is read, so it never
+// shows a pending invitation whose link has already stopped working.
+func TestListInvitationsExpiresStaleOnesFirst(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+
+	if rec := app.Do(t, http.MethodPost, adminPath(slug, "/invitations"),
+		map[string]any{"email": inviteeEmail, "name": "Kid"}, testrig.WithCookie(cookie)); rec.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", rec.Code, rec.Body.String())
+	}
+
+	fresh := app.Do(t, http.MethodGet, adminPath(slug, "/invitations"), nil, testrig.WithCookie(cookie))
+	if fresh.Code != http.StatusOK {
+		t.Fatalf("list: %d %s", fresh.Code, fresh.Body.String())
+	}
+	invitations, _ := app.JSON(t, fresh)["invitations"].([]any)
+	if len(invitations) != 1 {
+		t.Fatalf("invitations = %v", app.JSON(t, fresh)["invitations"])
+	}
+	if entry, _ := invitations[0].(map[string]any); entry["status"] != "pending" {
+		t.Errorf("status = %v, want pending", entry["status"])
+	}
+
+	app.Advance(testrig.InvitationTTL + time.Hour)
+
+	stale := app.Do(t, http.MethodGet, adminPath(slug, "/invitations"), nil, testrig.WithCookie(cookie))
+	if stale.Code != http.StatusOK {
+		t.Fatalf("list: %d %s", stale.Code, stale.Body.String())
+	}
+	expired, _ := app.JSON(t, stale)["invitations"].([]any)
+	if entry, _ := expired[0].(map[string]any); entry["status"] != "expired" {
+		t.Errorf("status = %v, want expired", entry["status"])
+	}
+}
+
+func TestResendInvitationCancelsTheOldOneAndKeepsItsScope(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	netflix := createProvider(t, app, cookie, slug, "netflix", "Netflix")
+
+	created := app.Do(t, http.MethodPost, adminPath(slug, "/invitations"), map[string]any{
+		"email": inviteeEmail, "name": "Kid", "role": "member", "providerIds": []string{netflix},
+	}, testrig.WithCookie(cookie))
+	if created.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", created.Code, created.Body.String())
+	}
+	first, _ := app.JSON(t, created)["invitation"].(map[string]any)
+	firstID, _ := first["id"].(string)
+	firstURL, _ := app.JSON(t, created)["inviteUrl"].(string)
+
+	rec := app.Do(t, http.MethodPost, adminPath(slug, "/invitations/"+firstID+"/resend"), nil,
+		testrig.WithCookie(cookie))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("resend: %d %s", rec.Code, rec.Body.String())
+	}
+	body := app.JSON(t, rec)
+	second, _ := body["invitation"].(map[string]any)
+	secondID, _ := second["id"].(string)
+	if secondID == firstID || secondID == "" {
+		t.Errorf("resend returned the same invitation: %v", second)
+	}
+	// A NEW token, so a link that went to the wrong inbox stops working —
+	// which is the whole point of the button.
+	if secondURL, _ := body["inviteUrl"].(string); secondURL == firstURL {
+		t.Error("resend reused the old token")
+	}
+	if providers, _ := second["providers"].([]any); len(providers) != 1 {
+		t.Errorf("providers = %v, want the original scope", second["providers"])
+	}
+	if second["email"] != inviteeEmail || second["role"] != "member" || second["name"] != "Kid" {
+		t.Errorf("invitation = %v", second)
+	}
+
+	if got := app.Count(t, "household_invitations", `"status" = 'pending'`); got != 1 {
+		t.Errorf("pending invitations = %d, want 1", got)
+	}
+	if got := app.Count(t, "household_invitations", `"id" = $1 AND "status" = 'cancelled'`, firstID); got != 1 {
+		t.Error("the replaced invitation was not cancelled")
+	}
+	if sent := app.Mail.Sent(); len(sent) != 2 {
+		t.Errorf("sent = %d messages, want 2", len(sent))
+	}
+	if got := app.Count(t, "audit_events",
+		`"action" = 'invitation.resent' AND "details" ->> 'replaces' = $1`, firstID); got != 1 {
+		t.Error("the trail does not name the invitation this one replaces")
+	}
+
+	// Resending the cancelled one is refused with the same message an unknown
+	// id gets, so the route cannot be used to learn which ids exist.
+	notPending := app.Do(t, http.MethodPost, adminPath(slug, "/invitations/"+firstID+"/resend"), nil,
+		testrig.WithCookie(cookie))
+	if notPending.Code != http.StatusNotFound {
+		t.Fatalf("resend cancelled: %d %s", notPending.Code, notPending.Body.String())
+	}
+	if got := app.JSON(t, notPending)["error"]; got != "Invitation not found or not resendable" {
+		t.Errorf("error = %q", got)
+	}
+	unknown := app.Do(t, http.MethodPost, adminPath(slug, "/invitations/nope/resend"), nil,
+		testrig.WithCookie(cookie))
+	if unknown.Code != http.StatusNotFound || app.JSON(t, unknown)["error"] != "Invitation not found or not resendable" {
+		t.Errorf("resend unknown: %d %s", unknown.Code, unknown.Body.String())
+	}
+}
+
+func TestCancelInvitation(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+
+	created := app.Do(t, http.MethodPost, adminPath(slug, "/invitations"),
+		map[string]any{"email": inviteeEmail, "name": "Kid"}, testrig.WithCookie(cookie))
+	if created.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", created.Code, created.Body.String())
+	}
+	invitation, _ := app.JSON(t, created)["invitation"].(map[string]any)
+	id, _ := invitation["id"].(string)
+
+	rec := app.Do(t, http.MethodDelete, adminPath(slug, "/invitations/"+id), nil, testrig.WithCookie(cookie))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("cancel: %d %s", rec.Code, rec.Body.String())
+	}
+	if got := app.JSON(t, rec)["ok"]; got != true {
+		t.Errorf("body = %s", rec.Body.String())
+	}
+	if got := app.Count(t, "household_invitations", `"status" = 'cancelled'`); got != 1 {
+		t.Errorf("cancelled invitations = %d, want 1", got)
+	}
+	if got := app.Count(t, "audit_events", `"action" = 'invitation.cancelled'`); got != 1 {
+		t.Errorf("invitation.cancelled audits = %d, want 1", got)
+	}
+
+	unknown := app.Do(t, http.MethodDelete, adminPath(slug, "/invitations/nope"), nil, testrig.WithCookie(cookie))
+	if unknown.Code != http.StatusNotFound || app.JSON(t, unknown)["error"] != "Invitation not found" {
+		t.Errorf("cancel unknown: %d %s", unknown.Code, unknown.Body.String())
+	}
+}
+
+// An invitation belongs to the household that issued it: another household's
+// owner cannot see it, cancel it or resend it by id.
+func TestInvitationRoutesAreScopedToTheHousehold(t *testing.T) {
+	app := testrig.App(t)
+	ownerCookie, slug := app.CompleteSetup(t)
+	_, otherCookie := signUp(t, app, "other@example.com", "Other")
+	if rec := createHousehold(t, app, otherCookie, "otra"); rec.StatusCode != http.StatusCreated {
+		t.Fatalf("second household: %d", rec.StatusCode)
+	}
+
+	created := app.Do(t, http.MethodPost, adminPath(slug, "/invitations"),
+		map[string]any{"email": inviteeEmail, "name": "Kid"}, testrig.WithCookie(ownerCookie))
+	if created.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", created.Code, created.Body.String())
+	}
+	invitation, _ := app.JSON(t, created)["invitation"].(map[string]any)
+	id, _ := invitation["id"].(string)
+
+	// The other owner asks under THEIR OWN slug, where they are allowed to be,
+	// with an id that is not theirs: a 404, and nothing changes.
+	for _, tc := range []struct{ method, path string }{
+		{http.MethodDelete, adminPath("otra", "/invitations/"+id)},
+		{http.MethodPost, adminPath("otra", "/invitations/"+id+"/resend")},
+	} {
+		rec := app.Do(t, tc.method, tc.path, nil, testrig.WithCookie(otherCookie))
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("%s %s: %d %s", tc.method, tc.path, rec.Code, rec.Body.String())
+		}
+	}
+	if got := app.Count(t, "household_invitations", `"status" = 'pending'`); got != 1 {
+		t.Errorf("pending invitations = %d, want the original still pending", got)
+	}
+}

--- a/apps/server/internal/api/admin_members.go
+++ b/apps/server/internal/api/admin_members.go
@@ -1,0 +1,295 @@
+package api
+
+import (
+	"context"
+	"strings"
+
+	"github.com/andersro93/mi-casa-su-casa/server/internal/api/gen"
+	applog "github.com/andersro93/mi-casa-su-casa/server/internal/log"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/repo"
+)
+
+// Ports src/server/routes/admin/members.ts, plus the members list that lived
+// in src/server/routes/admin/invitations.ts (REF §A2, "Admin"): who is in the
+// household, what they may read, and how they leave.
+//
+// Three refusals here are invariants rather than validation, and each one is
+// worded to say what to do instead:
+//
+//   - Removing YOURSELF is a 400 pointing at "Leave household". Giving up your
+//     own access and taking somebody else's are different acts with different
+//     consequences, and they should not share a button.
+//   - Changing your OWN role is a 403 pointing at the other owners. An owner
+//     who could demote themselves could leave a household nobody administers.
+//   - Removing the LAST owner is a 409, for the same reason from the other
+//     side. LeaveHousehold enforces the identical rule (households.go).
+
+// ListMembers answers the members screen: everybody in the household with the
+// providers each may read, and the household's providers so the screen can
+// offer the rest.
+func (s server) ListMembers(ctx context.Context, _ gen.ListMembersRequestObject) (gen.ListMembersResponseObject, error) {
+	_, household, ok := s.adminContext(ctx)
+	if !ok {
+		return gen.ListMembers403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	members, err := s.Repo.ListMembers(ctx, household.ID)
+	if err != nil {
+		return nil, err
+	}
+	access, err := s.Repo.ListMemberProviderAccess(ctx, household.ID)
+	if err != nil {
+		return nil, err
+	}
+	providers, err := s.Repo.ListProviders(ctx, household.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	// One row per (member, provider) comes back from the join, including a row
+	// with null provider columns for a member with no access at all — which is
+	// why the nulls are skipped rather than turned into an empty entry.
+	accessByUser := make(map[string][]gen.MemberProviderAccess, len(members))
+	for _, row := range access {
+		if row.ProviderKey == nil || row.ProviderDisplayName == nil {
+			continue
+		}
+		accessByUser[row.ID] = append(accessByUser[row.ID], gen.MemberProviderAccess{
+			ProviderKey: *row.ProviderKey,
+			DisplayName: *row.ProviderDisplayName,
+		})
+	}
+
+	rows := make([]gen.HouseholdMember, 0, len(members))
+	for _, member := range members {
+		granted := accessByUser[member.ID]
+		if granted == nil {
+			granted = []gen.MemberProviderAccess{}
+		}
+		rows = append(rows, gen.HouseholdMember{
+			Id:            member.ID,
+			HouseholdRole: gen.HouseholdMemberHouseholdRole(member.HouseholdRole),
+			Email:         member.Email,
+			Name:          member.Name,
+			// `role` carried Better Auth's global role in the TypeScript and
+			// the SPA reads both keys; this server has no global roles, so the
+			// household role goes in each.
+			Role:           gen.HouseholdMemberRole(member.HouseholdRole),
+			CreatedAt:      member.CreatedAt,
+			UpdatedAt:      member.UpdatedAt,
+			ProviderAccess: granted,
+		})
+	}
+
+	return gen.ListMembers200JSONResponse{
+		Members:   rows,
+		Providers: providerBodies(providers),
+	}, nil
+}
+
+// RemoveMember takes somebody else out of the household.
+func (s server) RemoveMember(ctx context.Context, request gen.RemoveMemberRequestObject) (gen.RemoveMemberResponseObject, error) {
+	viewer, household, ok := s.adminContext(ctx)
+	if !ok {
+		return gen.RemoveMember403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	if viewer.UserID == request.UserId {
+		return gen.RemoveMember400JSONResponse(errorBody("Use 'Leave household' to remove yourself.")), nil
+	}
+
+	membership, err := s.Repo.GetMembership(ctx, request.UserId, household.ID)
+	if err != nil {
+		return nil, err
+	}
+	if membership == nil {
+		return gen.RemoveMember404JSONResponse(errorBody("Member not found")), nil
+	}
+
+	if membership.Role == repo.RoleOwner {
+		owners, err := s.Repo.CountOwners(ctx, household.ID)
+		if err != nil {
+			return nil, err
+		}
+		if owners <= 1 {
+			return gen.RemoveMember409JSONResponse(errorBody("A household must keep at least one owner.")), nil
+		}
+	}
+
+	// Provider access rows hang off the membership and cascade with it, so one
+	// statement takes the mailbox access away too.
+	if err := s.Repo.RemoveMember(ctx, household.ID, request.UserId); err != nil {
+		return nil, err
+	}
+
+	applog.Event(applog.LevelInfo, "member_removed", map[string]any{
+		"householdId": household.ID,
+		"userId":      request.UserId,
+		"byUserId":    viewer.UserID,
+	})
+	s.audit(ctx, viewer, household, "member.removed", "user", &request.UserId, nil)
+
+	return gen.RemoveMember200JSONResponse(okBody()), nil
+}
+
+// UpdateMemberRole promotes or demotes somebody else.
+//
+// The self-check runs BEFORE the body is read, as the TypeScript's did: an
+// owner asking to change their own role gets the same answer whether or not
+// they also sent a valid role, because the refusal is about who, not what.
+func (s server) UpdateMemberRole(ctx context.Context, request gen.UpdateMemberRoleRequestObject) (gen.UpdateMemberRoleResponseObject, error) {
+	viewer, household, ok := s.adminContext(ctx)
+	if !ok {
+		return gen.UpdateMemberRole403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	if viewer.UserID == request.UserId {
+		return gen.UpdateMemberRole403JSONResponse(errorBody("Cannot change your own role. Ask another admin.")), nil
+	}
+
+	role, problems := normalizeRole(&request.Body.Role)
+	if len(problems) > 0 {
+		summary, fields := envelopeFor(problems)
+		return gen.UpdateMemberRole400JSONResponse(errorFieldsBody(summary, fields)), nil
+	}
+
+	membership, err := s.Repo.GetMembership(ctx, request.UserId, household.ID)
+	if err != nil {
+		return nil, err
+	}
+	if membership == nil {
+		return gen.UpdateMemberRole404JSONResponse(errorBody("Member not found")), nil
+	}
+
+	if err := s.Repo.SetMemberRole(ctx, household.ID, request.UserId, role); err != nil {
+		return nil, err
+	}
+	s.audit(ctx, viewer, household, "member.role_changed", "user", &request.UserId,
+		map[string]any{"role": role})
+
+	return gen.UpdateMemberRole200JSONResponse(okBody()), nil
+}
+
+// GrantProviderAccess lets a member read one provider's messages.
+//
+// Access is per provider rather than per household because that is the whole
+// point of the product: a housemate who needs the streaming codes does not
+// thereby get to read the bank's.
+func (s server) GrantProviderAccess(ctx context.Context, request gen.GrantProviderAccessRequestObject) (gen.GrantProviderAccessResponseObject, error) {
+	viewer, household, ok := s.adminContext(ctx)
+	if !ok {
+		return gen.GrantProviderAccess403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	providerKey, problems := normalizeProviderKey(request.Body.ProviderKey)
+	if len(problems) > 0 {
+		summary, fields := envelopeFor(problems)
+		return gen.GrantProviderAccess400JSONResponse(errorFieldsBody(summary, fields)), nil
+	}
+
+	provider, membership, err := s.providerAndMember(ctx, household.ID, providerKey, request.UserId)
+	if err != nil {
+		return nil, err
+	}
+	if provider == nil {
+		return gen.GrantProviderAccess404JSONResponse(errorBody("Provider not found")), nil
+	}
+	if membership == nil {
+		return gen.GrantProviderAccess404JSONResponse(errorBody("Member not found")), nil
+	}
+
+	if err := s.Repo.GrantProviderAccess(ctx, household.ID, request.UserId, provider.ID); err != nil {
+		return nil, err
+	}
+	s.audit(ctx, viewer, household, "member.provider_access_granted", "user", &request.UserId,
+		map[string]any{"providerKey": providerKey})
+
+	return gen.GrantProviderAccess200JSONResponse(okBody()), nil
+}
+
+// RevokeProviderAccess takes a provider away from a member.
+//
+// The key comes from the path and only from the path. The TypeScript also
+// accepted it in a JSON body on DELETE — a shape no client of this app sends
+// and one that intermediaries are entitled to discard — so the Go route drops
+// that half and lets the spec validate the parameter instead.
+func (s server) RevokeProviderAccess(ctx context.Context, request gen.RevokeProviderAccessRequestObject) (gen.RevokeProviderAccessResponseObject, error) {
+	viewer, household, ok := s.adminContext(ctx)
+	if !ok {
+		return gen.RevokeProviderAccess403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	providerKey, problems := normalizeProviderKey(request.ProviderKey)
+	if len(problems) > 0 {
+		return gen.RevokeProviderAccess400JSONResponse(errorBody("providerKey is invalid")), nil
+	}
+
+	provider, membership, err := s.providerAndMember(ctx, household.ID, providerKey, request.UserId)
+	if err != nil {
+		return nil, err
+	}
+	if provider == nil {
+		return gen.RevokeProviderAccess404JSONResponse(errorBody("Provider not found")), nil
+	}
+	if membership == nil {
+		return gen.RevokeProviderAccess404JSONResponse(errorBody("Member not found")), nil
+	}
+
+	if err := s.Repo.RevokeProviderAccess(ctx, household.ID, request.UserId, provider.ID); err != nil {
+		return nil, err
+	}
+	s.audit(ctx, viewer, household, "member.provider_access_revoked", "user", &request.UserId,
+		map[string]any{"providerKey": providerKey})
+
+	return gen.RevokeProviderAccess200JSONResponse(okBody()), nil
+}
+
+// providerAndMember resolves the two things both access routes need, in the
+// TypeScript's order: the provider first, then the membership. Both lookups
+// are scoped to the household, so an id or key from elsewhere is a nil rather
+// than a cross-tenant write.
+func (s server) providerAndMember(ctx context.Context, householdID, providerKey, userID string) (*repo.Provider, *repo.Membership, error) {
+	provider, err := s.Repo.GetProviderByKey(ctx, householdID, providerKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	if provider == nil {
+		return nil, nil, nil
+	}
+	membership, err := s.Repo.GetMembership(ctx, userID, householdID)
+	if err != nil {
+		return nil, nil, err
+	}
+	return provider, membership, nil
+}
+
+// normalizeProviderKey applies REF §A4's `providerAccess` schema: trimmed,
+// lower-cased, 1..40. Deliberately no character-set check — the TypeScript's
+// schema had none here either, so a key that could never have been created is
+// simply not found.
+func normalizeProviderKey(raw string) (string, []problem) {
+	providerKey := strings.ToLower(strings.TrimSpace(raw))
+	return providerKey, appendTextProblems(nil, "providerKey", providerKey, 40)
+}
+
+// normalizeRole applies REF §A4's `role` schema: owner or member, with `admin`
+// accepted and mapped to owner (the TypeScript's zod enum did the same, for
+// clients written against the Better Auth role names), and member as the
+// default when the property is absent.
+//
+// The value is compared as sent, not trimmed or lower-cased: the TypeScript's
+// enum did neither, and quietly accepting "Owner" here would be this server
+// accepting a request its predecessor refused.
+func normalizeRole(raw *string) (string, []problem) {
+	if raw == nil {
+		return repo.RoleMember, nil
+	}
+	switch *raw {
+	case repo.RoleOwner, "admin":
+		return repo.RoleOwner, nil
+	case repo.RoleMember:
+		return repo.RoleMember, nil
+	default:
+		return "", []problem{{field: "role", message: "role must be owner or member"}}
+	}
+}

--- a/apps/server/internal/api/admin_members_test.go
+++ b/apps/server/internal/api/admin_members_test.go
@@ -1,0 +1,285 @@
+package api_test
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	applog "github.com/andersro93/mi-casa-su-casa/server/internal/log"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/testrig"
+)
+
+// Ports test/integration/membership-removal.test.ts (the admin-route half; the
+// "leave" half is in households_test.go) and the owner-only assertions of
+// tenant-isolation.test.ts.
+
+func TestListMembersReturnsRolesProviderAccessAndTheProviderList(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	app.CreateMember(t, slug, memberEmail, "Member", "member")
+	netflix := createProvider(t, app, cookie, slug, "netflix", "Netflix")
+	createProvider(t, app, cookie, slug, "spotify", "Spotify")
+
+	member, err := app.Deps.Repo.FindUserByEmail(t.Context(), memberEmail)
+	if err != nil || member == nil {
+		t.Fatalf("member: %v", err)
+	}
+	grant := app.Do(t, http.MethodPost, adminPath(slug, "/members/"+member.ID+"/provider-access"),
+		map[string]any{"providerKey": "netflix"}, testrig.WithCookie(cookie))
+	if grant.Code != http.StatusOK {
+		t.Fatalf("grant: %d %s", grant.Code, grant.Body.String())
+	}
+
+	rec := app.Do(t, http.MethodGet, adminPath(slug, "/members"), nil, testrig.WithCookie(cookie))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	body := app.JSON(t, rec)
+
+	members, _ := body["members"].([]any)
+	if len(members) != 2 {
+		t.Fatalf("members = %v", body["members"])
+	}
+	// Ordered by the account's created_at, so the owner (created by setup)
+	// comes first.
+	owner, _ := members[0].(map[string]any)
+	invited, _ := members[1].(map[string]any)
+	if owner["householdRole"] != "owner" || owner["email"] != testrig.OwnerEmail {
+		t.Errorf("owner = %v", owner)
+	}
+	// `role` duplicates `householdRole`: the SPA reads both.
+	if owner["role"] != owner["householdRole"] {
+		t.Errorf("role = %v, householdRole = %v", owner["role"], owner["householdRole"])
+	}
+	if access, _ := owner["providerAccess"].([]any); len(access) != 0 {
+		t.Errorf("owner providerAccess = %v, want []", access)
+	}
+
+	access, _ := invited["providerAccess"].([]any)
+	if len(access) != 1 {
+		t.Fatalf("member providerAccess = %v", invited["providerAccess"])
+	}
+	entry, _ := access[0].(map[string]any)
+	if entry["providerKey"] != "netflix" || entry["displayName"] != "Netflix" {
+		t.Errorf("access = %v", entry)
+	}
+
+	providers, _ := body["providers"].([]any)
+	if len(providers) != 2 {
+		t.Errorf("providers = %v", body["providers"])
+	}
+	if netflix == "" {
+		t.Error("netflix was not created")
+	}
+}
+
+// The first case of membership-removal.test.ts: an owner removes a member and
+// the provider access goes with it; a member may not remove anybody.
+func TestRemoveMemberCascadesAccessAndIsOwnerOnly(t *testing.T) {
+	app := testrig.App(t)
+	ownerCookie, slug := app.CompleteSetup(t)
+	memberCookie := app.CreateMember(t, slug, memberEmail, "Member", "member")
+
+	member, err := app.Deps.Repo.FindUserByEmail(t.Context(), memberEmail)
+	if err != nil || member == nil {
+		t.Fatalf("member: %v", err)
+	}
+	owner, err := app.Deps.Repo.FindUserByEmail(t.Context(), testrig.OwnerEmail)
+	if err != nil || owner == nil {
+		t.Fatalf("owner: %v", err)
+	}
+	createProvider(t, app, ownerCookie, slug, "netflix", "Netflix")
+	if grant := app.Do(t, http.MethodPost, adminPath(slug, "/members/"+member.ID+"/provider-access"),
+		map[string]any{"providerKey": "netflix"}, testrig.WithCookie(ownerCookie)); grant.Code != http.StatusOK {
+		t.Fatalf("grant: %d %s", grant.Code, grant.Body.String())
+	}
+	if got := app.Count(t, "household_member_provider_access", "TRUE"); got != 1 {
+		t.Fatalf("access rows = %d, want 1", got)
+	}
+
+	// A member reaching an admin route is refused by the tier, not by the
+	// handler — so it never learns whether the target exists.
+	forbidden := app.Do(t, http.MethodDelete, adminPath(slug, "/members/"+owner.ID), nil,
+		testrig.WithCookie(memberCookie))
+	if forbidden.Code != http.StatusForbidden {
+		t.Fatalf("member removing owner: %d %s", forbidden.Code, forbidden.Body.String())
+	}
+
+	logs := &bytes.Buffer{}
+	applog.SetOutput(logs)
+	t.Cleanup(func() { applog.SetOutput(nil) })
+
+	removed := app.Do(t, http.MethodDelete, adminPath(slug, "/members/"+member.ID), nil,
+		testrig.WithCookie(ownerCookie))
+	if removed.Code != http.StatusOK {
+		t.Fatalf("remove: %d %s", removed.Code, removed.Body.String())
+	}
+	if got := app.JSON(t, removed)["ok"]; got != true {
+		t.Errorf("body = %s", removed.Body.String())
+	}
+	if got := app.Count(t, "household_memberships", "TRUE"); got != 1 {
+		t.Errorf("memberships = %d, want 1", got)
+	}
+	if got := app.Count(t, "household_member_provider_access", "TRUE"); got != 0 {
+		t.Errorf("access rows = %d, want 0", got)
+	}
+	if !bytes.Contains(logs.Bytes(), []byte(`"event":"member_removed"`)) {
+		t.Errorf("logs = %s, want a member_removed event", logs.String())
+	}
+	if got := app.Count(t, "audit_events", `"action" = 'member.removed'`); got != 1 {
+		t.Errorf("member.removed audits = %d, want 1", got)
+	}
+}
+
+// The second case: removing yourself through the admin route is refused, with
+// the message that names the route which does do it.
+func TestRemoveMemberRefusesSelfAndUnknownMembers(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	owner, err := app.Deps.Repo.FindUserByEmail(t.Context(), testrig.OwnerEmail)
+	if err != nil || owner == nil {
+		t.Fatalf("owner: %v", err)
+	}
+
+	self := app.Do(t, http.MethodDelete, adminPath(slug, "/members/"+owner.ID), nil, testrig.WithCookie(cookie))
+	if self.Code != http.StatusBadRequest {
+		t.Fatalf("self: %d %s", self.Code, self.Body.String())
+	}
+	if got := app.JSON(t, self)["error"]; got != "Use 'Leave household' to remove yourself." {
+		t.Errorf("error = %q", got)
+	}
+
+	// A signed-in stranger who is not a member of this household is a 404 from
+	// the handler — the tenancy guard already established the CALLER's right
+	// to be here, so the only thing left to say is that the target is not.
+	strangerID, _ := signUp(t, app, "stranger@example.com", "Stranger")
+	unknown := app.Do(t, http.MethodDelete, adminPath(slug, "/members/"+strangerID), nil, testrig.WithCookie(cookie))
+	if unknown.Code != http.StatusNotFound {
+		t.Fatalf("unknown: %d %s", unknown.Code, unknown.Body.String())
+	}
+	if got := app.JSON(t, unknown)["error"]; got != "Member not found" {
+		t.Errorf("error = %q", got)
+	}
+	if got := app.Count(t, "household_memberships", "TRUE"); got != 1 {
+		t.Errorf("memberships = %d, want 1", got)
+	}
+}
+
+func TestUpdateMemberRole(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	app.CreateMember(t, slug, memberEmail, "Member", "member")
+	member, err := app.Deps.Repo.FindUserByEmail(t.Context(), memberEmail)
+	if err != nil || member == nil {
+		t.Fatalf("member: %v", err)
+	}
+	owner, err := app.Deps.Repo.FindUserByEmail(t.Context(), testrig.OwnerEmail)
+	if err != nil || owner == nil {
+		t.Fatalf("owner: %v", err)
+	}
+
+	promoted := app.Do(t, http.MethodPatch, adminPath(slug, "/members/"+member.ID+"/role"),
+		map[string]any{"role": "owner"}, testrig.WithCookie(cookie))
+	if promoted.Code != http.StatusOK {
+		t.Fatalf("promote: %d %s", promoted.Code, promoted.Body.String())
+	}
+	if got := app.Count(t, "household_memberships", `"role" = 'owner'`); got != 2 {
+		t.Errorf("owners = %d, want 2", got)
+	}
+	if got := app.Count(t, "audit_events", `"action" = 'member.role_changed'`); got != 1 {
+		t.Errorf("role_changed audits = %d, want 1", got)
+	}
+
+	// REF §A4: `admin` is accepted and means owner, for clients written
+	// against the Better Auth role names.
+	if rec := app.Do(t, http.MethodPatch, adminPath(slug, "/members/"+member.ID+"/role"),
+		map[string]any{"role": "admin"}, testrig.WithCookie(cookie)); rec.Code != http.StatusOK {
+		t.Fatalf("admin role: %d %s", rec.Code, rec.Body.String())
+	}
+
+	// Changing your OWN role is refused before the body is even read, so the
+	// answer is the same whatever role was asked for.
+	self := app.Do(t, http.MethodPatch, adminPath(slug, "/members/"+owner.ID+"/role"),
+		map[string]any{"role": "member"}, testrig.WithCookie(cookie))
+	if self.Code != http.StatusForbidden {
+		t.Fatalf("self: %d %s", self.Code, self.Body.String())
+	}
+	if got := app.JSON(t, self)["error"]; got != "Cannot change your own role. Ask another admin." {
+		t.Errorf("error = %q", got)
+	}
+
+	badRole := app.Do(t, http.MethodPatch, adminPath(slug, "/members/"+member.ID+"/role"),
+		map[string]any{"role": "superuser"}, testrig.WithCookie(cookie))
+	if badRole.Code != http.StatusBadRequest {
+		t.Fatalf("bad role: %d %s", badRole.Code, badRole.Body.String())
+	}
+	fields, _ := app.JSON(t, badRole)["fields"].(map[string]any)
+	if got := fields["role"]; got != "role must be owner or member" {
+		t.Errorf("fields[role] = %v", got)
+	}
+
+	strangerID, _ := signUp(t, app, "stranger@example.com", "Stranger")
+	unknown := app.Do(t, http.MethodPatch, adminPath(slug, "/members/"+strangerID+"/role"),
+		map[string]any{"role": "member"}, testrig.WithCookie(cookie))
+	if unknown.Code != http.StatusNotFound || app.JSON(t, unknown)["error"] != "Member not found" {
+		t.Errorf("unknown: %d %s", unknown.Code, unknown.Body.String())
+	}
+}
+
+func TestGrantAndRevokeProviderAccess(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	app.CreateMember(t, slug, memberEmail, "Member", "member")
+	member, err := app.Deps.Repo.FindUserByEmail(t.Context(), memberEmail)
+	if err != nil || member == nil {
+		t.Fatalf("member: %v", err)
+	}
+	createProvider(t, app, cookie, slug, "netflix", "Netflix")
+	accessPath := adminPath(slug, "/members/"+member.ID+"/provider-access")
+
+	// Granting twice is granting once: a double-click is not an error.
+	for range 2 {
+		rec := app.Do(t, http.MethodPost, accessPath,
+			map[string]any{"providerKey": "netflix"}, testrig.WithCookie(cookie))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("grant: %d %s", rec.Code, rec.Body.String())
+		}
+	}
+	if got := app.Count(t, "household_member_provider_access", "TRUE"); got != 1 {
+		t.Errorf("access rows = %d, want 1", got)
+	}
+	if got := app.Count(t, "audit_events", `"action" = 'member.provider_access_granted'`); got != 2 {
+		t.Errorf("granted audits = %d, want 2", got)
+	}
+
+	unknownProvider := app.Do(t, http.MethodPost, accessPath,
+		map[string]any{"providerKey": "spotify"}, testrig.WithCookie(cookie))
+	if unknownProvider.Code != http.StatusNotFound || app.JSON(t, unknownProvider)["error"] != "Provider not found" {
+		t.Errorf("unknown provider: %d %s", unknownProvider.Code, unknownProvider.Body.String())
+	}
+
+	strangerID, _ := signUp(t, app, "stranger@example.com", "Stranger")
+	unknownMember := app.Do(t, http.MethodPost, adminPath(slug, "/members/"+strangerID+"/provider-access"),
+		map[string]any{"providerKey": "netflix"}, testrig.WithCookie(cookie))
+	if unknownMember.Code != http.StatusNotFound || app.JSON(t, unknownMember)["error"] != "Member not found" {
+		t.Errorf("unknown member: %d %s", unknownMember.Code, unknownMember.Body.String())
+	}
+
+	// The key travels in the path on DELETE, and is lower-cased before the
+	// lookup exactly as it is on the way in.
+	revoked := app.Do(t, http.MethodDelete, accessPath+"/NetFlix", nil, testrig.WithCookie(cookie))
+	if revoked.Code != http.StatusOK {
+		t.Fatalf("revoke: %d %s", revoked.Code, revoked.Body.String())
+	}
+	if got := app.Count(t, "household_member_provider_access", "TRUE"); got != 0 {
+		t.Errorf("access rows = %d, want 0", got)
+	}
+	if got := app.Count(t, "audit_events", `"action" = 'member.provider_access_revoked'`); got != 1 {
+		t.Errorf("revoked audits = %d, want 1", got)
+	}
+
+	missing := app.Do(t, http.MethodDelete, accessPath+"/spotify", nil, testrig.WithCookie(cookie))
+	if missing.Code != http.StatusNotFound || app.JSON(t, missing)["error"] != "Provider not found" {
+		t.Errorf("revoke unknown: %d %s", missing.Code, missing.Body.String())
+	}
+}

--- a/apps/server/internal/api/admin_providers.go
+++ b/apps/server/internal/api/admin_providers.go
@@ -1,0 +1,420 @@
+package api
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/andersro93/mi-casa-su-casa/server/internal/api/gen"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/repo"
+)
+
+// Ports src/server/routes/admin/providers.ts (REF §A2, "Admin"): the
+// providers a household files mail into, and the sender rules that decide
+// which mail goes where.
+//
+// The two are one screen and two tables. A provider is the mailbox ("Netflix")
+// and a rule is a claim about who fills it ("anything from netflix.com"). They
+// are separate so a provider can be renamed without touching what matches it,
+// and so several rules — an exact address plus a domain — can point at one
+// provider.
+//
+// Uniqueness is handled at two different layers, deliberately:
+//
+//   - A duplicate provider KEY is checked before the insert, because the
+//     answer names the field ("Provider key already exists") and the same
+//     check is needed on update to tell "unchanged" from "taken".
+//   - A duplicate RULE is not checked at all. The unique index on (household,
+//     match type, match value) is the authority — two owners can add the same
+//     rule at the same moment and only the index sees both — and REF §A1 item
+//     11's global mapping turns the violation into the 409 the SPA renders
+//     (see responseErrorHandler and errors.go).
+
+// providerKeyPattern is REF §A4's `providerKey` rule: a lower-case slug that
+// starts with a letter or a digit. The key appears in URLs (the inbox route
+// addresses a provider by it), which is what the character set is for.
+var providerKeyPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+
+// hostnamePattern is REF §A4's `senderRule` domain rule verbatim, minus the
+// total-length lookahead Go's RE2 cannot express — that bound is checked
+// separately in validateSenderRuleBody.
+var hostnamePattern = regexp.MustCompile(`^([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$`)
+
+// leadingAts strips the `@` an owner naturally types in front of a domain.
+var leadingAts = regexp.MustCompile(`^@+`)
+
+// ListProviderConfigurations answers the provider settings screen: every
+// provider with its rule count, and every rule.
+func (s server) ListProviderConfigurations(ctx context.Context, _ gen.ListProviderConfigurationsRequestObject) (gen.ListProviderConfigurationsResponseObject, error) {
+	_, household, ok := s.adminContext(ctx)
+	if !ok {
+		return gen.ListProviderConfigurations403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	providers, err := s.Repo.ListProviderConfigurations(ctx, household.ID)
+	if err != nil {
+		return nil, err
+	}
+	rules, err := s.Repo.ListSenderRules(ctx, household.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	return gen.ListProviderConfigurations200JSONResponse{
+		Providers: providerConfigurationBodies(providers),
+		Rules:     senderRuleBodies(rules),
+	}, nil
+}
+
+// CreateProvider adds a provider.
+func (s server) CreateProvider(ctx context.Context, request gen.CreateProviderRequestObject) (gen.CreateProviderResponseObject, error) {
+	viewer, household, ok := s.adminContext(ctx)
+	if !ok {
+		return gen.CreateProvider403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	providerKey, displayName, problems := normalizeProviderBody(request.Body.ProviderKey, request.Body.DisplayName)
+	if len(problems) > 0 {
+		summary, fields := envelopeFor(problems)
+		return gen.CreateProvider400JSONResponse(errorFieldsBody(summary, fields)), nil
+	}
+
+	existing, err := s.Repo.GetProviderByKey(ctx, household.ID, providerKey)
+	if err != nil {
+		return nil, err
+	}
+	if existing != nil {
+		return gen.CreateProvider409JSONResponse(errorBody("Provider key already exists")), nil
+	}
+
+	provider, err := s.Repo.CreateProvider(ctx, household.ID, providerKey, displayName)
+	if err != nil {
+		// The lookup above is not a lock; the unique index decides a race, and
+		// REF §A1 item 11's mapping answers the loser with the same 409.
+		return nil, err
+	}
+
+	s.audit(ctx, viewer, household, "provider.created", "provider", &provider.ID,
+		map[string]any{"providerKey": providerKey, "displayName": displayName})
+
+	return gen.CreateProvider201JSONResponse{Provider: providerBody(provider)}, nil
+}
+
+// UpdateProvider renames a provider or changes its key.
+func (s server) UpdateProvider(ctx context.Context, request gen.UpdateProviderRequestObject) (gen.UpdateProviderResponseObject, error) {
+	viewer, household, ok := s.adminContext(ctx)
+	if !ok {
+		return gen.UpdateProvider403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	providerKey, displayName, problems := normalizeProviderBody(request.Body.ProviderKey, request.Body.DisplayName)
+	if len(problems) > 0 {
+		summary, fields := envelopeFor(problems)
+		return gen.UpdateProvider400JSONResponse(errorFieldsBody(summary, fields)), nil
+	}
+
+	existing, err := s.Repo.GetProviderByID(ctx, household.ID, request.ProviderId)
+	if err != nil {
+		return nil, err
+	}
+	if existing == nil {
+		return gen.UpdateProvider404JSONResponse(errorBody("Provider not found")), nil
+	}
+
+	// Only a conflict with a DIFFERENT provider is one: renaming a provider
+	// while leaving its key alone must not report the provider against itself.
+	conflict, err := s.Repo.GetProviderByKey(ctx, household.ID, providerKey)
+	if err != nil {
+		return nil, err
+	}
+	if conflict != nil && conflict.ID != request.ProviderId {
+		return gen.UpdateProvider409JSONResponse(errorBody("Provider key already exists")), nil
+	}
+
+	provider, err := s.Repo.UpdateProvider(ctx, household.ID, request.ProviderId, providerKey, displayName)
+	if err != nil {
+		return nil, err
+	}
+	if provider == nil {
+		return gen.UpdateProvider404JSONResponse(errorBody("Provider not found")), nil
+	}
+
+	s.audit(ctx, viewer, household, "provider.updated", "provider", &request.ProviderId,
+		map[string]any{"providerKey": providerKey, "displayName": displayName})
+
+	return gen.UpdateProvider200JSONResponse{Provider: providerBody(*provider)}, nil
+}
+
+// DeleteProvider removes a provider and everything filed under it.
+//
+// The cascade is the point rather than a convenience: a provider's messages
+// carry verification codes, and leaving them readable after the mailbox they
+// belonged to was deleted would be the opposite of what the owner asked for.
+func (s server) DeleteProvider(ctx context.Context, request gen.DeleteProviderRequestObject) (gen.DeleteProviderResponseObject, error) {
+	viewer, household, ok := s.adminContext(ctx)
+	if !ok {
+		return gen.DeleteProvider403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	provider, err := s.Repo.GetProviderByID(ctx, household.ID, request.ProviderId)
+	if err != nil {
+		return nil, err
+	}
+	if provider == nil {
+		return gen.DeleteProvider404JSONResponse(errorBody("Provider not found")), nil
+	}
+
+	if _, err := s.Repo.DeleteProvider(ctx, household.ID, request.ProviderId); err != nil {
+		return nil, err
+	}
+	s.audit(ctx, viewer, household, "provider.deleted", "provider", &request.ProviderId, nil)
+
+	return gen.DeleteProvider200JSONResponse(okBody()), nil
+}
+
+// CreateSenderRule points an address or a domain at a provider.
+func (s server) CreateSenderRule(ctx context.Context, request gen.CreateSenderRuleRequestObject) (gen.CreateSenderRuleResponseObject, error) {
+	viewer, household, ok := s.adminContext(ctx)
+	if !ok {
+		return gen.CreateSenderRule403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	rule, problems := normalizeSenderRuleBody(request.Body.ProviderId, request.Body.MatchType, request.Body.MatchValue)
+	if len(problems) > 0 {
+		summary, fields := envelopeFor(problems)
+		return gen.CreateSenderRule400JSONResponse(errorFieldsBody(summary, fields)), nil
+	}
+
+	// The provider is looked up SCOPED to this household, which is what makes
+	// a provider id from somebody else's household a 404 rather than a rule
+	// that quietly files this household's mail into theirs.
+	provider, err := s.Repo.GetProviderByID(ctx, household.ID, rule.providerID)
+	if err != nil {
+		return nil, err
+	}
+	if provider == nil {
+		return gen.CreateSenderRule404JSONResponse(errorBody("Provider not found")), nil
+	}
+
+	created, err := s.Repo.CreateSenderRule(ctx, household.ID, rule.providerID, rule.matchType, rule.matchValue)
+	if err != nil {
+		// A duplicate rule arrives here as a unique violation and leaves as
+		// the 409 REF §A1 item 11 describes. See errors.go.
+		return nil, err
+	}
+
+	s.audit(ctx, viewer, household, "sender_rule.created", "sender_rule", &created.ID, map[string]any{
+		"providerId": rule.providerID,
+		"matchType":  rule.matchType,
+		"matchValue": rule.matchValue,
+	})
+
+	return gen.CreateSenderRule201JSONResponse{Rule: senderRuleBody(created)}, nil
+}
+
+// UpdateSenderRule repoints a rule or changes what it matches.
+func (s server) UpdateSenderRule(ctx context.Context, request gen.UpdateSenderRuleRequestObject) (gen.UpdateSenderRuleResponseObject, error) {
+	viewer, household, ok := s.adminContext(ctx)
+	if !ok {
+		return gen.UpdateSenderRule403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	rule, problems := normalizeSenderRuleBody(request.Body.ProviderId, request.Body.MatchType, request.Body.MatchValue)
+	if len(problems) > 0 {
+		summary, fields := envelopeFor(problems)
+		return gen.UpdateSenderRule400JSONResponse(errorFieldsBody(summary, fields)), nil
+	}
+
+	provider, err := s.Repo.GetProviderByID(ctx, household.ID, rule.providerID)
+	if err != nil {
+		return nil, err
+	}
+	if provider == nil {
+		return gen.UpdateSenderRule404JSONResponse(errorBody("Provider not found")), nil
+	}
+	existing, err := s.Repo.GetSenderRuleByID(ctx, household.ID, request.RuleId)
+	if err != nil {
+		return nil, err
+	}
+	if existing == nil {
+		return gen.UpdateSenderRule404JSONResponse(errorBody("Sender rule not found")), nil
+	}
+
+	updated, err := s.Repo.UpdateSenderRule(ctx, household.ID, request.RuleId, rule.providerID, rule.matchType, rule.matchValue)
+	if err != nil {
+		return nil, err
+	}
+	if updated == nil {
+		return gen.UpdateSenderRule404JSONResponse(errorBody("Sender rule not found")), nil
+	}
+
+	// No matchValue in the details, matching the TypeScript: the trail records
+	// that the rule was repointed, and the rule itself carries where to.
+	s.audit(ctx, viewer, household, "sender_rule.updated", "sender_rule", &request.RuleId, map[string]any{
+		"providerId": rule.providerID,
+		"matchType":  rule.matchType,
+	})
+
+	return gen.UpdateSenderRule200JSONResponse{Rule: senderRuleBody(*updated)}, nil
+}
+
+// DeleteSenderRule removes a rule. Messages already filed under its provider
+// stay: the rule decided where new mail goes, not who owns what arrived.
+func (s server) DeleteSenderRule(ctx context.Context, request gen.DeleteSenderRuleRequestObject) (gen.DeleteSenderRuleResponseObject, error) {
+	viewer, household, ok := s.adminContext(ctx)
+	if !ok {
+		return gen.DeleteSenderRule403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	rule, err := s.Repo.GetSenderRuleByID(ctx, household.ID, request.RuleId)
+	if err != nil {
+		return nil, err
+	}
+	if rule == nil {
+		return gen.DeleteSenderRule404JSONResponse(errorBody("Sender rule not found")), nil
+	}
+
+	if _, err := s.Repo.DeleteSenderRule(ctx, household.ID, request.RuleId); err != nil {
+		return nil, err
+	}
+	s.audit(ctx, viewer, household, "sender_rule.deleted", "sender_rule", &request.RuleId, nil)
+
+	return gen.DeleteSenderRule200JSONResponse(okBody()), nil
+}
+
+// normalizeProviderBody applies REF §A4's `provider` schema: the key is
+// trimmed and lower-cased before its rules run, so what is checked is what
+// will be stored.
+func normalizeProviderBody(rawKey, rawName string) (providerKey, displayName string, problems []problem) {
+	providerKey = strings.ToLower(strings.TrimSpace(rawKey))
+	displayName = strings.TrimSpace(rawName)
+
+	// The pattern check only runs on a key that survived the length rule, so
+	// one empty input produces one message rather than two.
+	if keyProblems := appendTextProblems(nil, "providerKey", providerKey, 40); len(keyProblems) > 0 {
+		problems = append(problems, keyProblems...)
+	} else if !providerKeyPattern.MatchString(providerKey) {
+		problems = append(problems, problem{
+			field:   "providerKey",
+			message: "providerKey may only contain lowercase letters, numbers and hyphens",
+		})
+	}
+	problems = appendTextProblems(problems, "displayName", displayName, 80)
+	return providerKey, displayName, problems
+}
+
+// senderRuleInput is a validated rule body, normalised the way it will be
+// stored.
+type senderRuleInput struct {
+	providerID string
+	matchType  string
+	matchValue string
+}
+
+// maxHostnameLength is the total-length bound REF §A4's hostname regex states
+// as a lookahead. Go's RE2 has no lookahead, so it is checked here instead.
+const maxHostnameLength = 253
+
+// normalizeSenderRuleBody applies REF §A4's `senderRule` schema, including the
+// two shape rules that depend on the match type: a domain rule drops any
+// leading `@` and must then be a hostname, an exact rule must be a full
+// address.
+//
+// `matchType` is validated here rather than as an OpenAPI enum for the reason
+// stated in the spec: an enum violation cannot say "matchType must be exact or
+// domain", and that wording is what the SPA renders next to the control.
+func normalizeSenderRuleBody(rawProviderID, rawMatchType, rawMatchValue string) (rule senderRuleInput, problems []problem) {
+	rule.providerID = strings.TrimSpace(rawProviderID)
+	rule.matchType = rawMatchType
+	rule.matchValue = strings.ToLower(strings.TrimSpace(rawMatchValue))
+
+	problems = appendTextProblems(problems, "providerId", rule.providerID, 64)
+
+	switch rule.matchType {
+	case repo.MatchExact, repo.MatchDomain:
+	default:
+		problems = append(problems, problem{field: "matchType", message: "matchType must be exact or domain"})
+	}
+
+	valueProblems := appendTextProblems(nil, "matchValue", rule.matchValue, 254)
+	problems = append(problems, valueProblems...)
+	if len(valueProblems) > 0 {
+		return rule, problems
+	}
+
+	switch rule.matchType {
+	case repo.MatchDomain:
+		rule.matchValue = leadingAts.ReplaceAllString(rule.matchValue, "")
+		if len(rule.matchValue) > maxHostnameLength || !hostnamePattern.MatchString(rule.matchValue) {
+			problems = append(problems, problem{
+				field:   "matchValue",
+				message: "matchValue must be a domain like netflix.com",
+			})
+		}
+	case repo.MatchExact:
+		if len(rule.matchValue) < 3 || !emailPattern.MatchString(rule.matchValue) {
+			problems = append(problems, problem{
+				field:   "matchValue",
+				message: "matchValue must be a full email address",
+			})
+		}
+	}
+
+	return rule, problems
+}
+
+// providerBody maps a provider onto the wire shape. snake_case keys: it is
+// what the TypeScript sent and what the SPA reads.
+func providerBody(provider repo.Provider) gen.Provider {
+	return gen.Provider{
+		Id:          provider.ID,
+		HouseholdId: provider.HouseholdID,
+		ProviderKey: provider.ProviderKey,
+		DisplayName: provider.DisplayName,
+		CreatedAt:   provider.CreatedAt,
+	}
+}
+
+// providerBodies maps a list, non-nil even when empty so the key marshals as
+// `[]` rather than as null.
+func providerBodies(providers []repo.Provider) []gen.Provider {
+	rows := make([]gen.Provider, 0, len(providers))
+	for _, provider := range providers {
+		rows = append(rows, providerBody(provider))
+	}
+	return rows
+}
+
+func providerConfigurationBodies(providers []repo.ProviderConfiguration) []gen.ProviderConfiguration {
+	rows := make([]gen.ProviderConfiguration, 0, len(providers))
+	for _, provider := range providers {
+		rows = append(rows, gen.ProviderConfiguration{
+			Id:          provider.ID,
+			HouseholdId: provider.HouseholdID,
+			ProviderKey: provider.ProviderKey,
+			DisplayName: provider.DisplayName,
+			CreatedAt:   provider.CreatedAt,
+			RuleCount:   provider.RuleCount,
+		})
+	}
+	return rows
+}
+
+func senderRuleBody(rule repo.SenderRule) gen.SenderRule {
+	return gen.SenderRule{
+		Id:          rule.ID,
+		HouseholdId: rule.HouseholdID,
+		ProviderId:  rule.ProviderID,
+		MatchType:   gen.SenderRuleMatchType(rule.MatchType),
+		MatchValue:  rule.MatchValue,
+		CreatedAt:   rule.CreatedAt,
+	}
+}
+
+func senderRuleBodies(rules []repo.SenderRule) []gen.SenderRule {
+	rows := make([]gen.SenderRule, 0, len(rules))
+	for _, rule := range rules {
+		rows = append(rows, senderRuleBody(rule))
+	}
+	return rows
+}

--- a/apps/server/internal/api/admin_providers_test.go
+++ b/apps/server/internal/api/admin_providers_test.go
@@ -1,0 +1,390 @@
+package api_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/andersro93/mi-casa-su-casa/server/internal/testrig"
+)
+
+// Ports the route-level half of test/integration/provider-rules.test.ts and
+// provider-summaries.test.ts, plus the duplicate-rule case of
+// error-handling.test.ts: the owner's provider and sender-rule routes against
+// a real database and the whole handler chain.
+
+// adminPath builds an /api/admin/{slug}/… URL.
+func adminPath(slug, suffix string) string { return "/api/admin/" + slug + suffix }
+
+// createProvider posts one provider and returns its id, failing the test if
+// the route refused.
+func createProvider(t *testing.T, app *testrig.AppRig, cookie, slug, key, name string) string {
+	t.Helper()
+
+	rec := app.Do(t, http.MethodPost, adminPath(slug, "/providers"),
+		map[string]any{"providerKey": key, "displayName": name},
+		testrig.WithCookie(cookie))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("createProvider(%q): %d %s", key, rec.Code, rec.Body.String())
+	}
+	provider, _ := app.JSON(t, rec)["provider"].(map[string]any)
+	id, _ := provider["id"].(string)
+	if id == "" {
+		t.Fatalf("createProvider(%q): no id in %s", key, rec.Body.String())
+	}
+	return id
+}
+
+// createRule posts one sender rule and returns the recorder, so callers can
+// assert on both the happy and the refused paths.
+func createRule(t *testing.T, app *testrig.AppRig, cookie, slug, providerID, matchType, matchValue string) *http.Response {
+	t.Helper()
+	return app.Do(t, http.MethodPost, adminPath(slug, "/provider-rules"),
+		map[string]any{"providerId": providerID, "matchType": matchType, "matchValue": matchValue},
+		testrig.WithCookie(cookie)).Result()
+}
+
+func TestListProviderConfigurationsReturnsProvidersWithRuleCountsAndRules(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	netflix := createProvider(t, app, cookie, slug, "netflix", "Netflix")
+	createProvider(t, app, cookie, slug, "spotify", "Spotify")
+	if got := createRule(t, app, cookie, slug, netflix, "domain", "netflix.com"); got.StatusCode != http.StatusCreated {
+		t.Fatalf("rule: %d", got.StatusCode)
+	}
+
+	rec := app.Do(t, http.MethodGet, adminPath(slug, "/providers"), nil, testrig.WithCookie(cookie))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	body := app.JSON(t, rec)
+
+	providers, _ := body["providers"].([]any)
+	if len(providers) != 2 {
+		t.Fatalf("providers = %v", body["providers"])
+	}
+	// Ordered by display_name, and each row carries its rule count.
+	first, _ := providers[0].(map[string]any)
+	second, _ := providers[1].(map[string]any)
+	if first["provider_key"] != "netflix" || second["provider_key"] != "spotify" {
+		t.Errorf("order = %v, %v", first["provider_key"], second["provider_key"])
+	}
+	if first["rule_count"] != float64(1) || second["rule_count"] != float64(0) {
+		t.Errorf("rule counts = %v, %v", first["rule_count"], second["rule_count"])
+	}
+	// snake_case keys, deliberately: it is what the SPA reads.
+	for _, key := range []string{"id", "household_id", "provider_key", "display_name", "created_at"} {
+		if value, ok := first[key].(string); !ok || value == "" {
+			t.Errorf("provider[%q] = %v", key, first[key])
+		}
+	}
+
+	rules, _ := body["rules"].([]any)
+	if len(rules) != 1 {
+		t.Fatalf("rules = %v", body["rules"])
+	}
+	rule, _ := rules[0].(map[string]any)
+	if rule["match_type"] != "domain" || rule["match_value"] != "netflix.com" || rule["provider_id"] != netflix {
+		t.Errorf("rule = %v", rule)
+	}
+}
+
+func TestCreateProviderRefusesADuplicateKey(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	createProvider(t, app, cookie, slug, "netflix", "Netflix")
+
+	rec := app.Do(t, http.MethodPost, adminPath(slug, "/providers"),
+		map[string]any{"providerKey": "netflix", "displayName": "Netflix Again"},
+		testrig.WithCookie(cookie))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	if got := app.JSON(t, rec)["error"]; got != "Provider key already exists" {
+		t.Errorf("error = %q", got)
+	}
+	if got := app.Count(t, "providers", "TRUE"); got != 1 {
+		t.Errorf("providers = %d, want 1", got)
+	}
+}
+
+func TestCreateProviderValidatesTheKeyAndName(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+
+	for _, tc := range []struct {
+		name, providerKey, displayName, field, message string
+	}{
+		{"empty key", "  ", "Netflix", "providerKey", "providerKey is required"},
+		{"bad characters", "net flix", "Netflix", "providerKey",
+			"providerKey may only contain lowercase letters, numbers and hyphens"},
+		{"leading hyphen", "-netflix", "Netflix", "providerKey",
+			"providerKey may only contain lowercase letters, numbers and hyphens"},
+		{"long key", strings.Repeat("a", 41), "Netflix", "providerKey",
+			"providerKey must be at most 40 characters"},
+		{"empty name", "netflix", "   ", "displayName", "displayName is required"},
+		{"long name", "netflix", strings.Repeat("n", 81), "displayName",
+			"displayName must be at most 80 characters"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := app.Do(t, http.MethodPost, adminPath(slug, "/providers"),
+				map[string]any{"providerKey": tc.providerKey, "displayName": tc.displayName},
+				testrig.WithCookie(cookie))
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+			}
+			fields, _ := app.JSON(t, rec)["fields"].(map[string]any)
+			if got := fields[tc.field]; got != tc.message {
+				t.Errorf("fields[%q] = %v, want %q", tc.field, got, tc.message)
+			}
+		})
+	}
+
+	if got := app.Count(t, "providers", "TRUE"); got != 0 {
+		t.Errorf("providers = %d, want 0", got)
+	}
+}
+
+// The key is lower-cased and trimmed before it is stored, so what was checked
+// is what ends up in the URL the inbox addresses the provider by.
+func TestCreateProviderNormalizesTheKey(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+
+	rec := app.Do(t, http.MethodPost, adminPath(slug, "/providers"),
+		map[string]any{"providerKey": "  NetFlix  ", "displayName": "  Netflix  "},
+		testrig.WithCookie(cookie))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	provider, _ := app.JSON(t, rec)["provider"].(map[string]any)
+	if provider["provider_key"] != "netflix" || provider["display_name"] != "Netflix" {
+		t.Errorf("provider = %v", provider)
+	}
+}
+
+func TestUpdateProvider(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	netflix := createProvider(t, app, cookie, slug, "netflix", "Netflix")
+	spotify := createProvider(t, app, cookie, slug, "spotify", "Spotify")
+
+	// Renaming while keeping the key must not report the provider against
+	// itself.
+	renamed := app.Do(t, http.MethodPatch, adminPath(slug, "/providers/"+netflix),
+		map[string]any{"providerKey": "netflix", "displayName": "Netflix HD"},
+		testrig.WithCookie(cookie))
+	if renamed.Code != http.StatusOK {
+		t.Fatalf("rename: %d %s", renamed.Code, renamed.Body.String())
+	}
+	provider, _ := app.JSON(t, renamed)["provider"].(map[string]any)
+	if provider["display_name"] != "Netflix HD" || provider["provider_key"] != "netflix" {
+		t.Errorf("provider = %v", provider)
+	}
+
+	// Taking another provider's key is a conflict.
+	conflict := app.Do(t, http.MethodPatch, adminPath(slug, "/providers/"+netflix),
+		map[string]any{"providerKey": "spotify", "displayName": "Netflix HD"},
+		testrig.WithCookie(cookie))
+	if conflict.Code != http.StatusConflict {
+		t.Fatalf("conflict: %d %s", conflict.Code, conflict.Body.String())
+	}
+	if got := app.JSON(t, conflict)["error"]; got != "Provider key already exists" {
+		t.Errorf("error = %q", got)
+	}
+
+	missing := app.Do(t, http.MethodPatch, adminPath(slug, "/providers/nope"),
+		map[string]any{"providerKey": "other", "displayName": "Other"},
+		testrig.WithCookie(cookie))
+	if missing.Code != http.StatusNotFound {
+		t.Fatalf("missing: %d %s", missing.Code, missing.Body.String())
+	}
+	if got := app.JSON(t, missing)["error"]; got != "Provider not found" {
+		t.Errorf("error = %q", got)
+	}
+	if spotify == "" {
+		t.Error("spotify was not created")
+	}
+}
+
+// Deleting a provider takes its rules with it — the messages filed under it
+// carry verification codes, so nothing may outlive the mailbox.
+func TestDeleteProviderCascadesItsRules(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	netflix := createProvider(t, app, cookie, slug, "netflix", "Netflix")
+	if got := createRule(t, app, cookie, slug, netflix, "domain", "netflix.com"); got.StatusCode != http.StatusCreated {
+		t.Fatalf("rule: %d", got.StatusCode)
+	}
+
+	rec := app.Do(t, http.MethodDelete, adminPath(slug, "/providers/"+netflix), nil, testrig.WithCookie(cookie))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	if got := app.JSON(t, rec)["ok"]; got != true {
+		t.Errorf("body = %s", rec.Body.String())
+	}
+	if got := app.Count(t, "providers", "TRUE"); got != 0 {
+		t.Errorf("providers = %d, want 0", got)
+	}
+	if got := app.Count(t, "sender_rules", "TRUE"); got != 0 {
+		t.Errorf("sender rules = %d, want 0", got)
+	}
+
+	again := app.Do(t, http.MethodDelete, adminPath(slug, "/providers/"+netflix), nil, testrig.WithCookie(cookie))
+	if again.Code != http.StatusNotFound {
+		t.Fatalf("second delete: %d %s", again.Code, again.Body.String())
+	}
+}
+
+func TestCreateSenderRuleNormalizesAndValidatesMatchValues(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	netflix := createProvider(t, app, cookie, slug, "netflix", "Netflix")
+
+	// A domain rule drops the `@` an owner naturally types and is lower-cased.
+	rec := app.Do(t, http.MethodPost, adminPath(slug, "/provider-rules"),
+		map[string]any{"providerId": netflix, "matchType": "domain", "matchValue": " @NetFlix.com "},
+		testrig.WithCookie(cookie))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	rule, _ := app.JSON(t, rec)["rule"].(map[string]any)
+	if rule["match_value"] != "netflix.com" || rule["match_type"] != "domain" {
+		t.Errorf("rule = %v", rule)
+	}
+
+	for _, tc := range []struct{ name, matchType, matchValue, message string }{
+		{"domain that is an address", "domain", "info@netflix.com", "matchValue must be a domain like netflix.com"},
+		{"domain that is a word", "domain", "netflix", "matchValue must be a domain like netflix.com"},
+		{"exact that is a domain", "exact", "netflix.com", "matchValue must be a full email address"},
+		{"exact that is nonsense", "exact", "not an address", "matchValue must be a full email address"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			refused := app.Do(t, http.MethodPost, adminPath(slug, "/provider-rules"),
+				map[string]any{"providerId": netflix, "matchType": tc.matchType, "matchValue": tc.matchValue},
+				testrig.WithCookie(cookie))
+			if refused.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d %s", refused.Code, refused.Body.String())
+			}
+			fields, _ := app.JSON(t, refused)["fields"].(map[string]any)
+			if got := fields["matchValue"]; got != tc.message {
+				t.Errorf("fields[matchValue] = %v, want %q", got, tc.message)
+			}
+		})
+	}
+
+	// The match type itself is checked in Go rather than as an OpenAPI enum,
+	// so the message is REF §A4's wording.
+	badType := app.Do(t, http.MethodPost, adminPath(slug, "/provider-rules"),
+		map[string]any{"providerId": netflix, "matchType": "regex", "matchValue": "netflix.com"},
+		testrig.WithCookie(cookie))
+	if badType.Code != http.StatusBadRequest {
+		t.Fatalf("bad matchType: %d %s", badType.Code, badType.Body.String())
+	}
+	fields, _ := app.JSON(t, badType)["fields"].(map[string]any)
+	if got := fields["matchType"]; got != "matchType must be exact or domain" {
+		t.Errorf("fields[matchType] = %v", got)
+	}
+}
+
+// The duplicate-rule case of error-handling.test.ts: a JSON 409 naming the
+// column, from the global unique-violation mapping — never a bare 500.
+func TestDuplicateSenderRuleIsAJSONConflict(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	netflix := createProvider(t, app, cookie, slug, "netflix", "Netflix")
+
+	if first := createRule(t, app, cookie, slug, netflix, "domain", "netflix.com"); first.StatusCode != http.StatusCreated {
+		t.Fatalf("first rule: %d", first.StatusCode)
+	}
+
+	rec := app.Do(t, http.MethodPost, adminPath(slug, "/provider-rules"),
+		map[string]any{"providerId": netflix, "matchType": "domain", "matchValue": "netflix.com"},
+		testrig.WithCookie(cookie))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); !strings.Contains(got, "application/json") {
+		t.Errorf("content-type = %q", got)
+	}
+	if got := app.JSON(t, rec)["error"]; got != "A record with the same household id already exists" {
+		t.Errorf("error = %q", got)
+	}
+	if got := app.Count(t, "sender_rules", "TRUE"); got != 1 {
+		t.Errorf("sender rules = %d, want 1", got)
+	}
+}
+
+func TestSenderRuleRoutesRefuseAProviderFromAnotherHousehold(t *testing.T) {
+	app := testrig.App(t)
+	ownerCookie, slug := app.CompleteSetup(t)
+	_, otherCookie := signUp(t, app, "other@example.com", "Other")
+	if rec := createHousehold(t, app, otherCookie, "otra"); rec.StatusCode != http.StatusCreated {
+		t.Fatalf("second household: %d", rec.StatusCode)
+	}
+	theirs := createProvider(t, app, otherCookie, "otra", "netflix", "Netflix")
+
+	// The provider exists — but not in this household, so it is a 404 and not
+	// a rule that files this household's mail into theirs.
+	rec := createRule(t, app, ownerCookie, slug, theirs, "domain", "netflix.com")
+	if rec.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d", rec.StatusCode)
+	}
+	if got := app.Count(t, "sender_rules", "TRUE"); got != 0 {
+		t.Errorf("sender rules = %d, want 0", got)
+	}
+}
+
+func TestUpdateAndDeleteSenderRule(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	netflix := createProvider(t, app, cookie, slug, "netflix", "Netflix")
+	ses := createProvider(t, app, cookie, slug, "ses", "SES")
+
+	created := app.Do(t, http.MethodPost, adminPath(slug, "/provider-rules"),
+		map[string]any{"providerId": netflix, "matchType": "domain", "matchValue": "netflix.com"},
+		testrig.WithCookie(cookie))
+	if created.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", created.Code, created.Body.String())
+	}
+	rule, _ := app.JSON(t, created)["rule"].(map[string]any)
+	ruleID, _ := rule["id"].(string)
+
+	repointed := app.Do(t, http.MethodPatch, adminPath(slug, "/provider-rules/"+ruleID),
+		map[string]any{"providerId": ses, "matchType": "domain", "matchValue": "em.netflix.com"},
+		testrig.WithCookie(cookie))
+	if repointed.Code != http.StatusOK {
+		t.Fatalf("patch: %d %s", repointed.Code, repointed.Body.String())
+	}
+	updated, _ := app.JSON(t, repointed)["rule"].(map[string]any)
+	if updated["provider_id"] != ses || updated["match_value"] != "em.netflix.com" {
+		t.Errorf("rule = %v", updated)
+	}
+
+	// An unknown rule and an unknown provider are told apart.
+	unknownRule := app.Do(t, http.MethodPatch, adminPath(slug, "/provider-rules/nope"),
+		map[string]any{"providerId": ses, "matchType": "domain", "matchValue": "x.example.com"},
+		testrig.WithCookie(cookie))
+	if unknownRule.Code != http.StatusNotFound || app.JSON(t, unknownRule)["error"] != "Sender rule not found" {
+		t.Errorf("unknown rule: %d %s", unknownRule.Code, unknownRule.Body.String())
+	}
+	unknownProvider := app.Do(t, http.MethodPatch, adminPath(slug, "/provider-rules/"+ruleID),
+		map[string]any{"providerId": "nope", "matchType": "domain", "matchValue": "x.example.com"},
+		testrig.WithCookie(cookie))
+	if unknownProvider.Code != http.StatusNotFound || app.JSON(t, unknownProvider)["error"] != "Provider not found" {
+		t.Errorf("unknown provider: %d %s", unknownProvider.Code, unknownProvider.Body.String())
+	}
+
+	deleted := app.Do(t, http.MethodDelete, adminPath(slug, "/provider-rules/"+ruleID), nil, testrig.WithCookie(cookie))
+	if deleted.Code != http.StatusOK {
+		t.Fatalf("delete: %d %s", deleted.Code, deleted.Body.String())
+	}
+	if got := app.Count(t, "sender_rules", "TRUE"); got != 0 {
+		t.Errorf("sender rules = %d, want 0", got)
+	}
+	again := app.Do(t, http.MethodDelete, adminPath(slug, "/provider-rules/"+ruleID), nil, testrig.WithCookie(cookie))
+	if again.Code != http.StatusNotFound || app.JSON(t, again)["error"] != "Sender rule not found" {
+		t.Errorf("second delete: %d %s", again.Code, again.Body.String())
+	}
+}

--- a/apps/server/internal/api/admin_settings.go
+++ b/apps/server/internal/api/admin_settings.go
@@ -1,0 +1,176 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/andersro93/mi-casa-su-casa/server/internal/api/gen"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/api/middleware"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/auth"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/repo"
+)
+
+// Ports src/server/routes/admin/settings.ts and src/server/routes/admin/audit.ts
+// (REF §A2, "Admin"): the household's own name and address, and the trail of
+// everything the owners have done to it.
+//
+// Every route in the four admin_*.go files runs behind tierOwner (routes.go),
+// which is the Go spelling of the TypeScript's `adminRoutes.use("/:slug/*",
+// requireHouseholdContext)` plus `requireOwner`. That is also why each handler
+// starts by resolving the household from the request rather than by looking a
+// slug up: the guard already did the lookup AND the authorization, and doing
+// it again here would be a second implementation of the tenancy boundary.
+
+// auditLimit is how much of the trail the admin screen reads. REF §A2:
+// "newest 100".
+const auditLimit = 100
+
+// ListAuditEvents answers the audit screen.
+func (s server) ListAuditEvents(ctx context.Context, _ gen.ListAuditEventsRequestObject) (gen.ListAuditEventsResponseObject, error) {
+	_, household, ok := s.adminContext(ctx)
+	if !ok {
+		return gen.ListAuditEvents403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	events, err := s.Repo.ListAuditEvents(ctx, household.ID, auditLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	rows := make([]gen.AuditEvent, 0, len(events))
+	for _, event := range events {
+		rows = append(rows, gen.AuditEvent{
+			Id:          event.ID,
+			ActorUserId: event.ActorUserID,
+			HouseholdId: event.HouseholdID,
+			Action:      event.Action,
+			TargetType:  event.TargetType,
+			TargetId:    event.TargetID,
+			Details:     auditDetails(event.Details),
+			CreatedAt:   event.CreatedAt,
+		})
+	}
+	return gen.ListAuditEvents200JSONResponse{Events: rows}, nil
+}
+
+// GetHouseholdSettings answers the household settings screen.
+func (s server) GetHouseholdSettings(ctx context.Context, _ gen.GetHouseholdSettingsRequestObject) (gen.GetHouseholdSettingsResponseObject, error) {
+	_, household, ok := s.adminContext(ctx)
+	if !ok {
+		return gen.GetHouseholdSettings403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	settings, err := s.Repo.GetHouseholdByID(ctx, household.ID)
+	if err != nil {
+		return nil, err
+	}
+	if settings == nil {
+		return gen.GetHouseholdSettings404JSONResponse(errorBody("Household not found")), nil
+	}
+	return gen.GetHouseholdSettings200JSONResponse{
+		Household: s.householdSettingsBody(*settings),
+	}, nil
+}
+
+// UpdateHouseholdSettings renames the household.
+//
+// The slug is deliberately not settable. It is the local part of the
+// household's inbound address, so changing it would silently break every
+// sender rule a provider has already been pointed at — and would free the old
+// address for somebody else to claim.
+func (s server) UpdateHouseholdSettings(ctx context.Context, request gen.UpdateHouseholdSettingsRequestObject) (gen.UpdateHouseholdSettingsResponseObject, error) {
+	viewer, household, ok := s.adminContext(ctx)
+	if !ok {
+		return gen.UpdateHouseholdSettings403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	displayName := strings.TrimSpace(request.Body.DisplayName)
+	if problems := appendTextProblems(nil, "displayName", displayName, 80); len(problems) > 0 {
+		summary, fields := envelopeFor(problems)
+		return gen.UpdateHouseholdSettings400JSONResponse(errorFieldsBody(summary, fields)), nil
+	}
+
+	settings, err := s.Repo.UpdateHouseholdDisplayName(ctx, household.ID, displayName)
+	if err != nil {
+		return nil, err
+	}
+	if settings == nil {
+		return gen.UpdateHouseholdSettings404JSONResponse(errorBody("Household not found")), nil
+	}
+
+	s.audit(ctx, viewer, household, "household.settings_updated", "household", &household.ID,
+		map[string]any{"displayName": displayName})
+
+	return gen.UpdateHouseholdSettings200JSONResponse{
+		Household: s.householdSettingsBody(*settings),
+	}, nil
+}
+
+// householdSettingsBody maps a household onto the settings screen's shape,
+// adding the one field that is not stored: the address providers must be told
+// to send codes to, which is the slug at the installation's inbound domain.
+//
+// It is null when EMAIL_DOMAIN is unset, as the TypeScript's was. internal/config
+// requires the variable, so a running server never produces that — but the
+// nullable field is what the SPA already handles, and inventing "slug@" for a
+// misconfigured installation would be worse than saying nothing.
+func (s server) householdSettingsBody(household repo.Household) gen.HouseholdSettings {
+	body := gen.HouseholdSettings{
+		Slug:        household.Slug,
+		DisplayName: household.DisplayName,
+	}
+	if domain := strings.TrimSpace(s.EmailDomain); domain != "" {
+		body.EmailAddress = ptr(household.Slug + "@" + domain)
+	}
+	return body
+}
+
+// auditDetails parses a stored details blob back into the object the screen
+// renders. Anything that is not a JSON object — including SQL NULL — comes
+// back as null rather than as an error: the trail is a record of what
+// happened, and one unreadable detail blob must not cost the reader the rest
+// of the page.
+func auditDetails(raw json.RawMessage) *map[string]any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var details map[string]any
+	if err := json.Unmarshal(raw, &details); err != nil || details == nil {
+		return nil
+	}
+	return &details
+}
+
+// adminContext is the pair every admin handler opens with: the caller and the
+// household the tenancy guard resolved.
+//
+// ok is false only if an admin route were ever mounted without tierOwner, in
+// which case refusing is the failure that leaks nothing. Each handler answers
+// its own 403 rather than sharing one, because the generated response types
+// are per-operation.
+func (s server) adminContext(ctx context.Context) (*auth.Session, *middleware.Household, bool) {
+	viewer := viewerFrom(ctx)
+	household := householdFrom(ctx)
+	if viewer == nil || household == nil {
+		return nil, nil, false
+	}
+	return viewer, household, true
+}
+
+// audit records one owner action against the current household — the Go
+// counterpart of src/server/routes/admin/audit.ts's `audit(c, …)` helper.
+//
+// It returns nothing, deliberately: RecordAudit logs its own failures
+// (`audit_write_failed`) and never returns one, because REF §A6 requires that
+// an unwritable trail cannot fail the action it was recording.
+func (s server) audit(ctx context.Context, viewer *auth.Session, household *middleware.Household, action, targetType string, targetID *string, details map[string]any) {
+	s.Repo.RecordAudit(ctx, repo.AuditEventInput{
+		ActorUserID: &viewer.UserID,
+		HouseholdID: &household.ID,
+		Action:      action,
+		TargetType:  targetType,
+		TargetID:    targetID,
+		Details:     details,
+	})
+}

--- a/apps/server/internal/api/admin_settings_test.go
+++ b/apps/server/internal/api/admin_settings_test.go
@@ -1,0 +1,318 @@
+package api_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/andersro93/mi-casa-su-casa/server/internal/testrig"
+)
+
+// Ports test/integration/audit-log.test.ts, the owner-only half of
+// tenant-isolation.test.ts, and the envelope cases of error-handling.test.ts:
+// the household settings and audit routes, plus the guard every admin route
+// shares.
+
+func TestGetHouseholdSettingsIncludesTheInboundAddress(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+
+	rec := app.Do(t, http.MethodGet, adminPath(slug, "/settings"), nil, testrig.WithCookie(cookie))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	household, _ := app.JSON(t, rec)["household"].(map[string]any)
+	if household["slug"] != slug || household["displayName"] != testrig.OwnerHouseholdName {
+		t.Errorf("household = %v", household)
+	}
+	// The address providers must be told to send codes to: the slug at the
+	// installation's inbound domain.
+	if got := household["emailAddress"]; got != slug+"@"+testrig.EmailDomain {
+		t.Errorf("emailAddress = %v", got)
+	}
+}
+
+func TestUpdateHouseholdSettingsRenamesAndRecordsIt(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+
+	rec := app.Do(t, http.MethodPatch, adminPath(slug, "/settings"),
+		map[string]any{"displayName": "  Casa Nueva  "}, testrig.WithCookie(cookie))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	household, _ := app.JSON(t, rec)["household"].(map[string]any)
+	if household["displayName"] != "Casa Nueva" {
+		t.Errorf("displayName = %v", household["displayName"])
+	}
+	// The slug is not settable: it is the local part of the inbound address,
+	// so changing it would break every rule a provider was pointed at.
+	if household["slug"] != slug || household["emailAddress"] != slug+"@"+testrig.EmailDomain {
+		t.Errorf("household = %v", household)
+	}
+	if got := app.Count(t, "audit_events",
+		`"action" = 'household.settings_updated' AND "details" ->> 'displayName' = 'Casa Nueva'`); got != 1 {
+		t.Errorf("settings_updated audits = %d, want 1", got)
+	}
+
+	for _, tc := range []struct{ name, displayName, message string }{
+		{"empty", "   ", "displayName is required"},
+		{"too long", strings.Repeat("c", 81), "displayName must be at most 80 characters"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			refused := app.Do(t, http.MethodPatch, adminPath(slug, "/settings"),
+				map[string]any{"displayName": tc.displayName}, testrig.WithCookie(cookie))
+			if refused.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d %s", refused.Code, refused.Body.String())
+			}
+			fields, _ := app.JSON(t, refused)["fields"].(map[string]any)
+			if got := fields["displayName"]; got != tc.message {
+				t.Errorf("fields[displayName] = %v, want %q", got, tc.message)
+			}
+		})
+	}
+}
+
+// The first case of audit-log.test.ts: every owner action lands in the trail
+// with the actor and the household, and only owners may read it.
+func TestAuditLogRecordsOwnerActionsWithActorAndHousehold(t *testing.T) {
+	app := testrig.App(t)
+	ownerCookie, slug := app.CompleteSetup(t)
+	memberCookie := app.CreateMember(t, slug, memberEmail, "Member", "member")
+
+	owner, err := app.Deps.Repo.FindUserByEmail(t.Context(), testrig.OwnerEmail)
+	if err != nil || owner == nil {
+		t.Fatalf("owner: %v", err)
+	}
+	member, err := app.Deps.Repo.FindUserByEmail(t.Context(), memberEmail)
+	if err != nil || member == nil {
+		t.Fatalf("member: %v", err)
+	}
+	household, err := app.Deps.Repo.GetHouseholdBySlug(t.Context(), slug)
+	if err != nil || household == nil {
+		t.Fatalf("household: %v", err)
+	}
+
+	netflix := createProvider(t, app, ownerCookie, slug, "netflix", "Netflix")
+	if rec := createRule(t, app, ownerCookie, slug, netflix, "domain", "netflix.com"); rec.StatusCode != http.StatusCreated {
+		t.Fatalf("rule: %d", rec.StatusCode)
+	}
+	if rec := app.Do(t, http.MethodPost, adminPath(slug, "/members/"+member.ID+"/provider-access"),
+		map[string]any{"providerKey": "netflix"}, testrig.WithCookie(ownerCookie)); rec.Code != http.StatusOK {
+		t.Fatalf("grant: %d %s", rec.Code, rec.Body.String())
+	}
+	if rec := app.Do(t, http.MethodPatch, adminPath(slug, "/members/"+member.ID+"/role"),
+		map[string]any{"role": "owner"}, testrig.WithCookie(ownerCookie)); rec.Code != http.StatusOK {
+		t.Fatalf("role: %d %s", rec.Code, rec.Body.String())
+	}
+	if rec := app.Do(t, http.MethodPatch, adminPath(slug, "/settings"),
+		map[string]any{"displayName": "Casa 2"}, testrig.WithCookie(ownerCookie)); rec.Code != http.StatusOK {
+		t.Fatalf("settings: %d %s", rec.Code, rec.Body.String())
+	}
+
+	rec := app.Do(t, http.MethodGet, adminPath(slug, "/audit"), nil, testrig.WithCookie(ownerCookie))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("audit: %d %s", rec.Code, rec.Body.String())
+	}
+	events, _ := app.JSON(t, rec)["events"].([]any)
+
+	var actions []string
+	var providerCreated map[string]any
+	for _, entry := range events {
+		event, _ := entry.(map[string]any)
+		actions = append(actions, event["action"].(string))
+		if event["actorUserId"] != owner.ID {
+			t.Errorf("actorUserId = %v, want the owner", event["actorUserId"])
+		}
+		if event["householdId"] != household.ID {
+			t.Errorf("householdId = %v", event["householdId"])
+		}
+		if event["action"] == "provider.created" {
+			providerCreated = event
+		}
+	}
+	sort.Strings(actions)
+
+	// The setup route's own installation event is filed against the household
+	// too, so it is part of this trail.
+	want := []string{
+		"household.settings_updated",
+		"installation.setup_completed",
+		"member.provider_access_granted",
+		"member.role_changed",
+		"provider.created",
+		"sender_rule.created",
+	}
+	if strings.Join(actions, ",") != strings.Join(want, ",") {
+		t.Errorf("actions = %v, want %v", actions, want)
+	}
+
+	if providerCreated == nil {
+		t.Fatal("no provider.created event")
+	}
+	if providerCreated["targetId"] != netflix || providerCreated["targetType"] != "provider" {
+		t.Errorf("provider.created target = %v/%v", providerCreated["targetType"], providerCreated["targetId"])
+	}
+	details, _ := providerCreated["details"].(map[string]any)
+	if details["providerKey"] != "netflix" {
+		t.Errorf("details = %v", details)
+	}
+
+	// The member was promoted above, so demote them and check the denial —
+	// the trail names who did what to whom, which is not a member's business.
+	if err := app.Deps.Repo.SetMemberRole(t.Context(), household.ID, member.ID, "member"); err != nil {
+		t.Fatalf("demote: %v", err)
+	}
+	denied := app.Do(t, http.MethodGet, adminPath(slug, "/audit"), nil, testrig.WithCookie(memberCookie))
+	if denied.Code != http.StatusForbidden {
+		t.Fatalf("member reading the audit log: %d %s", denied.Code, denied.Body.String())
+	}
+}
+
+// An action with no details of its own stores none, and the response says
+// null rather than omitting the key.
+func TestAuditEventsWithoutDetailsAnswerNull(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	netflix := createProvider(t, app, cookie, slug, "netflix", "Netflix")
+	if rec := app.Do(t, http.MethodDelete, adminPath(slug, "/providers/"+netflix), nil,
+		testrig.WithCookie(cookie)); rec.Code != http.StatusOK {
+		t.Fatalf("delete: %d %s", rec.Code, rec.Body.String())
+	}
+
+	rec := app.Do(t, http.MethodGet, adminPath(slug, "/audit"), nil, testrig.WithCookie(cookie))
+	events, _ := app.JSON(t, rec)["events"].([]any)
+	for _, entry := range events {
+		event, _ := entry.(map[string]any)
+		if event["action"] != "provider.deleted" {
+			continue
+		}
+		value, present := event["details"]
+		if !present || value != nil {
+			t.Errorf("details = %v (present: %v), want null", value, present)
+		}
+		return
+	}
+	t.Fatalf("no provider.deleted event in %s", rec.Body.String())
+}
+
+// adminRequests is one representative request per admin route, used by the two
+// guard tests below. Every one of them must be refused for the same reason,
+// so listing them here keeps a future route from quietly missing the check.
+func adminRequests(slug string) []struct {
+	method, path string
+	body         any
+} {
+	return []struct {
+		method, path string
+		body         any
+	}{
+		{http.MethodGet, adminPath(slug, "/audit"), nil},
+		{http.MethodGet, adminPath(slug, "/settings"), nil},
+		{http.MethodPatch, adminPath(slug, "/settings"), map[string]any{"displayName": "Taken"}},
+		{http.MethodGet, adminPath(slug, "/providers"), nil},
+		{http.MethodPost, adminPath(slug, "/providers"), map[string]any{"providerKey": "x", "displayName": "X"}},
+		{http.MethodPatch, adminPath(slug, "/providers/pid"), map[string]any{"providerKey": "x", "displayName": "X"}},
+		{http.MethodDelete, adminPath(slug, "/providers/pid"), nil},
+		{http.MethodPost, adminPath(slug, "/provider-rules"),
+			map[string]any{"providerId": "pid", "matchType": "domain", "matchValue": "x.example.com"}},
+		{http.MethodPatch, adminPath(slug, "/provider-rules/rid"),
+			map[string]any{"providerId": "pid", "matchType": "domain", "matchValue": "x.example.com"}},
+		{http.MethodDelete, adminPath(slug, "/provider-rules/rid"), nil},
+		{http.MethodGet, adminPath(slug, "/members"), nil},
+		{http.MethodPost, adminPath(slug, "/members"), map[string]any{"email": "x@example.com", "name": "X"}},
+		{http.MethodDelete, adminPath(slug, "/members/uid"), nil},
+		{http.MethodPatch, adminPath(slug, "/members/uid/role"), map[string]any{"role": "owner"}},
+		{http.MethodPost, adminPath(slug, "/members/uid/provider-access"), map[string]any{"providerKey": "x"}},
+		{http.MethodDelete, adminPath(slug, "/members/uid/provider-access/x"), nil},
+		{http.MethodGet, adminPath(slug, "/invitations"), nil},
+		{http.MethodPost, adminPath(slug, "/invitations"), map[string]any{"email": "x@example.com", "name": "X"}},
+		{http.MethodPost, adminPath(slug, "/invitations/iid/resend"), nil},
+		{http.MethodDelete, adminPath(slug, "/invitations/iid"), nil},
+	}
+}
+
+// A member of the household may not reach any admin route: the tier refuses
+// before the handler runs, so nothing leaks about what exists.
+func TestEveryAdminRouteIsOwnerOnly(t *testing.T) {
+	app := testrig.App(t)
+	_, slug := app.CompleteSetup(t)
+	memberCookie := app.CreateMember(t, slug, memberEmail, "Member", "member")
+
+	for _, tc := range adminRequests(slug) {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			rec := app.Do(t, tc.method, tc.path, tc.body, testrig.WithCookie(memberCookie))
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+			}
+			if got := app.JSON(t, rec)["error"]; got != "Forbidden" {
+				t.Errorf("error = %q", got)
+			}
+		})
+	}
+}
+
+// The owner-only half of tenant-isolation.test.ts, widened to every admin
+// route: another household's owner is a stranger here, and gets the same 403 a
+// stranger gets — never a 404 that would confirm the household exists.
+func TestAdminRoutesRefuseAnotherHouseholdsOwner(t *testing.T) {
+	app := testrig.App(t)
+	_, slug := app.CompleteSetup(t)
+	_, otherCookie := signUp(t, app, "other@example.com", "Other")
+	if rec := createHousehold(t, app, otherCookie, "otra"); rec.StatusCode != http.StatusCreated {
+		t.Fatalf("second household: %d", rec.StatusCode)
+	}
+
+	for _, tc := range adminRequests(slug) {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			rec := app.Do(t, tc.method, tc.path, tc.body, testrig.WithCookie(otherCookie))
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+	// Nothing of the other household was touched.
+	if got := app.Count(t, "households", `"slug" = $1 AND "display_name" = $2`,
+		slug, testrig.OwnerHouseholdName); got != 1 {
+		t.Error("the other household was modified")
+	}
+}
+
+func TestAdminRoutesRequireASession(t *testing.T) {
+	app := testrig.App(t)
+	_, slug := app.CompleteSetup(t)
+
+	rec := app.Do(t, http.MethodGet, adminPath(slug, "/settings"), nil)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	if got := app.JSON(t, rec)["error"]; got != "Unauthorized" {
+		t.Errorf("error = %q", got)
+	}
+}
+
+// The envelope half of error-handling.test.ts: a body that is not JSON is a
+// 400 saying so, not a 500 and not a text/plain error from the decoder.
+func TestAdminRoutesRejectAnInvalidJSONBody(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+
+	req := httptest.NewRequest(http.MethodPatch, adminPath(slug, "/settings"),
+		strings.NewReader("{not json"))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", testrig.AppURL)
+	req.Header.Set("Cookie", cookie)
+
+	rec := app.DoRequest(req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); !strings.Contains(got, "application/json") {
+		t.Errorf("content-type = %q", got)
+	}
+	if got := app.JSON(t, rec)["error"]; got != "Invalid JSON body" {
+		t.Errorf("error = %q", got)
+	}
+}

--- a/apps/server/internal/api/api.go
+++ b/apps/server/internal/api/api.go
@@ -242,11 +242,26 @@ func requestErrorHandler(w http.ResponseWriter, _ *http.Request, _ error) {
 }
 
 // responseErrorHandler answers a handler that returned an error rather than a
-// response object: an unexpected failure, which REF §A1 item 11 answers with
-// `unhandled_error` in the log and a 500 that says nothing else. The error
-// text stays in the log — a pgx error names the statement that failed, which
-// is for the operator and not for the caller.
+// response object.
+//
+// One error is expected rather than unexpected and gets a real answer: a
+// unique-constraint violation, which REF §A1 item 11 maps to 409 with a message
+// naming what collided (see errors.go). Several routes check for a duplicate
+// and then insert, which is not a lock — the index is what actually decides —
+// and a couple skip the check entirely because of that. Both reach the caller
+// through here.
+//
+// Everything else is an unexpected failure: `unhandled_error` in the log and a
+// 500 that says nothing else. The error text stays in the log — a pgx error
+// names the statement that failed, which is for the operator and not for the
+// caller.
 func responseErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
+	if repo.IsUniqueViolation(err) {
+		respond.Error(w, http.StatusConflict,
+			uniqueViolationMessage(repo.UniqueViolationConstraint(err)))
+		return
+	}
+
 	applog.Event(applog.LevelError, "unhandled_error", map[string]any{
 		"method": r.Method,
 		"path":   r.URL.Path,

--- a/apps/server/internal/api/errors.go
+++ b/apps/server/internal/api/errors.go
@@ -1,0 +1,59 @@
+package api
+
+// Ports src/server/http/errors.ts: the last-resort answer for a handler that
+// returned an error rather than a response object.
+//
+// One failure gets a real answer rather than a 500: a unique-constraint
+// violation. Several routes race a check-then-insert (two owners adding the
+// same sender rule at once) and several more do not bother to check at all,
+// because the index is the authority either way. Answering those with 409 and
+// a message naming what collided is REF §A1 item 11, and it is what keeps a
+// duplicate sender rule from reaching the SPA as a bare "Internal error".
+
+// uniqueTargetColumns maps a Postgres constraint name to the column the
+// TypeScript's message named for the same collision.
+//
+// The indirection exists because the two databases report a violation
+// differently and the MESSAGE must not change. SQLite said
+//
+//	UNIQUE constraint failed: sender_rules.household_id, sender_rules.match_type, sender_rules.match_value
+//
+// and src/server/http/errors.ts took the FIRST column out of that list
+// (uniqueViolationTarget's regex stops at the first space, describeUniqueTarget
+// keeps the part after the dot) and spelled it with spaces — "household id".
+// Postgres names the CONSTRAINT instead ("sender_rules_household_match_unique")
+// and says nothing about columns, so the first column of each constraint is
+// recorded here, once, next to the constraint that has it.
+//
+// Add a row whenever a migration adds a unique constraint; a constraint with no
+// row here falls back to the same "the same values" wording the TypeScript used
+// when it could not parse a target.
+var uniqueTargetColumns = map[string]string{
+	// App tables.
+	"households_slug_unique":                       "slug",
+	"household_memberships_household_user_unique":  "household id",
+	"providers_household_key_unique":               "household id",
+	"household_member_provider_access_unique":      "household membership id",
+	"sender_rules_household_match_unique":          "household id",
+	"messages_household_message_unique":            "household id",
+	"quarantine_messages_household_message_unique": "household id",
+	"household_invitations_token_hash_unique":      "token hash",
+	"household_invitation_provider_access_unique":  "invitation id",
+
+	// Limen-owned tables. Nothing in this package writes them directly, but a
+	// sign-up racing another sign-up for the same address surfaces here.
+	"users_email_unique":               "email",
+	"users_public_id_unique":           "public id",
+	"sessions_token_unique":            "token",
+	"accounts_provider_account_unique": "provider",
+	"rate_limits_key_unique":           "key",
+	"two_factors_user_unique":          "user id",
+}
+
+// uniqueViolationMessage is the 409 body for a violated constraint.
+func uniqueViolationMessage(constraint string) string {
+	if column, ok := uniqueTargetColumns[constraint]; ok {
+		return "A record with the same " + column + " already exists"
+	}
+	return "A record with the same values already exists"
+}

--- a/apps/server/internal/api/gen/server.gen.go
+++ b/apps/server/internal/api/gen/server.gen.go
@@ -20,6 +20,66 @@ import (
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
+	// ListAuditEvents The household's audit trail, newest 100 first. Owner-only: it names who did what to whom, which is exactly the sort of thing a member has no business reading about the rest of the household.
+	// (GET /api/admin/{slug}/audit)
+	ListAuditEvents(w http.ResponseWriter, r *http.Request, slug HouseholdSlug)
+	// ListInvitations Every invitation this household has issued, newest first. Invitations past their expiry are marked expired before the list is read, so the screen never shows a pending invitation whose link no longer works.
+	// (GET /api/admin/{slug}/invitations)
+	ListInvitations(w http.ResponseWriter, r *http.Request, slug HouseholdSlug)
+	// CreateInvitation Invite somebody, optionally scoped to a set of providers they will be able to read the moment they accept.
+	// (POST /api/admin/{slug}/invitations)
+	CreateInvitation(w http.ResponseWriter, r *http.Request, slug HouseholdSlug)
+	// CancelInvitation Cancel a pending invitation, which makes its link stop working.
+	// (DELETE /api/admin/{slug}/invitations/{invitationId})
+	CancelInvitation(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, invitationId InvitationId)
+	// ResendInvitation Issue a fresh invitation to the same person with the same role and provider scope, cancelling the old one. A new token, so the link in the first email stops working — which is what makes "resend" safe to offer after a link has been forwarded to the wrong inbox.
+	// (POST /api/admin/{slug}/invitations/{invitationId}/resend)
+	ResendInvitation(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, invitationId InvitationId)
+	// ListMembers Everybody in the household with the providers each of them may read, plus the household's providers so the screen can offer the rest.
+	// (GET /api/admin/{slug}/members)
+	ListMembers(w http.ResponseWriter, r *http.Request, slug HouseholdSlug)
+	// CreateMember "Add a member" — which is an invitation with no provider scope, not an account this endpoint creates. Nobody may be given a password by somebody else, so the invitee always sets their own.
+	// (POST /api/admin/{slug}/members)
+	CreateMember(w http.ResponseWriter, r *http.Request, slug HouseholdSlug)
+	// RemoveMember Remove somebody else from the household. Refused for the last owner, and refused for yourself — "leave household" is the route for that, so that giving up your own access is never a click away from removing somebody else's.
+	// (DELETE /api/admin/{slug}/members/{userId})
+	RemoveMember(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, userId MemberUserId)
+	// GrantProviderAccess Let a member read one provider's messages. Idempotent: granting twice is the same as granting once, so a double-click is not an error.
+	// (POST /api/admin/{slug}/members/{userId}/provider-access)
+	GrantProviderAccess(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, userId MemberUserId)
+	// RevokeProviderAccess Take a provider away from a member. The key is a path parameter and only a path parameter — the TypeScript also read it from a JSON body on DELETE, which is a shape no client sends and every proxy is entitled to drop.
+	// (DELETE /api/admin/{slug}/members/{userId}/provider-access/{providerKey})
+	RevokeProviderAccess(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, userId MemberUserId, providerKey string)
+	// UpdateMemberRole Promote or demote somebody else. Refused for yourself: an owner who could demote themselves could leave a household with no owner at all, and the answer names the other owners as the way out.
+	// (PATCH /api/admin/{slug}/members/{userId}/role)
+	UpdateMemberRole(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, userId MemberUserId)
+	// CreateSenderRule Add a sender rule: the address or domain whose mail files into a provider. Exact rules beat domain rules, and the most specific domain rule wins among those.
+	// (POST /api/admin/{slug}/provider-rules)
+	CreateSenderRule(w http.ResponseWriter, r *http.Request, slug HouseholdSlug)
+	// DeleteSenderRule Remove a sender rule. Messages already filed under its provider stay.
+	// (DELETE /api/admin/{slug}/provider-rules/{ruleId})
+	DeleteSenderRule(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, ruleId SenderRuleId)
+	// UpdateSenderRule Repoint a sender rule, or change what it matches.
+	// (PATCH /api/admin/{slug}/provider-rules/{ruleId})
+	UpdateSenderRule(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, ruleId SenderRuleId)
+	// ListProviderConfigurations Every provider in the household with the number of sender rules that point at it, plus the rules themselves — the two halves of the provider settings screen in one request.
+	// (GET /api/admin/{slug}/providers)
+	ListProviderConfigurations(w http.ResponseWriter, r *http.Request, slug HouseholdSlug)
+	// CreateProvider Add a provider — the mailbox a set of sender rules files messages into.
+	// (POST /api/admin/{slug}/providers)
+	CreateProvider(w http.ResponseWriter, r *http.Request, slug HouseholdSlug)
+	// DeleteProvider Remove a provider. Its sender rules, its stored messages and every member's access to it go with it — the foreign keys cascade, which is the point: a deleted provider must not leave readable messages behind.
+	// (DELETE /api/admin/{slug}/providers/{providerId})
+	DeleteProvider(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, providerId ProviderId)
+	// UpdateProvider Rename a provider or change its key.
+	// (PATCH /api/admin/{slug}/providers/{providerId})
+	UpdateProvider(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, providerId ProviderId)
+	// GetHouseholdSettings The household's own settings: its name and the inbound address providers must be told to send codes to.
+	// (GET /api/admin/{slug}/settings)
+	GetHouseholdSettings(w http.ResponseWriter, r *http.Request, slug HouseholdSlug)
+	// UpdateHouseholdSettings Rename the household. The slug — and therefore the inbound address — never changes.
+	// (PATCH /api/admin/{slug}/settings)
+	UpdateHouseholdSettings(w http.ResponseWriter, r *http.Request, slug HouseholdSlug)
 	// CreateHousehold Create a household with the caller as its owner. Restricted (REF §A2): the installation owner may always; anybody else only while they belong to no household at all, so a member cannot mint extra households or squat inbound addresses. Rate limited (10 per hour).
 	// (POST /api/households)
 	CreateHousehold(w http.ResponseWriter, r *http.Request)
@@ -72,6 +132,625 @@ type ServerInterfaceWrapper struct {
 }
 
 type MiddlewareFunc func(http.Handler) http.Handler
+
+// ListAuditEvents operation middleware
+func (siw *ServerInterfaceWrapper) ListAuditEvents(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListAuditEvents(w, r, slug)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListInvitations operation middleware
+func (siw *ServerInterfaceWrapper) ListInvitations(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListInvitations(w, r, slug)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreateInvitation operation middleware
+func (siw *ServerInterfaceWrapper) CreateInvitation(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateInvitation(w, r, slug)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CancelInvitation operation middleware
+func (siw *ServerInterfaceWrapper) CancelInvitation(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "invitationId" -------------
+	var invitationId InvitationId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "invitationId", r.PathValue("invitationId"), &invitationId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "invitationId", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CancelInvitation(w, r, slug, invitationId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ResendInvitation operation middleware
+func (siw *ServerInterfaceWrapper) ResendInvitation(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "invitationId" -------------
+	var invitationId InvitationId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "invitationId", r.PathValue("invitationId"), &invitationId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "invitationId", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ResendInvitation(w, r, slug, invitationId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListMembers operation middleware
+func (siw *ServerInterfaceWrapper) ListMembers(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListMembers(w, r, slug)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreateMember operation middleware
+func (siw *ServerInterfaceWrapper) CreateMember(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateMember(w, r, slug)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// RemoveMember operation middleware
+func (siw *ServerInterfaceWrapper) RemoveMember(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "userId" -------------
+	var userId MemberUserId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "userId", r.PathValue("userId"), &userId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "userId", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.RemoveMember(w, r, slug, userId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GrantProviderAccess operation middleware
+func (siw *ServerInterfaceWrapper) GrantProviderAccess(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "userId" -------------
+	var userId MemberUserId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "userId", r.PathValue("userId"), &userId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "userId", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GrantProviderAccess(w, r, slug, userId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// RevokeProviderAccess operation middleware
+func (siw *ServerInterfaceWrapper) RevokeProviderAccess(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "userId" -------------
+	var userId MemberUserId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "userId", r.PathValue("userId"), &userId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "userId", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "providerKey" -------------
+	var providerKey string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "providerKey", r.PathValue("providerKey"), &providerKey, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "providerKey", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.RevokeProviderAccess(w, r, slug, userId, providerKey)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateMemberRole operation middleware
+func (siw *ServerInterfaceWrapper) UpdateMemberRole(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "userId" -------------
+	var userId MemberUserId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "userId", r.PathValue("userId"), &userId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "userId", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateMemberRole(w, r, slug, userId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreateSenderRule operation middleware
+func (siw *ServerInterfaceWrapper) CreateSenderRule(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateSenderRule(w, r, slug)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteSenderRule operation middleware
+func (siw *ServerInterfaceWrapper) DeleteSenderRule(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "ruleId" -------------
+	var ruleId SenderRuleId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "ruleId", r.PathValue("ruleId"), &ruleId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "ruleId", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteSenderRule(w, r, slug, ruleId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateSenderRule operation middleware
+func (siw *ServerInterfaceWrapper) UpdateSenderRule(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "ruleId" -------------
+	var ruleId SenderRuleId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "ruleId", r.PathValue("ruleId"), &ruleId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "ruleId", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateSenderRule(w, r, slug, ruleId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListProviderConfigurations operation middleware
+func (siw *ServerInterfaceWrapper) ListProviderConfigurations(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListProviderConfigurations(w, r, slug)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreateProvider operation middleware
+func (siw *ServerInterfaceWrapper) CreateProvider(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateProvider(w, r, slug)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteProvider operation middleware
+func (siw *ServerInterfaceWrapper) DeleteProvider(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "providerId" -------------
+	var providerId ProviderId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "providerId", r.PathValue("providerId"), &providerId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "providerId", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteProvider(w, r, slug, providerId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateProvider operation middleware
+func (siw *ServerInterfaceWrapper) UpdateProvider(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "providerId" -------------
+	var providerId ProviderId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "providerId", r.PathValue("providerId"), &providerId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "providerId", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateProvider(w, r, slug, providerId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetHouseholdSettings operation middleware
+func (siw *ServerInterfaceWrapper) GetHouseholdSettings(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetHouseholdSettings(w, r, slug)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateHouseholdSettings operation middleware
+func (siw *ServerInterfaceWrapper) UpdateHouseholdSettings(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateHouseholdSettings(w, r, slug)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
 
 // CreateHousehold operation middleware
 func (siw *ServerInterfaceWrapper) CreateHousehold(w http.ResponseWriter, r *http.Request) {
@@ -481,8 +1160,1454 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodPatch+" "+options.BaseURL+"/api/settings/profile", wrapper.UpdateProfile)
 	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/settings/sessions/others", wrapper.RevokeOtherSessions)
 	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/settings/sessions/{sessionId}", wrapper.RevokeSession)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/admin/{slug}/audit", wrapper.ListAuditEvents)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/admin/{slug}/settings", wrapper.GetHouseholdSettings)
+	m.HandleFunc(http.MethodPatch+" "+options.BaseURL+"/api/admin/{slug}/settings", wrapper.UpdateHouseholdSettings)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/admin/{slug}/providers", wrapper.ListProviderConfigurations)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/admin/{slug}/providers", wrapper.CreateProvider)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/admin/{slug}/providers/{providerId}", wrapper.DeleteProvider)
+	m.HandleFunc(http.MethodPatch+" "+options.BaseURL+"/api/admin/{slug}/providers/{providerId}", wrapper.UpdateProvider)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/admin/{slug}/provider-rules", wrapper.CreateSenderRule)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/admin/{slug}/provider-rules/{ruleId}", wrapper.DeleteSenderRule)
+	m.HandleFunc(http.MethodPatch+" "+options.BaseURL+"/api/admin/{slug}/provider-rules/{ruleId}", wrapper.UpdateSenderRule)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/admin/{slug}/members", wrapper.ListMembers)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/admin/{slug}/members", wrapper.CreateMember)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/admin/{slug}/members/{userId}", wrapper.RemoveMember)
+	m.HandleFunc(http.MethodPatch+" "+options.BaseURL+"/api/admin/{slug}/members/{userId}/role", wrapper.UpdateMemberRole)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/admin/{slug}/members/{userId}/provider-access", wrapper.GrantProviderAccess)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/admin/{slug}/members/{userId}/provider-access/{providerKey}", wrapper.RevokeProviderAccess)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/admin/{slug}/invitations", wrapper.ListInvitations)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/admin/{slug}/invitations", wrapper.CreateInvitation)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/admin/{slug}/invitations/{invitationId}/resend", wrapper.ResendInvitation)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/admin/{slug}/invitations/{invitationId}", wrapper.CancelInvitation)
 
 	return m
+}
+
+type ListAuditEventsRequestObject struct {
+	Slug HouseholdSlug `json:"slug"`
+}
+
+type ListAuditEventsResponseObject interface {
+	VisitListAuditEventsResponse(w http.ResponseWriter) error
+}
+
+type ListAuditEvents200JSONResponse AuditEventList
+
+func (response ListAuditEvents200JSONResponse) VisitListAuditEventsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListAuditEvents401JSONResponse Error
+
+func (response ListAuditEvents401JSONResponse) VisitListAuditEventsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListAuditEvents403JSONResponse Error
+
+func (response ListAuditEvents403JSONResponse) VisitListAuditEventsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListInvitationsRequestObject struct {
+	Slug HouseholdSlug `json:"slug"`
+}
+
+type ListInvitationsResponseObject interface {
+	VisitListInvitationsResponse(w http.ResponseWriter) error
+}
+
+type ListInvitations200JSONResponse InvitationList
+
+func (response ListInvitations200JSONResponse) VisitListInvitationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListInvitations401JSONResponse Error
+
+func (response ListInvitations401JSONResponse) VisitListInvitationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListInvitations403JSONResponse Error
+
+func (response ListInvitations403JSONResponse) VisitListInvitationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateInvitationRequestObject struct {
+	Slug HouseholdSlug `json:"slug"`
+	Body *CreateInvitationJSONRequestBody
+}
+
+type CreateInvitationResponseObject interface {
+	VisitCreateInvitationResponse(w http.ResponseWriter) error
+}
+
+type CreateInvitation201JSONResponse InvitationResult
+
+func (response CreateInvitation201JSONResponse) VisitCreateInvitationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(201)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateInvitation400JSONResponse Error
+
+func (response CreateInvitation400JSONResponse) VisitCreateInvitationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateInvitation401JSONResponse Error
+
+func (response CreateInvitation401JSONResponse) VisitCreateInvitationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateInvitation403JSONResponse Error
+
+func (response CreateInvitation403JSONResponse) VisitCreateInvitationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CancelInvitationRequestObject struct {
+	Slug         HouseholdSlug `json:"slug"`
+	InvitationId InvitationId  `json:"invitationId"`
+}
+
+type CancelInvitationResponseObject interface {
+	VisitCancelInvitationResponse(w http.ResponseWriter) error
+}
+
+type CancelInvitation200JSONResponse Ok
+
+func (response CancelInvitation200JSONResponse) VisitCancelInvitationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CancelInvitation401JSONResponse Error
+
+func (response CancelInvitation401JSONResponse) VisitCancelInvitationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CancelInvitation403JSONResponse Error
+
+func (response CancelInvitation403JSONResponse) VisitCancelInvitationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CancelInvitation404JSONResponse Error
+
+func (response CancelInvitation404JSONResponse) VisitCancelInvitationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ResendInvitationRequestObject struct {
+	Slug         HouseholdSlug `json:"slug"`
+	InvitationId InvitationId  `json:"invitationId"`
+}
+
+type ResendInvitationResponseObject interface {
+	VisitResendInvitationResponse(w http.ResponseWriter) error
+}
+
+type ResendInvitation200JSONResponse InvitationResult
+
+func (response ResendInvitation200JSONResponse) VisitResendInvitationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ResendInvitation401JSONResponse Error
+
+func (response ResendInvitation401JSONResponse) VisitResendInvitationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ResendInvitation403JSONResponse Error
+
+func (response ResendInvitation403JSONResponse) VisitResendInvitationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ResendInvitation404JSONResponse Error
+
+func (response ResendInvitation404JSONResponse) VisitResendInvitationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListMembersRequestObject struct {
+	Slug HouseholdSlug `json:"slug"`
+}
+
+type ListMembersResponseObject interface {
+	VisitListMembersResponse(w http.ResponseWriter) error
+}
+
+type ListMembers200JSONResponse MemberList
+
+func (response ListMembers200JSONResponse) VisitListMembersResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListMembers401JSONResponse Error
+
+func (response ListMembers401JSONResponse) VisitListMembersResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListMembers403JSONResponse Error
+
+func (response ListMembers403JSONResponse) VisitListMembersResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateMemberRequestObject struct {
+	Slug HouseholdSlug `json:"slug"`
+	Body *CreateMemberJSONRequestBody
+}
+
+type CreateMemberResponseObject interface {
+	VisitCreateMemberResponse(w http.ResponseWriter) error
+}
+
+type CreateMember201JSONResponse InvitationResult
+
+func (response CreateMember201JSONResponse) VisitCreateMemberResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(201)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateMember400JSONResponse Error
+
+func (response CreateMember400JSONResponse) VisitCreateMemberResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateMember401JSONResponse Error
+
+func (response CreateMember401JSONResponse) VisitCreateMemberResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateMember403JSONResponse Error
+
+func (response CreateMember403JSONResponse) VisitCreateMemberResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type RemoveMemberRequestObject struct {
+	Slug   HouseholdSlug `json:"slug"`
+	UserId MemberUserId  `json:"userId"`
+}
+
+type RemoveMemberResponseObject interface {
+	VisitRemoveMemberResponse(w http.ResponseWriter) error
+}
+
+type RemoveMember200JSONResponse Ok
+
+func (response RemoveMember200JSONResponse) VisitRemoveMemberResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type RemoveMember400JSONResponse Error
+
+func (response RemoveMember400JSONResponse) VisitRemoveMemberResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type RemoveMember401JSONResponse Error
+
+func (response RemoveMember401JSONResponse) VisitRemoveMemberResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type RemoveMember403JSONResponse Error
+
+func (response RemoveMember403JSONResponse) VisitRemoveMemberResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type RemoveMember404JSONResponse Error
+
+func (response RemoveMember404JSONResponse) VisitRemoveMemberResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type RemoveMember409JSONResponse Error
+
+func (response RemoveMember409JSONResponse) VisitRemoveMemberResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(409)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GrantProviderAccessRequestObject struct {
+	Slug   HouseholdSlug `json:"slug"`
+	UserId MemberUserId  `json:"userId"`
+	Body   *GrantProviderAccessJSONRequestBody
+}
+
+type GrantProviderAccessResponseObject interface {
+	VisitGrantProviderAccessResponse(w http.ResponseWriter) error
+}
+
+type GrantProviderAccess200JSONResponse Ok
+
+func (response GrantProviderAccess200JSONResponse) VisitGrantProviderAccessResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GrantProviderAccess400JSONResponse Error
+
+func (response GrantProviderAccess400JSONResponse) VisitGrantProviderAccessResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GrantProviderAccess401JSONResponse Error
+
+func (response GrantProviderAccess401JSONResponse) VisitGrantProviderAccessResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GrantProviderAccess403JSONResponse Error
+
+func (response GrantProviderAccess403JSONResponse) VisitGrantProviderAccessResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GrantProviderAccess404JSONResponse Error
+
+func (response GrantProviderAccess404JSONResponse) VisitGrantProviderAccessResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type RevokeProviderAccessRequestObject struct {
+	Slug        HouseholdSlug `json:"slug"`
+	UserId      MemberUserId  `json:"userId"`
+	ProviderKey string        `json:"providerKey"`
+}
+
+type RevokeProviderAccessResponseObject interface {
+	VisitRevokeProviderAccessResponse(w http.ResponseWriter) error
+}
+
+type RevokeProviderAccess200JSONResponse Ok
+
+func (response RevokeProviderAccess200JSONResponse) VisitRevokeProviderAccessResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type RevokeProviderAccess400JSONResponse Error
+
+func (response RevokeProviderAccess400JSONResponse) VisitRevokeProviderAccessResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type RevokeProviderAccess401JSONResponse Error
+
+func (response RevokeProviderAccess401JSONResponse) VisitRevokeProviderAccessResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type RevokeProviderAccess403JSONResponse Error
+
+func (response RevokeProviderAccess403JSONResponse) VisitRevokeProviderAccessResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type RevokeProviderAccess404JSONResponse Error
+
+func (response RevokeProviderAccess404JSONResponse) VisitRevokeProviderAccessResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateMemberRoleRequestObject struct {
+	Slug   HouseholdSlug `json:"slug"`
+	UserId MemberUserId  `json:"userId"`
+	Body   *UpdateMemberRoleJSONRequestBody
+}
+
+type UpdateMemberRoleResponseObject interface {
+	VisitUpdateMemberRoleResponse(w http.ResponseWriter) error
+}
+
+type UpdateMemberRole200JSONResponse Ok
+
+func (response UpdateMemberRole200JSONResponse) VisitUpdateMemberRoleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateMemberRole400JSONResponse Error
+
+func (response UpdateMemberRole400JSONResponse) VisitUpdateMemberRoleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateMemberRole401JSONResponse Error
+
+func (response UpdateMemberRole401JSONResponse) VisitUpdateMemberRoleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateMemberRole403JSONResponse Error
+
+func (response UpdateMemberRole403JSONResponse) VisitUpdateMemberRoleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateMemberRole404JSONResponse Error
+
+func (response UpdateMemberRole404JSONResponse) VisitUpdateMemberRoleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateSenderRuleRequestObject struct {
+	Slug HouseholdSlug `json:"slug"`
+	Body *CreateSenderRuleJSONRequestBody
+}
+
+type CreateSenderRuleResponseObject interface {
+	VisitCreateSenderRuleResponse(w http.ResponseWriter) error
+}
+
+type CreateSenderRule201JSONResponse SenderRuleResult
+
+func (response CreateSenderRule201JSONResponse) VisitCreateSenderRuleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(201)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateSenderRule400JSONResponse Error
+
+func (response CreateSenderRule400JSONResponse) VisitCreateSenderRuleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateSenderRule401JSONResponse Error
+
+func (response CreateSenderRule401JSONResponse) VisitCreateSenderRuleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateSenderRule403JSONResponse Error
+
+func (response CreateSenderRule403JSONResponse) VisitCreateSenderRuleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateSenderRule404JSONResponse Error
+
+func (response CreateSenderRule404JSONResponse) VisitCreateSenderRuleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateSenderRule409JSONResponse Error
+
+func (response CreateSenderRule409JSONResponse) VisitCreateSenderRuleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(409)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DeleteSenderRuleRequestObject struct {
+	Slug   HouseholdSlug `json:"slug"`
+	RuleId SenderRuleId  `json:"ruleId"`
+}
+
+type DeleteSenderRuleResponseObject interface {
+	VisitDeleteSenderRuleResponse(w http.ResponseWriter) error
+}
+
+type DeleteSenderRule200JSONResponse Ok
+
+func (response DeleteSenderRule200JSONResponse) VisitDeleteSenderRuleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DeleteSenderRule401JSONResponse Error
+
+func (response DeleteSenderRule401JSONResponse) VisitDeleteSenderRuleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DeleteSenderRule403JSONResponse Error
+
+func (response DeleteSenderRule403JSONResponse) VisitDeleteSenderRuleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DeleteSenderRule404JSONResponse Error
+
+func (response DeleteSenderRule404JSONResponse) VisitDeleteSenderRuleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateSenderRuleRequestObject struct {
+	Slug   HouseholdSlug `json:"slug"`
+	RuleId SenderRuleId  `json:"ruleId"`
+	Body   *UpdateSenderRuleJSONRequestBody
+}
+
+type UpdateSenderRuleResponseObject interface {
+	VisitUpdateSenderRuleResponse(w http.ResponseWriter) error
+}
+
+type UpdateSenderRule200JSONResponse SenderRuleResult
+
+func (response UpdateSenderRule200JSONResponse) VisitUpdateSenderRuleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateSenderRule400JSONResponse Error
+
+func (response UpdateSenderRule400JSONResponse) VisitUpdateSenderRuleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateSenderRule401JSONResponse Error
+
+func (response UpdateSenderRule401JSONResponse) VisitUpdateSenderRuleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateSenderRule403JSONResponse Error
+
+func (response UpdateSenderRule403JSONResponse) VisitUpdateSenderRuleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateSenderRule404JSONResponse Error
+
+func (response UpdateSenderRule404JSONResponse) VisitUpdateSenderRuleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateSenderRule409JSONResponse Error
+
+func (response UpdateSenderRule409JSONResponse) VisitUpdateSenderRuleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(409)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListProviderConfigurationsRequestObject struct {
+	Slug HouseholdSlug `json:"slug"`
+}
+
+type ListProviderConfigurationsResponseObject interface {
+	VisitListProviderConfigurationsResponse(w http.ResponseWriter) error
+}
+
+type ListProviderConfigurations200JSONResponse ProviderConfigurationList
+
+func (response ListProviderConfigurations200JSONResponse) VisitListProviderConfigurationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListProviderConfigurations401JSONResponse Error
+
+func (response ListProviderConfigurations401JSONResponse) VisitListProviderConfigurationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListProviderConfigurations403JSONResponse Error
+
+func (response ListProviderConfigurations403JSONResponse) VisitListProviderConfigurationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateProviderRequestObject struct {
+	Slug HouseholdSlug `json:"slug"`
+	Body *CreateProviderJSONRequestBody
+}
+
+type CreateProviderResponseObject interface {
+	VisitCreateProviderResponse(w http.ResponseWriter) error
+}
+
+type CreateProvider201JSONResponse ProviderResult
+
+func (response CreateProvider201JSONResponse) VisitCreateProviderResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(201)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateProvider400JSONResponse Error
+
+func (response CreateProvider400JSONResponse) VisitCreateProviderResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateProvider401JSONResponse Error
+
+func (response CreateProvider401JSONResponse) VisitCreateProviderResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateProvider403JSONResponse Error
+
+func (response CreateProvider403JSONResponse) VisitCreateProviderResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateProvider409JSONResponse Error
+
+func (response CreateProvider409JSONResponse) VisitCreateProviderResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(409)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DeleteProviderRequestObject struct {
+	Slug       HouseholdSlug `json:"slug"`
+	ProviderId ProviderId    `json:"providerId"`
+}
+
+type DeleteProviderResponseObject interface {
+	VisitDeleteProviderResponse(w http.ResponseWriter) error
+}
+
+type DeleteProvider200JSONResponse Ok
+
+func (response DeleteProvider200JSONResponse) VisitDeleteProviderResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DeleteProvider401JSONResponse Error
+
+func (response DeleteProvider401JSONResponse) VisitDeleteProviderResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DeleteProvider403JSONResponse Error
+
+func (response DeleteProvider403JSONResponse) VisitDeleteProviderResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DeleteProvider404JSONResponse Error
+
+func (response DeleteProvider404JSONResponse) VisitDeleteProviderResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateProviderRequestObject struct {
+	Slug       HouseholdSlug `json:"slug"`
+	ProviderId ProviderId    `json:"providerId"`
+	Body       *UpdateProviderJSONRequestBody
+}
+
+type UpdateProviderResponseObject interface {
+	VisitUpdateProviderResponse(w http.ResponseWriter) error
+}
+
+type UpdateProvider200JSONResponse ProviderResult
+
+func (response UpdateProvider200JSONResponse) VisitUpdateProviderResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateProvider400JSONResponse Error
+
+func (response UpdateProvider400JSONResponse) VisitUpdateProviderResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateProvider401JSONResponse Error
+
+func (response UpdateProvider401JSONResponse) VisitUpdateProviderResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateProvider403JSONResponse Error
+
+func (response UpdateProvider403JSONResponse) VisitUpdateProviderResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateProvider404JSONResponse Error
+
+func (response UpdateProvider404JSONResponse) VisitUpdateProviderResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateProvider409JSONResponse Error
+
+func (response UpdateProvider409JSONResponse) VisitUpdateProviderResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(409)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetHouseholdSettingsRequestObject struct {
+	Slug HouseholdSlug `json:"slug"`
+}
+
+type GetHouseholdSettingsResponseObject interface {
+	VisitGetHouseholdSettingsResponse(w http.ResponseWriter) error
+}
+
+type GetHouseholdSettings200JSONResponse HouseholdSettingsResult
+
+func (response GetHouseholdSettings200JSONResponse) VisitGetHouseholdSettingsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetHouseholdSettings401JSONResponse Error
+
+func (response GetHouseholdSettings401JSONResponse) VisitGetHouseholdSettingsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetHouseholdSettings403JSONResponse Error
+
+func (response GetHouseholdSettings403JSONResponse) VisitGetHouseholdSettingsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetHouseholdSettings404JSONResponse Error
+
+func (response GetHouseholdSettings404JSONResponse) VisitGetHouseholdSettingsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateHouseholdSettingsRequestObject struct {
+	Slug HouseholdSlug `json:"slug"`
+	Body *UpdateHouseholdSettingsJSONRequestBody
+}
+
+type UpdateHouseholdSettingsResponseObject interface {
+	VisitUpdateHouseholdSettingsResponse(w http.ResponseWriter) error
+}
+
+type UpdateHouseholdSettings200JSONResponse HouseholdSettingsResult
+
+func (response UpdateHouseholdSettings200JSONResponse) VisitUpdateHouseholdSettingsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateHouseholdSettings400JSONResponse Error
+
+func (response UpdateHouseholdSettings400JSONResponse) VisitUpdateHouseholdSettingsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateHouseholdSettings401JSONResponse Error
+
+func (response UpdateHouseholdSettings401JSONResponse) VisitUpdateHouseholdSettingsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateHouseholdSettings403JSONResponse Error
+
+func (response UpdateHouseholdSettings403JSONResponse) VisitUpdateHouseholdSettingsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateHouseholdSettings404JSONResponse Error
+
+func (response UpdateHouseholdSettings404JSONResponse) VisitUpdateHouseholdSettingsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
 }
 
 type CreateHouseholdRequestObject struct {
@@ -1295,6 +3420,66 @@ func (response Readyz503JSONResponse) VisitReadyzResponse(w http.ResponseWriter)
 
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {
+	// ListAuditEvents The household's audit trail, newest 100 first. Owner-only: it names who did what to whom, which is exactly the sort of thing a member has no business reading about the rest of the household.
+	// (GET /api/admin/{slug}/audit)
+	ListAuditEvents(ctx context.Context, request ListAuditEventsRequestObject) (ListAuditEventsResponseObject, error)
+	// ListInvitations Every invitation this household has issued, newest first. Invitations past their expiry are marked expired before the list is read, so the screen never shows a pending invitation whose link no longer works.
+	// (GET /api/admin/{slug}/invitations)
+	ListInvitations(ctx context.Context, request ListInvitationsRequestObject) (ListInvitationsResponseObject, error)
+	// CreateInvitation Invite somebody, optionally scoped to a set of providers they will be able to read the moment they accept.
+	// (POST /api/admin/{slug}/invitations)
+	CreateInvitation(ctx context.Context, request CreateInvitationRequestObject) (CreateInvitationResponseObject, error)
+	// CancelInvitation Cancel a pending invitation, which makes its link stop working.
+	// (DELETE /api/admin/{slug}/invitations/{invitationId})
+	CancelInvitation(ctx context.Context, request CancelInvitationRequestObject) (CancelInvitationResponseObject, error)
+	// ResendInvitation Issue a fresh invitation to the same person with the same role and provider scope, cancelling the old one. A new token, so the link in the first email stops working — which is what makes "resend" safe to offer after a link has been forwarded to the wrong inbox.
+	// (POST /api/admin/{slug}/invitations/{invitationId}/resend)
+	ResendInvitation(ctx context.Context, request ResendInvitationRequestObject) (ResendInvitationResponseObject, error)
+	// ListMembers Everybody in the household with the providers each of them may read, plus the household's providers so the screen can offer the rest.
+	// (GET /api/admin/{slug}/members)
+	ListMembers(ctx context.Context, request ListMembersRequestObject) (ListMembersResponseObject, error)
+	// CreateMember "Add a member" — which is an invitation with no provider scope, not an account this endpoint creates. Nobody may be given a password by somebody else, so the invitee always sets their own.
+	// (POST /api/admin/{slug}/members)
+	CreateMember(ctx context.Context, request CreateMemberRequestObject) (CreateMemberResponseObject, error)
+	// RemoveMember Remove somebody else from the household. Refused for the last owner, and refused for yourself — "leave household" is the route for that, so that giving up your own access is never a click away from removing somebody else's.
+	// (DELETE /api/admin/{slug}/members/{userId})
+	RemoveMember(ctx context.Context, request RemoveMemberRequestObject) (RemoveMemberResponseObject, error)
+	// GrantProviderAccess Let a member read one provider's messages. Idempotent: granting twice is the same as granting once, so a double-click is not an error.
+	// (POST /api/admin/{slug}/members/{userId}/provider-access)
+	GrantProviderAccess(ctx context.Context, request GrantProviderAccessRequestObject) (GrantProviderAccessResponseObject, error)
+	// RevokeProviderAccess Take a provider away from a member. The key is a path parameter and only a path parameter — the TypeScript also read it from a JSON body on DELETE, which is a shape no client sends and every proxy is entitled to drop.
+	// (DELETE /api/admin/{slug}/members/{userId}/provider-access/{providerKey})
+	RevokeProviderAccess(ctx context.Context, request RevokeProviderAccessRequestObject) (RevokeProviderAccessResponseObject, error)
+	// UpdateMemberRole Promote or demote somebody else. Refused for yourself: an owner who could demote themselves could leave a household with no owner at all, and the answer names the other owners as the way out.
+	// (PATCH /api/admin/{slug}/members/{userId}/role)
+	UpdateMemberRole(ctx context.Context, request UpdateMemberRoleRequestObject) (UpdateMemberRoleResponseObject, error)
+	// CreateSenderRule Add a sender rule: the address or domain whose mail files into a provider. Exact rules beat domain rules, and the most specific domain rule wins among those.
+	// (POST /api/admin/{slug}/provider-rules)
+	CreateSenderRule(ctx context.Context, request CreateSenderRuleRequestObject) (CreateSenderRuleResponseObject, error)
+	// DeleteSenderRule Remove a sender rule. Messages already filed under its provider stay.
+	// (DELETE /api/admin/{slug}/provider-rules/{ruleId})
+	DeleteSenderRule(ctx context.Context, request DeleteSenderRuleRequestObject) (DeleteSenderRuleResponseObject, error)
+	// UpdateSenderRule Repoint a sender rule, or change what it matches.
+	// (PATCH /api/admin/{slug}/provider-rules/{ruleId})
+	UpdateSenderRule(ctx context.Context, request UpdateSenderRuleRequestObject) (UpdateSenderRuleResponseObject, error)
+	// ListProviderConfigurations Every provider in the household with the number of sender rules that point at it, plus the rules themselves — the two halves of the provider settings screen in one request.
+	// (GET /api/admin/{slug}/providers)
+	ListProviderConfigurations(ctx context.Context, request ListProviderConfigurationsRequestObject) (ListProviderConfigurationsResponseObject, error)
+	// CreateProvider Add a provider — the mailbox a set of sender rules files messages into.
+	// (POST /api/admin/{slug}/providers)
+	CreateProvider(ctx context.Context, request CreateProviderRequestObject) (CreateProviderResponseObject, error)
+	// DeleteProvider Remove a provider. Its sender rules, its stored messages and every member's access to it go with it — the foreign keys cascade, which is the point: a deleted provider must not leave readable messages behind.
+	// (DELETE /api/admin/{slug}/providers/{providerId})
+	DeleteProvider(ctx context.Context, request DeleteProviderRequestObject) (DeleteProviderResponseObject, error)
+	// UpdateProvider Rename a provider or change its key.
+	// (PATCH /api/admin/{slug}/providers/{providerId})
+	UpdateProvider(ctx context.Context, request UpdateProviderRequestObject) (UpdateProviderResponseObject, error)
+	// GetHouseholdSettings The household's own settings: its name and the inbound address providers must be told to send codes to.
+	// (GET /api/admin/{slug}/settings)
+	GetHouseholdSettings(ctx context.Context, request GetHouseholdSettingsRequestObject) (GetHouseholdSettingsResponseObject, error)
+	// UpdateHouseholdSettings Rename the household. The slug — and therefore the inbound address — never changes.
+	// (PATCH /api/admin/{slug}/settings)
+	UpdateHouseholdSettings(ctx context.Context, request UpdateHouseholdSettingsRequestObject) (UpdateHouseholdSettingsResponseObject, error)
 	// CreateHousehold Create a household with the caller as its owner. Restricted (REF §A2): the installation owner may always; anybody else only while they belong to no household at all, so a member cannot mint extra households or squat inbound addresses. Rate limited (10 per hour).
 	// (POST /api/households)
 	CreateHousehold(ctx context.Context, request CreateHouseholdRequestObject) (CreateHouseholdResponseObject, error)
@@ -1376,6 +3561,600 @@ type strictHandler struct {
 	ssi         StrictServerInterface
 	middlewares []StrictMiddlewareFunc
 	options     StrictHTTPServerOptions
+}
+
+// ListAuditEvents operation middleware
+func (sh *strictHandler) ListAuditEvents(w http.ResponseWriter, r *http.Request, slug HouseholdSlug) {
+	var request ListAuditEventsRequestObject
+
+	request.Slug = slug
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListAuditEvents(ctx, request.(ListAuditEventsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListAuditEvents")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListAuditEventsResponseObject); ok {
+		if err := validResponse.VisitListAuditEventsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// ListInvitations operation middleware
+func (sh *strictHandler) ListInvitations(w http.ResponseWriter, r *http.Request, slug HouseholdSlug) {
+	var request ListInvitationsRequestObject
+
+	request.Slug = slug
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListInvitations(ctx, request.(ListInvitationsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListInvitations")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListInvitationsResponseObject); ok {
+		if err := validResponse.VisitListInvitationsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// CreateInvitation operation middleware
+func (sh *strictHandler) CreateInvitation(w http.ResponseWriter, r *http.Request, slug HouseholdSlug) {
+	var request CreateInvitationRequestObject
+
+	request.Slug = slug
+
+	var body CreateInvitationJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.CreateInvitation(ctx, request.(CreateInvitationRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "CreateInvitation")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(CreateInvitationResponseObject); ok {
+		if err := validResponse.VisitCreateInvitationResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// CancelInvitation operation middleware
+func (sh *strictHandler) CancelInvitation(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, invitationId InvitationId) {
+	var request CancelInvitationRequestObject
+
+	request.Slug = slug
+	request.InvitationId = invitationId
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.CancelInvitation(ctx, request.(CancelInvitationRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "CancelInvitation")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(CancelInvitationResponseObject); ok {
+		if err := validResponse.VisitCancelInvitationResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// ResendInvitation operation middleware
+func (sh *strictHandler) ResendInvitation(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, invitationId InvitationId) {
+	var request ResendInvitationRequestObject
+
+	request.Slug = slug
+	request.InvitationId = invitationId
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ResendInvitation(ctx, request.(ResendInvitationRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ResendInvitation")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ResendInvitationResponseObject); ok {
+		if err := validResponse.VisitResendInvitationResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// ListMembers operation middleware
+func (sh *strictHandler) ListMembers(w http.ResponseWriter, r *http.Request, slug HouseholdSlug) {
+	var request ListMembersRequestObject
+
+	request.Slug = slug
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListMembers(ctx, request.(ListMembersRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListMembers")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListMembersResponseObject); ok {
+		if err := validResponse.VisitListMembersResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// CreateMember operation middleware
+func (sh *strictHandler) CreateMember(w http.ResponseWriter, r *http.Request, slug HouseholdSlug) {
+	var request CreateMemberRequestObject
+
+	request.Slug = slug
+
+	var body CreateMemberJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.CreateMember(ctx, request.(CreateMemberRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "CreateMember")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(CreateMemberResponseObject); ok {
+		if err := validResponse.VisitCreateMemberResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// RemoveMember operation middleware
+func (sh *strictHandler) RemoveMember(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, userId MemberUserId) {
+	var request RemoveMemberRequestObject
+
+	request.Slug = slug
+	request.UserId = userId
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.RemoveMember(ctx, request.(RemoveMemberRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "RemoveMember")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(RemoveMemberResponseObject); ok {
+		if err := validResponse.VisitRemoveMemberResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GrantProviderAccess operation middleware
+func (sh *strictHandler) GrantProviderAccess(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, userId MemberUserId) {
+	var request GrantProviderAccessRequestObject
+
+	request.Slug = slug
+	request.UserId = userId
+
+	var body GrantProviderAccessJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GrantProviderAccess(ctx, request.(GrantProviderAccessRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GrantProviderAccess")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GrantProviderAccessResponseObject); ok {
+		if err := validResponse.VisitGrantProviderAccessResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// RevokeProviderAccess operation middleware
+func (sh *strictHandler) RevokeProviderAccess(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, userId MemberUserId, providerKey string) {
+	var request RevokeProviderAccessRequestObject
+
+	request.Slug = slug
+	request.UserId = userId
+	request.ProviderKey = providerKey
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.RevokeProviderAccess(ctx, request.(RevokeProviderAccessRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "RevokeProviderAccess")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(RevokeProviderAccessResponseObject); ok {
+		if err := validResponse.VisitRevokeProviderAccessResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// UpdateMemberRole operation middleware
+func (sh *strictHandler) UpdateMemberRole(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, userId MemberUserId) {
+	var request UpdateMemberRoleRequestObject
+
+	request.Slug = slug
+	request.UserId = userId
+
+	var body UpdateMemberRoleJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.UpdateMemberRole(ctx, request.(UpdateMemberRoleRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "UpdateMemberRole")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(UpdateMemberRoleResponseObject); ok {
+		if err := validResponse.VisitUpdateMemberRoleResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// CreateSenderRule operation middleware
+func (sh *strictHandler) CreateSenderRule(w http.ResponseWriter, r *http.Request, slug HouseholdSlug) {
+	var request CreateSenderRuleRequestObject
+
+	request.Slug = slug
+
+	var body CreateSenderRuleJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.CreateSenderRule(ctx, request.(CreateSenderRuleRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "CreateSenderRule")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(CreateSenderRuleResponseObject); ok {
+		if err := validResponse.VisitCreateSenderRuleResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// DeleteSenderRule operation middleware
+func (sh *strictHandler) DeleteSenderRule(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, ruleId SenderRuleId) {
+	var request DeleteSenderRuleRequestObject
+
+	request.Slug = slug
+	request.RuleId = ruleId
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.DeleteSenderRule(ctx, request.(DeleteSenderRuleRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "DeleteSenderRule")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(DeleteSenderRuleResponseObject); ok {
+		if err := validResponse.VisitDeleteSenderRuleResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// UpdateSenderRule operation middleware
+func (sh *strictHandler) UpdateSenderRule(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, ruleId SenderRuleId) {
+	var request UpdateSenderRuleRequestObject
+
+	request.Slug = slug
+	request.RuleId = ruleId
+
+	var body UpdateSenderRuleJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.UpdateSenderRule(ctx, request.(UpdateSenderRuleRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "UpdateSenderRule")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(UpdateSenderRuleResponseObject); ok {
+		if err := validResponse.VisitUpdateSenderRuleResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// ListProviderConfigurations operation middleware
+func (sh *strictHandler) ListProviderConfigurations(w http.ResponseWriter, r *http.Request, slug HouseholdSlug) {
+	var request ListProviderConfigurationsRequestObject
+
+	request.Slug = slug
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListProviderConfigurations(ctx, request.(ListProviderConfigurationsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListProviderConfigurations")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListProviderConfigurationsResponseObject); ok {
+		if err := validResponse.VisitListProviderConfigurationsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// CreateProvider operation middleware
+func (sh *strictHandler) CreateProvider(w http.ResponseWriter, r *http.Request, slug HouseholdSlug) {
+	var request CreateProviderRequestObject
+
+	request.Slug = slug
+
+	var body CreateProviderJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.CreateProvider(ctx, request.(CreateProviderRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "CreateProvider")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(CreateProviderResponseObject); ok {
+		if err := validResponse.VisitCreateProviderResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// DeleteProvider operation middleware
+func (sh *strictHandler) DeleteProvider(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, providerId ProviderId) {
+	var request DeleteProviderRequestObject
+
+	request.Slug = slug
+	request.ProviderId = providerId
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.DeleteProvider(ctx, request.(DeleteProviderRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "DeleteProvider")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(DeleteProviderResponseObject); ok {
+		if err := validResponse.VisitDeleteProviderResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// UpdateProvider operation middleware
+func (sh *strictHandler) UpdateProvider(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, providerId ProviderId) {
+	var request UpdateProviderRequestObject
+
+	request.Slug = slug
+	request.ProviderId = providerId
+
+	var body UpdateProviderJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.UpdateProvider(ctx, request.(UpdateProviderRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "UpdateProvider")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(UpdateProviderResponseObject); ok {
+		if err := validResponse.VisitUpdateProviderResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetHouseholdSettings operation middleware
+func (sh *strictHandler) GetHouseholdSettings(w http.ResponseWriter, r *http.Request, slug HouseholdSlug) {
+	var request GetHouseholdSettingsRequestObject
+
+	request.Slug = slug
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetHouseholdSettings(ctx, request.(GetHouseholdSettingsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetHouseholdSettings")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetHouseholdSettingsResponseObject); ok {
+		if err := validResponse.VisitGetHouseholdSettingsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// UpdateHouseholdSettings operation middleware
+func (sh *strictHandler) UpdateHouseholdSettings(w http.ResponseWriter, r *http.Request, slug HouseholdSlug) {
+	var request UpdateHouseholdSettingsRequestObject
+
+	request.Slug = slug
+
+	var body UpdateHouseholdSettingsJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.UpdateHouseholdSettings(ctx, request.(UpdateHouseholdSettingsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "UpdateHouseholdSettings")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(UpdateHouseholdSettingsResponseObject); ok {
+		if err := validResponse.VisitUpdateHouseholdSettingsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
 }
 
 // CreateHousehold operation middleware

--- a/apps/server/internal/api/gen/server.gen.go
+++ b/apps/server/internal/api/gen/server.gen.go
@@ -20,12 +20,36 @@ import (
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
+	// CreateHousehold Create a household with the caller as its owner. Restricted (REF §A2): the installation owner may always; anybody else only while they belong to no household at all, so a member cannot mint extra households or squat inbound addresses. Rate limited (10 per hour).
+	// (POST /api/households)
+	CreateHousehold(w http.ResponseWriter, r *http.Request)
+	// ListMyHouseholds Every household the caller belongs to, for the household switcher. Ordered by lower-cased display name so the list does not reshuffle when somebody renames a household with a capital letter.
+	// (GET /api/households/me)
+	ListMyHouseholds(w http.ResponseWriter, r *http.Request)
+	// LeaveHousehold Give up your own membership of this household. Refused for the last owner, which is what keeps a household from being left with nobody who can administer it.
+	// (POST /api/households/{slug}/leave)
+	LeaveHousehold(w http.ResponseWriter, r *http.Request, slug HouseholdSlug)
 	// AcceptInvitation Accept an invitation, as the signed-in user or by creating the invited account. Rate limited with the lookup above.
 	// (POST /api/invitations/accept)
 	AcceptInvitation(w http.ResponseWriter, r *http.Request, params AcceptInvitationParams)
 	// LookupInvitation What an invitation link points at, for the invite page. Public and rate limited (20 per 10 minutes): together with accept, this is the one unauthenticated path that reveals whether a token exists.
 	// (GET /api/invitations/lookup)
 	LookupInvitation(w http.ResponseWriter, r *http.Request, params LookupInvitationParams)
+	// GetAccountSettings The account settings screen in one request: the caller's profile with their households, and their signed-in devices newest first.
+	// (GET /api/settings)
+	GetAccountSettings(w http.ResponseWriter, r *http.Request)
+	// ListSettingsHouseholds The caller's households, the same list GET /api/households/me answers with. It exists separately because the settings screen refetches it on its own after leaving a household.
+	// (GET /api/settings/households)
+	ListSettingsHouseholds(w http.ResponseWriter, r *http.Request)
+	// UpdateProfile Update the caller's display name and avatar.
+	// (PATCH /api/settings/profile)
+	UpdateProfile(w http.ResponseWriter, r *http.Request)
+	// RevokeOtherSessions Sign out everywhere else: every session of this account except the one this request arrived on.
+	// (DELETE /api/settings/sessions/others)
+	RevokeOtherSessions(w http.ResponseWriter, r *http.Request)
+	// RevokeSession Revoke one device. A session id that is not the caller's own revokes nothing and still answers 200 — deliberately, so the endpoint cannot be used to discover whether an id exists.
+	// (DELETE /api/settings/sessions/{sessionId})
+	RevokeSession(w http.ResponseWriter, r *http.Request, sessionId string)
 	// CompleteSetup Claim the installation: create the owner account, their first household, and lock setup. Rate limited (5 per 15 minutes) because the body carries SETUP_SECRET.
 	// (POST /api/setup/complete)
 	CompleteSetup(w http.ResponseWriter, r *http.Request)
@@ -48,6 +72,60 @@ type ServerInterfaceWrapper struct {
 }
 
 type MiddlewareFunc func(http.Handler) http.Handler
+
+// CreateHousehold operation middleware
+func (siw *ServerInterfaceWrapper) CreateHousehold(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateHousehold(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListMyHouseholds operation middleware
+func (siw *ServerInterfaceWrapper) ListMyHouseholds(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListMyHouseholds(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// LeaveHousehold operation middleware
+func (siw *ServerInterfaceWrapper) LeaveHousehold(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.LeaveHousehold(w, r, slug)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
 
 // AcceptInvitation operation middleware
 func (siw *ServerInterfaceWrapper) AcceptInvitation(w http.ResponseWriter, r *http.Request) {
@@ -122,6 +200,88 @@ func (siw *ServerInterfaceWrapper) LookupInvitation(w http.ResponseWriter, r *ht
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.LookupInvitation(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetAccountSettings operation middleware
+func (siw *ServerInterfaceWrapper) GetAccountSettings(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetAccountSettings(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListSettingsHouseholds operation middleware
+func (siw *ServerInterfaceWrapper) ListSettingsHouseholds(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListSettingsHouseholds(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateProfile operation middleware
+func (siw *ServerInterfaceWrapper) UpdateProfile(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateProfile(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// RevokeOtherSessions operation middleware
+func (siw *ServerInterfaceWrapper) RevokeOtherSessions(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.RevokeOtherSessions(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// RevokeSession operation middleware
+func (siw *ServerInterfaceWrapper) RevokeSession(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "sessionId" -------------
+	var sessionId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "sessionId", r.PathValue("sessionId"), &sessionId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "sessionId", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.RevokeSession(w, r, sessionId)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -313,8 +473,207 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/setup/complete", wrapper.CompleteSetup)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/invitations/lookup", wrapper.LookupInvitation)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/invitations/accept", wrapper.AcceptInvitation)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/households/me", wrapper.ListMyHouseholds)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/households", wrapper.CreateHousehold)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/households/{slug}/leave", wrapper.LeaveHousehold)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/settings", wrapper.GetAccountSettings)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/settings/households", wrapper.ListSettingsHouseholds)
+	m.HandleFunc(http.MethodPatch+" "+options.BaseURL+"/api/settings/profile", wrapper.UpdateProfile)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/settings/sessions/others", wrapper.RevokeOtherSessions)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/settings/sessions/{sessionId}", wrapper.RevokeSession)
 
 	return m
+}
+
+type CreateHouseholdRequestObject struct {
+	Body *CreateHouseholdJSONRequestBody
+}
+
+type CreateHouseholdResponseObject interface {
+	VisitCreateHouseholdResponse(w http.ResponseWriter) error
+}
+
+type CreateHousehold201JSONResponse HouseholdResult
+
+func (response CreateHousehold201JSONResponse) VisitCreateHouseholdResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(201)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateHousehold400JSONResponse Error
+
+func (response CreateHousehold400JSONResponse) VisitCreateHouseholdResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateHousehold401JSONResponse Error
+
+func (response CreateHousehold401JSONResponse) VisitCreateHouseholdResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateHousehold403JSONResponse Error
+
+func (response CreateHousehold403JSONResponse) VisitCreateHouseholdResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateHousehold409JSONResponse Error
+
+func (response CreateHousehold409JSONResponse) VisitCreateHouseholdResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(409)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateHousehold429JSONResponse Error
+
+func (response CreateHousehold429JSONResponse) VisitCreateHouseholdResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(429)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListMyHouseholdsRequestObject struct {
+}
+
+type ListMyHouseholdsResponseObject interface {
+	VisitListMyHouseholdsResponse(w http.ResponseWriter) error
+}
+
+type ListMyHouseholds200JSONResponse HouseholdList
+
+func (response ListMyHouseholds200JSONResponse) VisitListMyHouseholdsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListMyHouseholds401JSONResponse Error
+
+func (response ListMyHouseholds401JSONResponse) VisitListMyHouseholdsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type LeaveHouseholdRequestObject struct {
+	Slug HouseholdSlug `json:"slug"`
+}
+
+type LeaveHouseholdResponseObject interface {
+	VisitLeaveHouseholdResponse(w http.ResponseWriter) error
+}
+
+type LeaveHousehold200JSONResponse Ok
+
+func (response LeaveHousehold200JSONResponse) VisitLeaveHouseholdResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type LeaveHousehold401JSONResponse Error
+
+func (response LeaveHousehold401JSONResponse) VisitLeaveHouseholdResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type LeaveHousehold403JSONResponse Error
+
+func (response LeaveHousehold403JSONResponse) VisitLeaveHouseholdResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type LeaveHousehold409JSONResponse Error
+
+func (response LeaveHousehold409JSONResponse) VisitLeaveHouseholdResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(409)
+	_, err := buf.WriteTo(w)
+	return err
 }
 
 type AcceptInvitationRequestObject struct {
@@ -530,6 +889,225 @@ func (response LookupInvitation429JSONResponse) VisitLookupInvitationResponse(w 
 	return err
 }
 
+type GetAccountSettingsRequestObject struct {
+}
+
+type GetAccountSettingsResponseObject interface {
+	VisitGetAccountSettingsResponse(w http.ResponseWriter) error
+}
+
+type GetAccountSettings200JSONResponse AccountSettings
+
+func (response GetAccountSettings200JSONResponse) VisitGetAccountSettingsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetAccountSettings401JSONResponse Error
+
+func (response GetAccountSettings401JSONResponse) VisitGetAccountSettingsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetAccountSettings404JSONResponse Error
+
+func (response GetAccountSettings404JSONResponse) VisitGetAccountSettingsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListSettingsHouseholdsRequestObject struct {
+}
+
+type ListSettingsHouseholdsResponseObject interface {
+	VisitListSettingsHouseholdsResponse(w http.ResponseWriter) error
+}
+
+type ListSettingsHouseholds200JSONResponse HouseholdList
+
+func (response ListSettingsHouseholds200JSONResponse) VisitListSettingsHouseholdsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListSettingsHouseholds401JSONResponse Error
+
+func (response ListSettingsHouseholds401JSONResponse) VisitListSettingsHouseholdsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateProfileRequestObject struct {
+	Body *UpdateProfileJSONRequestBody
+}
+
+type UpdateProfileResponseObject interface {
+	VisitUpdateProfileResponse(w http.ResponseWriter) error
+}
+
+type UpdateProfile200JSONResponse ProfileResult
+
+func (response UpdateProfile200JSONResponse) VisitUpdateProfileResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateProfile400JSONResponse Error
+
+func (response UpdateProfile400JSONResponse) VisitUpdateProfileResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateProfile401JSONResponse Error
+
+func (response UpdateProfile401JSONResponse) VisitUpdateProfileResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateProfile404JSONResponse Error
+
+func (response UpdateProfile404JSONResponse) VisitUpdateProfileResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type RevokeOtherSessionsRequestObject struct {
+}
+
+type RevokeOtherSessionsResponseObject interface {
+	VisitRevokeOtherSessionsResponse(w http.ResponseWriter) error
+}
+
+type RevokeOtherSessions200JSONResponse Ok
+
+func (response RevokeOtherSessions200JSONResponse) VisitRevokeOtherSessionsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type RevokeOtherSessions401JSONResponse Error
+
+func (response RevokeOtherSessions401JSONResponse) VisitRevokeOtherSessionsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type RevokeSessionRequestObject struct {
+	SessionId string `json:"sessionId"`
+}
+
+type RevokeSessionResponseObject interface {
+	VisitRevokeSessionResponse(w http.ResponseWriter) error
+}
+
+type RevokeSession200JSONResponse Ok
+
+func (response RevokeSession200JSONResponse) VisitRevokeSessionResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type RevokeSession401JSONResponse Error
+
+func (response RevokeSession401JSONResponse) VisitRevokeSessionResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
 type CompleteSetupRequestObject struct {
 	Body *CompleteSetupJSONRequestBody
 }
@@ -717,12 +1295,36 @@ func (response Readyz503JSONResponse) VisitReadyzResponse(w http.ResponseWriter)
 
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {
+	// CreateHousehold Create a household with the caller as its owner. Restricted (REF §A2): the installation owner may always; anybody else only while they belong to no household at all, so a member cannot mint extra households or squat inbound addresses. Rate limited (10 per hour).
+	// (POST /api/households)
+	CreateHousehold(ctx context.Context, request CreateHouseholdRequestObject) (CreateHouseholdResponseObject, error)
+	// ListMyHouseholds Every household the caller belongs to, for the household switcher. Ordered by lower-cased display name so the list does not reshuffle when somebody renames a household with a capital letter.
+	// (GET /api/households/me)
+	ListMyHouseholds(ctx context.Context, request ListMyHouseholdsRequestObject) (ListMyHouseholdsResponseObject, error)
+	// LeaveHousehold Give up your own membership of this household. Refused for the last owner, which is what keeps a household from being left with nobody who can administer it.
+	// (POST /api/households/{slug}/leave)
+	LeaveHousehold(ctx context.Context, request LeaveHouseholdRequestObject) (LeaveHouseholdResponseObject, error)
 	// AcceptInvitation Accept an invitation, as the signed-in user or by creating the invited account. Rate limited with the lookup above.
 	// (POST /api/invitations/accept)
 	AcceptInvitation(ctx context.Context, request AcceptInvitationRequestObject) (AcceptInvitationResponseObject, error)
 	// LookupInvitation What an invitation link points at, for the invite page. Public and rate limited (20 per 10 minutes): together with accept, this is the one unauthenticated path that reveals whether a token exists.
 	// (GET /api/invitations/lookup)
 	LookupInvitation(ctx context.Context, request LookupInvitationRequestObject) (LookupInvitationResponseObject, error)
+	// GetAccountSettings The account settings screen in one request: the caller's profile with their households, and their signed-in devices newest first.
+	// (GET /api/settings)
+	GetAccountSettings(ctx context.Context, request GetAccountSettingsRequestObject) (GetAccountSettingsResponseObject, error)
+	// ListSettingsHouseholds The caller's households, the same list GET /api/households/me answers with. It exists separately because the settings screen refetches it on its own after leaving a household.
+	// (GET /api/settings/households)
+	ListSettingsHouseholds(ctx context.Context, request ListSettingsHouseholdsRequestObject) (ListSettingsHouseholdsResponseObject, error)
+	// UpdateProfile Update the caller's display name and avatar.
+	// (PATCH /api/settings/profile)
+	UpdateProfile(ctx context.Context, request UpdateProfileRequestObject) (UpdateProfileResponseObject, error)
+	// RevokeOtherSessions Sign out everywhere else: every session of this account except the one this request arrived on.
+	// (DELETE /api/settings/sessions/others)
+	RevokeOtherSessions(ctx context.Context, request RevokeOtherSessionsRequestObject) (RevokeOtherSessionsResponseObject, error)
+	// RevokeSession Revoke one device. A session id that is not the caller's own revokes nothing and still answers 200 — deliberately, so the endpoint cannot be used to discover whether an id exists.
+	// (DELETE /api/settings/sessions/{sessionId})
+	RevokeSession(ctx context.Context, request RevokeSessionRequestObject) (RevokeSessionResponseObject, error)
 	// CompleteSetup Claim the installation: create the owner account, their first household, and lock setup. Rate limited (5 per 15 minutes) because the body carries SETUP_SECRET.
 	// (POST /api/setup/complete)
 	CompleteSetup(ctx context.Context, request CompleteSetupRequestObject) (CompleteSetupResponseObject, error)
@@ -774,6 +1376,87 @@ type strictHandler struct {
 	ssi         StrictServerInterface
 	middlewares []StrictMiddlewareFunc
 	options     StrictHTTPServerOptions
+}
+
+// CreateHousehold operation middleware
+func (sh *strictHandler) CreateHousehold(w http.ResponseWriter, r *http.Request) {
+	var request CreateHouseholdRequestObject
+
+	var body CreateHouseholdJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.CreateHousehold(ctx, request.(CreateHouseholdRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "CreateHousehold")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(CreateHouseholdResponseObject); ok {
+		if err := validResponse.VisitCreateHouseholdResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// ListMyHouseholds operation middleware
+func (sh *strictHandler) ListMyHouseholds(w http.ResponseWriter, r *http.Request) {
+	var request ListMyHouseholdsRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListMyHouseholds(ctx, request.(ListMyHouseholdsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListMyHouseholds")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListMyHouseholdsResponseObject); ok {
+		if err := validResponse.VisitListMyHouseholdsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// LeaveHousehold operation middleware
+func (sh *strictHandler) LeaveHousehold(w http.ResponseWriter, r *http.Request, slug HouseholdSlug) {
+	var request LeaveHouseholdRequestObject
+
+	request.Slug = slug
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.LeaveHousehold(ctx, request.(LeaveHouseholdRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "LeaveHousehold")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(LeaveHouseholdResponseObject); ok {
+		if err := validResponse.VisitLeaveHouseholdResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
 }
 
 // AcceptInvitation operation middleware
@@ -831,6 +1514,135 @@ func (sh *strictHandler) LookupInvitation(w http.ResponseWriter, r *http.Request
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(LookupInvitationResponseObject); ok {
 		if err := validResponse.VisitLookupInvitationResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetAccountSettings operation middleware
+func (sh *strictHandler) GetAccountSettings(w http.ResponseWriter, r *http.Request) {
+	var request GetAccountSettingsRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetAccountSettings(ctx, request.(GetAccountSettingsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetAccountSettings")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetAccountSettingsResponseObject); ok {
+		if err := validResponse.VisitGetAccountSettingsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// ListSettingsHouseholds operation middleware
+func (sh *strictHandler) ListSettingsHouseholds(w http.ResponseWriter, r *http.Request) {
+	var request ListSettingsHouseholdsRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListSettingsHouseholds(ctx, request.(ListSettingsHouseholdsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListSettingsHouseholds")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListSettingsHouseholdsResponseObject); ok {
+		if err := validResponse.VisitListSettingsHouseholdsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// UpdateProfile operation middleware
+func (sh *strictHandler) UpdateProfile(w http.ResponseWriter, r *http.Request) {
+	var request UpdateProfileRequestObject
+
+	var body UpdateProfileJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.UpdateProfile(ctx, request.(UpdateProfileRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "UpdateProfile")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(UpdateProfileResponseObject); ok {
+		if err := validResponse.VisitUpdateProfileResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// RevokeOtherSessions operation middleware
+func (sh *strictHandler) RevokeOtherSessions(w http.ResponseWriter, r *http.Request) {
+	var request RevokeOtherSessionsRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.RevokeOtherSessions(ctx, request.(RevokeOtherSessionsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "RevokeOtherSessions")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(RevokeOtherSessionsResponseObject); ok {
+		if err := validResponse.VisitRevokeOtherSessionsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// RevokeSession operation middleware
+func (sh *strictHandler) RevokeSession(w http.ResponseWriter, r *http.Request, sessionId string) {
+	var request RevokeSessionRequestObject
+
+	request.SessionId = sessionId
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.RevokeSession(ctx, request.(RevokeSessionRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "RevokeSession")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(RevokeSessionResponseObject); ok {
+		if err := validResponse.VisitRevokeSessionResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {

--- a/apps/server/internal/api/gen/types.gen.go
+++ b/apps/server/internal/api/gen/types.gen.go
@@ -7,6 +7,42 @@ import (
 	"time"
 )
 
+// Defines values for HouseholdSummaryRole.
+const (
+	HouseholdSummaryRoleMember HouseholdSummaryRole = "member"
+	HouseholdSummaryRoleOwner  HouseholdSummaryRole = "owner"
+)
+
+// Valid indicates whether the value is a known member of the HouseholdSummaryRole enum.
+func (e HouseholdSummaryRole) Valid() bool {
+	switch e {
+	case HouseholdSummaryRoleMember:
+		return true
+	case HouseholdSummaryRoleOwner:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for HouseholdWithRoleRole.
+const (
+	HouseholdWithRoleRoleMember HouseholdWithRoleRole = "member"
+	HouseholdWithRoleRoleOwner  HouseholdWithRoleRole = "owner"
+)
+
+// Valid indicates whether the value is a known member of the HouseholdWithRoleRole enum.
+func (e HouseholdWithRoleRole) Valid() bool {
+	switch e {
+	case HouseholdWithRoleRoleMember:
+		return true
+	case HouseholdWithRoleRoleOwner:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for InvitationRole.
 const (
 	InvitationRoleMember InvitationRole = "member"
@@ -142,6 +178,22 @@ type AcceptInvitationRequest struct {
 	Password *string `json:"password,omitempty"`
 }
 
+// AccountSettings defines model for AccountSettings.
+type AccountSettings struct {
+	// Profile The account settings screen's view of the caller. `role` is always null: it carried Better Auth's global role in the TypeScript server, which the Go one has no counterpart for, and stays in the payload because the SPA reads it.
+	Profile  Profile          `json:"profile"`
+	Sessions []SessionSummary `json:"sessions"`
+}
+
+// CreateHouseholdRequest REF §A4's `createHousehold` schema. As with SetupRequest, only the shape is stated here: the slug is normalised (trimmed, lower-cased) before REF §A3's rules are applied to it, and the message each failure produces is the wording the SPA renders next to the input.
+type CreateHouseholdRequest struct {
+	// DisplayName Trimmed, 1..80 characters.
+	DisplayName string `json:"displayName"`
+
+	// Slug Trimmed, lower-cased, and subject to REF §A3's slug rules.
+	Slug string `json:"slug"`
+}
+
 // Error The failure envelope every error response in this API uses. `fields` carries one message per rejected input (keyed by the property or parameter name, `_` for the request body as a whole); `code` is a stable discriminator for the few failures a client must branch on rather than merely display.
 type Error struct {
 	Code   *string            `json:"code,omitempty"`
@@ -157,6 +209,41 @@ type Household struct {
 	Slug        string    `json:"slug"`
 	UpdatedAt   time.Time `json:"updatedAt"`
 }
+
+// HouseholdList defines model for HouseholdList.
+type HouseholdList struct {
+	Households []HouseholdSummary `json:"households"`
+}
+
+// HouseholdResult defines model for HouseholdResult.
+type HouseholdResult struct {
+	// Household A newly created household: the switcher entry's keys plus the timestamps, so the client can drop it straight into its cache.
+	Household HouseholdWithRole `json:"household"`
+}
+
+// HouseholdSummary One entry in the household switcher: a household plus what the caller may do in it.
+type HouseholdSummary struct {
+	DisplayName string               `json:"displayName"`
+	Id          string               `json:"id"`
+	Role        HouseholdSummaryRole `json:"role"`
+	Slug        string               `json:"slug"`
+}
+
+// HouseholdSummaryRole defines model for HouseholdSummary.Role.
+type HouseholdSummaryRole string
+
+// HouseholdWithRole A newly created household: the switcher entry's keys plus the timestamps, so the client can drop it straight into its cache.
+type HouseholdWithRole struct {
+	CreatedAt   time.Time             `json:"createdAt"`
+	DisplayName string                `json:"displayName"`
+	Id          string                `json:"id"`
+	Role        HouseholdWithRoleRole `json:"role"`
+	Slug        string                `json:"slug"`
+	UpdatedAt   time.Time             `json:"updatedAt"`
+}
+
+// HouseholdWithRoleRole defines model for HouseholdWithRole.Role.
+type HouseholdWithRoleRole string
 
 // Invitation One invitation record. The token itself never appears — only its SHA-256 is stored, and the plaintext lives solely in the link.
 type Invitation struct {
@@ -229,6 +316,49 @@ type MembershipResult struct {
 	Member Member `json:"member"`
 }
 
+// Ok The acknowledgement every "it is done, and there is nothing to show for it" endpoint answers with.
+type Ok struct {
+	Ok bool `json:"ok"`
+}
+
+// Profile The account settings screen's view of the caller. `role` is always null: it carried Better Auth's global role in the TypeScript server, which the Go one has no counterpart for, and stays in the payload because the SPA reads it.
+type Profile struct {
+	Email            string             `json:"email"`
+	Households       []HouseholdSummary `json:"households"`
+	Id               string             `json:"id"`
+	Image            *string            `json:"image"`
+	Name             string             `json:"name"`
+	Role             *string            `json:"role"`
+	TwoFactorEnabled bool               `json:"twoFactorEnabled"`
+}
+
+// ProfileRequest REF §A4's `profile` schema. `image` is optional and an empty string clears the avatar; anything else must be an http(s) URL of at most 2048 characters, checked in Go so the message is the TypeScript's ("image must be an http(s) URL").
+type ProfileRequest struct {
+	// Image An http(s) URL, or "" to clear the avatar.
+	Image *string `json:"image,omitempty"`
+
+	// Name Trimmed, 1..80 characters.
+	Name string `json:"name"`
+}
+
+// ProfileResult defines model for ProfileResult.
+type ProfileResult struct {
+	// Profile The account settings screen's view of the caller. `role` is always null: it carried Better Auth's global role in the TypeScript server, which the Go one has no counterpart for, and stays in the payload because the SPA reads it.
+	Profile Profile `json:"profile"`
+}
+
+// SessionSummary One signed-in device. The session TOKEN is a bearer secret and never appears here — `isCurrent` is all the client needs to tell which row it is looking through. `ipAddress` is the digest Limen stored, not a readable address, and `impersonatedBy` is always null (the Go server has no impersonation).
+type SessionSummary struct {
+	CreatedAt      time.Time  `json:"createdAt"`
+	ExpiresAt      time.Time  `json:"expiresAt"`
+	Id             string     `json:"id"`
+	ImpersonatedBy *string    `json:"impersonatedBy"`
+	IpAddress      *string    `json:"ipAddress"`
+	IsCurrent      bool       `json:"isCurrent"`
+	UpdatedAt      *time.Time `json:"updatedAt"`
+	UserAgent      *string    `json:"userAgent"`
+}
+
 // SetupRequest REF §A4's `setup` schema. The shape — which properties exist, which are required, and that each is a string — is enforced here; the LENGTH and FORMAT rules named in each description below are enforced in Go (internal/api/setup.go's validateSetupBody) and deliberately not repeated as `minLength`/`pattern`.
 // Two reasons. The values are trimmed and lower-cased before they are checked, so a schema rule would be testing what was sent rather than what is kept; and the messages the SPA renders next to each input are REF §A4's exact wording, which a schema violation cannot produce.
 type SetupRequest struct {
@@ -268,6 +398,9 @@ type SetupStatus struct {
 // SetupStatusStatus defines model for SetupStatus.Status.
 type SetupStatusStatus string
 
+// HouseholdSlug defines model for HouseholdSlug.
+type HouseholdSlug = string
+
 // InvitationToken defines model for InvitationToken.
 type InvitationToken = string
 
@@ -294,8 +427,14 @@ type Readyz200JSONResponseBodyOk bool
 // Readyz503JSONResponseBodyOk defines parameters for Readyz.
 type Readyz503JSONResponseBodyOk bool
 
+// CreateHouseholdJSONRequestBody defines body for CreateHousehold for application/json ContentType.
+type CreateHouseholdJSONRequestBody = CreateHouseholdRequest
+
 // AcceptInvitationJSONRequestBody defines body for AcceptInvitation for application/json ContentType.
 type AcceptInvitationJSONRequestBody = AcceptInvitationRequest
+
+// UpdateProfileJSONRequestBody defines body for UpdateProfile for application/json ContentType.
+type UpdateProfileJSONRequestBody = ProfileRequest
 
 // CompleteSetupJSONRequestBody defines body for CompleteSetup for application/json ContentType.
 type CompleteSetupJSONRequestBody = SetupRequest

--- a/apps/server/internal/api/gen/types.gen.go
+++ b/apps/server/internal/api/gen/types.gen.go
@@ -7,6 +7,42 @@ import (
 	"time"
 )
 
+// Defines values for HouseholdMemberHouseholdRole.
+const (
+	HouseholdMemberHouseholdRoleMember HouseholdMemberHouseholdRole = "member"
+	HouseholdMemberHouseholdRoleOwner  HouseholdMemberHouseholdRole = "owner"
+)
+
+// Valid indicates whether the value is a known member of the HouseholdMemberHouseholdRole enum.
+func (e HouseholdMemberHouseholdRole) Valid() bool {
+	switch e {
+	case HouseholdMemberHouseholdRoleMember:
+		return true
+	case HouseholdMemberHouseholdRoleOwner:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for HouseholdMemberRole.
+const (
+	HouseholdMemberRoleMember HouseholdMemberRole = "member"
+	HouseholdMemberRoleOwner  HouseholdMemberRole = "owner"
+)
+
+// Valid indicates whether the value is a known member of the HouseholdMemberRole enum.
+func (e HouseholdMemberRole) Valid() bool {
+	switch e {
+	case HouseholdMemberRoleMember:
+		return true
+	case HouseholdMemberRoleOwner:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for HouseholdSummaryRole.
 const (
 	HouseholdSummaryRoleMember HouseholdSummaryRole = "member"
@@ -103,6 +139,24 @@ func (e MemberRole) Valid() bool {
 	}
 }
 
+// Defines values for SenderRuleMatchType.
+const (
+	Domain SenderRuleMatchType = "domain"
+	Exact  SenderRuleMatchType = "exact"
+)
+
+// Valid indicates whether the value is a known member of the SenderRuleMatchType enum.
+func (e SenderRuleMatchType) Valid() bool {
+	switch e {
+	case Domain:
+		return true
+	case Exact:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for SetupStatusStatus.
 const (
 	SetupStatusStatusComplete   SetupStatusStatus = "complete"
@@ -185,6 +239,23 @@ type AccountSettings struct {
 	Sessions []SessionSummary `json:"sessions"`
 }
 
+// AuditEvent One line of the audit trail. `details` is whatever the action recorded (the new role, the provider key, whether an invitation email got out), parsed back from the stored JSON.
+type AuditEvent struct {
+	Action      string                  `json:"action"`
+	ActorUserId *string                 `json:"actorUserId"`
+	CreatedAt   time.Time               `json:"createdAt"`
+	Details     *map[string]interface{} `json:"details"`
+	HouseholdId *string                 `json:"householdId"`
+	Id          string                  `json:"id"`
+	TargetId    *string                 `json:"targetId"`
+	TargetType  string                  `json:"targetType"`
+}
+
+// AuditEventList defines model for AuditEventList.
+type AuditEventList struct {
+	Events []AuditEvent `json:"events"`
+}
+
 // CreateHouseholdRequest REF §A4's `createHousehold` schema. As with SetupRequest, only the shape is stated here: the slug is normalised (trimmed, lower-cased) before REF §A3's rules are applied to it, and the message each failure produces is the wording the SPA renders next to the input.
 type CreateHouseholdRequest struct {
 	// DisplayName Trimmed, 1..80 characters.
@@ -192,6 +263,18 @@ type CreateHouseholdRequest struct {
 
 	// Slug Trimmed, lower-cased, and subject to REF §A3's slug rules.
 	Slug string `json:"slug"`
+}
+
+// CreateMemberRequest REF §A4's `createMember` schema. `role` is a plain string, defaulting to member when absent: the enum would reject `admin`, which REF §A4 accepts and maps to owner, and its rejection would not read "role must be owner or member".
+type CreateMemberRequest struct {
+	// Email Trimmed, lower-cased, 3..254 characters, must look like an address.
+	Email string `json:"email"`
+
+	// Name Trimmed, 1..80 characters.
+	Name string `json:"name"`
+
+	// Role `owner` or `member` (`admin` is accepted and means owner). Defaults to member.
+	Role *string `json:"role,omitempty"`
 }
 
 // Error The failure envelope every error response in this API uses. `fields` carries one message per rejected input (keyed by the property or parameter name, `_` for the request body as a whole); `code` is a stable discriminator for the few failures a client must branch on rather than merely display.
@@ -215,10 +298,47 @@ type HouseholdList struct {
 	Households []HouseholdSummary `json:"households"`
 }
 
+// HouseholdMember One member of the household, with the providers they may read. `role` duplicates `householdRole`: it carried Better Auth's global role in the TypeScript server and the SPA reads both, so the Go server puts the household role in each.
+type HouseholdMember struct {
+	CreatedAt      time.Time                    `json:"createdAt"`
+	Email          string                       `json:"email"`
+	HouseholdRole  HouseholdMemberHouseholdRole `json:"householdRole"`
+	Id             string                       `json:"id"`
+	Name           string                       `json:"name"`
+	ProviderAccess []MemberProviderAccess       `json:"providerAccess"`
+	Role           HouseholdMemberRole          `json:"role"`
+	UpdatedAt      time.Time                    `json:"updatedAt"`
+}
+
+// HouseholdMemberHouseholdRole defines model for HouseholdMember.HouseholdRole.
+type HouseholdMemberHouseholdRole string
+
+// HouseholdMemberRole defines model for HouseholdMember.Role.
+type HouseholdMemberRole string
+
 // HouseholdResult defines model for HouseholdResult.
 type HouseholdResult struct {
 	// Household A newly created household: the switcher entry's keys plus the timestamps, so the client can drop it straight into its cache.
 	Household HouseholdWithRole `json:"household"`
+}
+
+// HouseholdSettings A household's own settings. `emailAddress` is `slug@EMAIL_DOMAIN` — the address providers must be told to send to — and is null only if the installation has no inbound domain configured.
+type HouseholdSettings struct {
+	DisplayName  string  `json:"displayName"`
+	EmailAddress *string `json:"emailAddress"`
+	Slug         string  `json:"slug"`
+}
+
+// HouseholdSettingsRequest REF §A4's `householdSettings` schema. Trimmed and length-checked in Go, for the wording.
+type HouseholdSettingsRequest struct {
+	// DisplayName Trimmed, 1..80 characters.
+	DisplayName string `json:"displayName"`
+}
+
+// HouseholdSettingsResult defines model for HouseholdSettingsResult.
+type HouseholdSettingsResult struct {
+	// Household A household's own settings. `emailAddress` is `slug@EMAIL_DOMAIN` — the address providers must be told to send to — and is null only if the installation has no inbound domain configured.
+	Household HouseholdSettings `json:"household"`
 }
 
 // HouseholdSummary One entry in the household switcher: a household plus what the caller may do in it.
@@ -269,6 +389,11 @@ type InvitationRole string
 // InvitationStatus defines model for Invitation.Status.
 type InvitationStatus string
 
+// InvitationList defines model for InvitationList.
+type InvitationList struct {
+	Invitations []Invitation `json:"invitations"`
+}
+
 // InvitationLookup Everything the invite page needs to pick a flow: create an account, sign in first, or accept as whoever is already signed in.
 type InvitationLookup struct {
 	// AccountExists An account already exists for the invited address.
@@ -297,6 +422,31 @@ type InvitationProvider struct {
 	ProviderKey string `json:"provider_key"`
 }
 
+// InvitationRequest REF §A4's `invitation` schema. See CreateMemberRequest for why `role` is a plain string.
+type InvitationRequest struct {
+	// Email Trimmed, lower-cased, 3..254 characters, must look like an address.
+	Email string `json:"email"`
+
+	// Name Trimmed, 1..80 characters.
+	Name string `json:"name"`
+
+	// ProviderIds The providers the invitee may read the moment they accept. At most 50; every id must belong to this household.
+	ProviderIds *[]string `json:"providerIds,omitempty"`
+
+	// Role `owner` or `member` (`admin` is accepted and means owner). Defaults to member.
+	Role *string `json:"role,omitempty"`
+}
+
+// InvitationResult A newly issued invitation, its link, and whether the email carrying that link got out. A failed delivery is NOT an error (REF §A3): the invitation stands and `inviteUrl` can be shared by hand, so `emailSent` is false and `emailError` says what went wrong.
+type InvitationResult struct {
+	EmailError *string `json:"emailError,omitempty"`
+	EmailSent  bool    `json:"emailSent"`
+
+	// Invitation One invitation record. The token itself never appears — only its SHA-256 is stored, and the plaintext lives solely in the link.
+	Invitation Invitation `json:"invitation"`
+	InviteUrl  string     `json:"inviteUrl"`
+}
+
 // Member The account that was just created or signed in, with its role in the household.
 type Member struct {
 	Email string     `json:"email"`
@@ -307,6 +457,18 @@ type Member struct {
 
 // MemberRole defines model for Member.Role.
 type MemberRole string
+
+// MemberList defines model for MemberList.
+type MemberList struct {
+	Members   []HouseholdMember `json:"members"`
+	Providers []Provider        `json:"providers"`
+}
+
+// MemberProviderAccess One provider a member may read.
+type MemberProviderAccess struct {
+	DisplayName string `json:"displayName"`
+	ProviderKey string `json:"providerKey"`
+}
 
 // MembershipResult What both "you are now the owner" (setup) and "you are now a member" (invitation accept) answer with.
 type MembershipResult struct {
@@ -345,6 +507,89 @@ type ProfileRequest struct {
 type ProfileResult struct {
 	// Profile The account settings screen's view of the caller. `role` is always null: it carried Better Auth's global role in the TypeScript server, which the Go one has no counterpart for, and stays in the payload because the SPA reads it.
 	Profile Profile `json:"profile"`
+}
+
+// Provider One provider. snake_case keys, deliberately: it is what the TypeScript returned and what the SPA reads.
+type Provider struct {
+	CreatedAt   time.Time `json:"created_at"`
+	DisplayName string    `json:"display_name"`
+	HouseholdId string    `json:"household_id"`
+	Id          string    `json:"id"`
+	ProviderKey string    `json:"provider_key"`
+}
+
+// ProviderAccessRequest REF §A4's `providerAccess` schema.
+type ProviderAccessRequest struct {
+	// ProviderKey Trimmed, lower-cased, 1..40 characters.
+	ProviderKey string `json:"providerKey"`
+}
+
+// ProviderConfiguration A provider plus how many sender rules point at it.
+type ProviderConfiguration struct {
+	CreatedAt   time.Time `json:"created_at"`
+	DisplayName string    `json:"display_name"`
+	HouseholdId string    `json:"household_id"`
+	Id          string    `json:"id"`
+	ProviderKey string    `json:"provider_key"`
+	RuleCount   int       `json:"rule_count"`
+}
+
+// ProviderConfigurationList defines model for ProviderConfigurationList.
+type ProviderConfigurationList struct {
+	Providers []ProviderConfiguration `json:"providers"`
+	Rules     []SenderRule            `json:"rules"`
+}
+
+// ProviderRequest REF §A4's `provider` schema. Only the shape is stated here: the key is trimmed and lower-cased before its rules run, and the message each failure produces is REF §A4's wording, which a schema violation cannot produce.
+type ProviderRequest struct {
+	// DisplayName Trimmed, 1..80 characters.
+	DisplayName string `json:"displayName"`
+
+	// ProviderKey Trimmed, lower-cased, 1..40, lowercase letters, numbers and hyphens, starting with a letter or number.
+	ProviderKey string `json:"providerKey"`
+}
+
+// ProviderResult defines model for ProviderResult.
+type ProviderResult struct {
+	// Provider One provider. snake_case keys, deliberately: it is what the TypeScript returned and what the SPA reads.
+	Provider Provider `json:"provider"`
+}
+
+// RoleChangeRequest REF §A4's `roleChange` schema. See CreateMemberRequest for why `role` is not an enum here.
+type RoleChangeRequest struct {
+	// Role `owner` or `member` (`admin` is accepted and means owner).
+	Role string `json:"role"`
+}
+
+// SenderRule One sender rule — the address or domain whose mail files into a provider.
+type SenderRule struct {
+	CreatedAt   time.Time           `json:"created_at"`
+	HouseholdId string              `json:"household_id"`
+	Id          string              `json:"id"`
+	MatchType   SenderRuleMatchType `json:"match_type"`
+	MatchValue  string              `json:"match_value"`
+	ProviderId  string              `json:"provider_id"`
+}
+
+// SenderRuleMatchType defines model for SenderRule.MatchType.
+type SenderRuleMatchType string
+
+// SenderRuleRequest REF §A4's `senderRule` schema. `matchType` is a plain string here rather than an enum for the same reason the lengths are absent: the rejection must read "matchType must be exact or domain", which is checked in Go.
+type SenderRuleRequest struct {
+	// MatchType `exact` or `domain`.
+	MatchType string `json:"matchType"`
+
+	// MatchValue Trimmed, lower-cased, 1..254. A domain rule drops any leading `@` and must then be a hostname; an exact rule must be a full email address.
+	MatchValue string `json:"matchValue"`
+
+	// ProviderId Trimmed, 1..64 characters.
+	ProviderId string `json:"providerId"`
+}
+
+// SenderRuleResult defines model for SenderRuleResult.
+type SenderRuleResult struct {
+	// Rule One sender rule — the address or domain whose mail files into a provider.
+	Rule SenderRule `json:"rule"`
 }
 
 // SessionSummary One signed-in device. The session TOKEN is a bearer secret and never appears here — `isCurrent` is all the client needs to tell which row it is looking through. `ipAddress` is the digest Limen stored, not a readable address, and `impersonatedBy` is always null (the Go server has no impersonation).
@@ -401,8 +646,20 @@ type SetupStatusStatus string
 // HouseholdSlug defines model for HouseholdSlug.
 type HouseholdSlug = string
 
+// InvitationId defines model for InvitationId.
+type InvitationId = string
+
 // InvitationToken defines model for InvitationToken.
 type InvitationToken = string
+
+// MemberUserId defines model for MemberUserId.
+type MemberUserId = string
+
+// ProviderId defines model for ProviderId.
+type ProviderId = string
+
+// SenderRuleId defines model for SenderRuleId.
+type SenderRuleId = string
 
 // AcceptInvitationParams defines parameters for AcceptInvitation.
 type AcceptInvitationParams struct {
@@ -426,6 +683,33 @@ type Readyz200JSONResponseBodyOk bool
 
 // Readyz503JSONResponseBodyOk defines parameters for Readyz.
 type Readyz503JSONResponseBodyOk bool
+
+// CreateInvitationJSONRequestBody defines body for CreateInvitation for application/json ContentType.
+type CreateInvitationJSONRequestBody = InvitationRequest
+
+// CreateMemberJSONRequestBody defines body for CreateMember for application/json ContentType.
+type CreateMemberJSONRequestBody = CreateMemberRequest
+
+// GrantProviderAccessJSONRequestBody defines body for GrantProviderAccess for application/json ContentType.
+type GrantProviderAccessJSONRequestBody = ProviderAccessRequest
+
+// UpdateMemberRoleJSONRequestBody defines body for UpdateMemberRole for application/json ContentType.
+type UpdateMemberRoleJSONRequestBody = RoleChangeRequest
+
+// CreateSenderRuleJSONRequestBody defines body for CreateSenderRule for application/json ContentType.
+type CreateSenderRuleJSONRequestBody = SenderRuleRequest
+
+// UpdateSenderRuleJSONRequestBody defines body for UpdateSenderRule for application/json ContentType.
+type UpdateSenderRuleJSONRequestBody = SenderRuleRequest
+
+// CreateProviderJSONRequestBody defines body for CreateProvider for application/json ContentType.
+type CreateProviderJSONRequestBody = ProviderRequest
+
+// UpdateProviderJSONRequestBody defines body for UpdateProvider for application/json ContentType.
+type UpdateProviderJSONRequestBody = ProviderRequest
+
+// UpdateHouseholdSettingsJSONRequestBody defines body for UpdateHouseholdSettings for application/json ContentType.
+type UpdateHouseholdSettingsJSONRequestBody = HouseholdSettingsRequest
 
 // CreateHouseholdJSONRequestBody defines body for CreateHousehold for application/json ContentType.
 type CreateHouseholdJSONRequestBody = CreateHouseholdRequest

--- a/apps/server/internal/api/helpers.go
+++ b/apps/server/internal/api/helpers.go
@@ -58,6 +58,18 @@ func viewerFrom(ctx context.Context) *auth.Session {
 	return middleware.UserFrom(r)
 }
 
+// householdFrom is the tenancy context RequireHousehold resolved, or nil when
+// the operation's tier does not mount it. It reaches the request the same way
+// viewerFrom does, because a strict handler is handed a context and nothing
+// else.
+func householdFrom(ctx context.Context) *middleware.Household {
+	_, r, ok := middleware.HTTPFromContext(ctx)
+	if !ok || r == nil {
+		return nil
+	}
+	return middleware.HouseholdFrom(r)
+}
+
 // emailPattern is REF §A4's email rule verbatim: deliberately loose, because
 // the authoritative test of an address is whether mail to it arrives, and a
 // stricter pattern only rejects addresses that work.
@@ -85,6 +97,26 @@ func householdBody(household *repo.Household) *gen.Household {
 		UpdatedAt:   household.UpdatedAt,
 	}
 }
+
+// householdSummaries maps the switcher list onto the wire shape. The slice is
+// made non-nil even when empty: `households: []` is what the SPA expects, and
+// a nil slice would marshal as null.
+func householdSummaries(households []repo.HouseholdSummary) []gen.HouseholdSummary {
+	summaries := make([]gen.HouseholdSummary, 0, len(households))
+	for _, household := range households {
+		summaries = append(summaries, gen.HouseholdSummary{
+			Id:          household.ID,
+			Slug:        household.Slug,
+			DisplayName: household.DisplayName,
+			Role:        gen.HouseholdSummaryRole(household.Role),
+		})
+	}
+	return summaries
+}
+
+// okBody is the acknowledgement every "it is done, and there is nothing to
+// show for it" route answers with.
+func okBody() gen.Ok { return gen.Ok{Ok: true} }
 
 // invitationBody maps an invitation and its provider scope onto the wire
 // shape. The provider entries keep their snake_case keys inside a camelCase

--- a/apps/server/internal/api/households.go
+++ b/apps/server/internal/api/households.go
@@ -1,0 +1,194 @@
+package api
+
+import (
+	"context"
+	"strings"
+
+	"github.com/andersro93/mi-casa-su-casa/server/internal/api/gen"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/auth"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/domain"
+	applog "github.com/andersro93/mi-casa-su-casa/server/internal/log"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/repo"
+)
+
+// Ports src/server/routes/households.ts (REF §A2, "Households"): the three
+// routes a signed-in person uses to see, create and give up a household.
+//
+// Two of them are policy rather than plumbing:
+//
+//   - Creation is restricted. A household's slug is also its inbound email
+//     local part, so "anyone signed in may create one" would let an invited
+//     member squat addresses on somebody else's installation. The rule
+//     (mayCreateHousehold) is the installation owner, or a person who belongs
+//     to no household at all — the second half being the recovery path for
+//     somebody whose only household was removed.
+//   - Leaving is refused for the last owner, so a household is never left with
+//     members nobody can administer.
+
+// ListMyHouseholds is the household switcher's list.
+func (s server) ListMyHouseholds(ctx context.Context, _ gen.ListMyHouseholdsRequestObject) (gen.ListMyHouseholdsResponseObject, error) {
+	viewer := viewerFrom(ctx)
+	if viewer == nil {
+		return gen.ListMyHouseholds401JSONResponse(errorBody("Unauthorized")), nil
+	}
+
+	households, err := s.Repo.ListHouseholdsForUser(ctx, viewer.UserID)
+	if err != nil {
+		return nil, err
+	}
+	return gen.ListMyHouseholds200JSONResponse{Households: householdSummaries(households)}, nil
+}
+
+// CreateHousehold creates a household with the caller as its owner.
+//
+// The order below is the TypeScript's: the body is validated before the
+// permission check, so somebody who may not create a household is told that
+// rather than being sent to fix a slug they were never going to be allowed to
+// use — and the check that costs two queries runs on a request that at least
+// makes sense.
+func (s server) CreateHousehold(ctx context.Context, request gen.CreateHouseholdRequestObject) (gen.CreateHouseholdResponseObject, error) {
+	viewer := viewerFrom(ctx)
+	if viewer == nil {
+		return gen.CreateHousehold401JSONResponse(errorBody("Unauthorized")), nil
+	}
+
+	slug := domain.NormalizeHouseholdSlug(request.Body.Slug)
+	displayName := strings.TrimSpace(request.Body.DisplayName)
+	if problems := validateCreateHouseholdBody(slug, displayName); len(problems) > 0 {
+		summary, fields := envelopeFor(problems)
+		return gen.CreateHousehold400JSONResponse(errorFieldsBody(summary, fields)), nil
+	}
+
+	allowed, err := s.mayCreateHousehold(ctx, viewer)
+	if err != nil {
+		return nil, err
+	}
+	if !allowed {
+		return gen.CreateHousehold403JSONResponse(errorBody(
+			"Only the installation owner can create additional households. " +
+				"Ask them to create it and invite you.")), nil
+	}
+
+	existing, err := s.Repo.GetHouseholdBySlug(ctx, slug)
+	if err != nil {
+		return nil, err
+	}
+	if existing != nil {
+		return gen.CreateHousehold409JSONResponse(errorBody("Household slug already exists")), nil
+	}
+
+	household, err := s.Repo.CreateHousehold(ctx, slug, displayName, viewer.UserID)
+	if err != nil {
+		// The lookup above is not a lock: two requests racing for the same
+		// slug both pass it, and the unique index decides. Answering the loser
+		// with the same 409 keeps the outcome the caller sees identical either
+		// way.
+		if repo.IsUniqueViolation(err) {
+			return gen.CreateHousehold409JSONResponse(errorBody("Household slug already exists")), nil
+		}
+		return nil, err
+	}
+
+	s.Repo.RecordAudit(ctx, repo.AuditEventInput{
+		ActorUserID: &viewer.UserID,
+		HouseholdID: &household.ID,
+		Action:      "household.created",
+		TargetType:  "household",
+		TargetID:    &household.ID,
+		Details:     map[string]any{"slug": slug},
+	})
+
+	// The same keys a /api/households/me entry has, plus the timestamps, so
+	// the client can drop the answer straight into its cache.
+	return gen.CreateHousehold201JSONResponse{
+		Household: gen.HouseholdWithRole{
+			Id:          household.ID,
+			Slug:        household.Slug,
+			DisplayName: household.DisplayName,
+			CreatedAt:   household.CreatedAt,
+			UpdatedAt:   household.UpdatedAt,
+			Role:        gen.HouseholdWithRoleRole(repo.RoleOwner),
+		},
+	}, nil
+}
+
+// LeaveHousehold gives up the caller's own membership.
+//
+// It is the counterpart of the admin route that removes somebody else, and it
+// enforces the same invariant from the other side: a household always keeps at
+// least one owner.
+func (s server) LeaveHousehold(ctx context.Context, _ gen.LeaveHouseholdRequestObject) (gen.LeaveHouseholdResponseObject, error) {
+	viewer := viewerFrom(ctx)
+	household := householdFrom(ctx)
+	if viewer == nil || household == nil {
+		// Unreachable behind tierHousehold; refusing is the failure that
+		// cannot leak anything if a future route forgets the guard.
+		return gen.LeaveHousehold403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	if household.Role == repo.RoleOwner {
+		owners, err := s.Repo.CountOwners(ctx, household.ID)
+		if err != nil {
+			return nil, err
+		}
+		if owners <= 1 {
+			return gen.LeaveHousehold409JSONResponse(errorBody(
+				"You are the only owner of this household. " +
+					"Make another member an owner first.")), nil
+		}
+	}
+
+	// The member's provider access rows hang off the membership and cascade
+	// with it, so leaving takes the mailbox access away in the same statement.
+	if err := s.Repo.RemoveMember(ctx, household.ID, viewer.UserID); err != nil {
+		return nil, err
+	}
+
+	applog.Event(applog.LevelInfo, "member_left", map[string]any{
+		"householdId": household.ID,
+		"userId":      viewer.UserID,
+	})
+	s.Repo.RecordAudit(ctx, repo.AuditEventInput{
+		ActorUserID: &viewer.UserID,
+		HouseholdID: &household.ID,
+		Action:      "member.left",
+		TargetType:  "user",
+		TargetID:    &viewer.UserID,
+	})
+
+	return gen.LeaveHousehold200JSONResponse(okBody()), nil
+}
+
+// mayCreateHousehold is REF §A2's creation policy: the installation owner
+// always, and anybody else only while they belong to no household.
+//
+// The TypeScript had a third branch — an app-level `admin` role from Better
+// Auth — which has no Go counterpart: Limen has no global roles, and this
+// installation's roles are per household.
+func (s server) mayCreateHousehold(ctx context.Context, viewer *auth.Session) (bool, error) {
+	installation, err := s.Q.GetInstallation(ctx)
+	if err != nil {
+		return false, err
+	}
+	if installation.OwnerUserID != nil && *installation.OwnerUserID == viewer.UserID {
+		return true, nil
+	}
+
+	households, err := s.Repo.ListHouseholdsForUser(ctx, viewer.UserID)
+	if err != nil {
+		return false, err
+	}
+	return len(households) == 0, nil
+}
+
+// validateCreateHouseholdBody is REF §A4's `createHousehold` schema applied to
+// the normalised values, exactly as validateSetupBody is for setup: the
+// OpenAPI document states the shape, and the rules that run on what is KEPT
+// (trimmed, lower-cased) run here, with the TypeScript's messages.
+func validateCreateHouseholdBody(slug, displayName string) []problem {
+	var problems []problem
+	if err := domain.ValidateHouseholdSlug(slug); err != nil {
+		problems = append(problems, problem{field: "slug", message: err.Error()})
+	}
+	return appendTextProblems(problems, "displayName", displayName, 80)
+}

--- a/apps/server/internal/api/households_test.go
+++ b/apps/server/internal/api/households_test.go
@@ -1,0 +1,364 @@
+package api_test
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"testing"
+
+	applog "github.com/andersro93/mi-casa-su-casa/server/internal/log"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/testrig"
+)
+
+// Ports test/integration/household-creation.test.ts and the "leave" half of
+// test/integration/membership-removal.test.ts: the household routes against a
+// real database and the whole handler chain.
+
+const memberEmail = "member@example.com"
+
+// signUp creates an account without an invitation and signs it in, which is
+// what the TypeScript tests did with the provisioning auth instance. Setup and
+// invitation-accept are the only routes that mint an account, and neither is
+// what these tests are about.
+func signUp(t *testing.T, app *testrig.AppRig, email, name string) (userID, cookie string) {
+	t.Helper()
+
+	userID, err := app.Deps.Auth.CreateUser(t.Context(), name, email, testrig.Password)
+	if err != nil {
+		t.Fatalf("signUp(%q): %v", email, err)
+	}
+	return userID, app.SignIn(t, email, testrig.Password)
+}
+
+// createHousehold posts one creation request.
+func createHousehold(t *testing.T, app *testrig.AppRig, cookie, slug string) *http.Response {
+	t.Helper()
+	return app.Do(t, http.MethodPost, "/api/households",
+		map[string]any{"slug": slug, "displayName": "Household " + slug},
+		testrig.WithCookie(cookie)).Result()
+}
+
+func TestListMyHouseholds(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+
+	rec := app.Do(t, http.MethodGet, "/api/households/me", nil, testrig.WithCookie(cookie))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+
+	households, ok := app.JSON(t, rec)["households"].([]any)
+	if !ok || len(households) != 1 {
+		t.Fatalf("households = %v, want one entry", app.JSON(t, rec)["households"])
+	}
+	entry, _ := households[0].(map[string]any)
+	if entry["slug"] != slug || entry["role"] != "owner" || entry["displayName"] != testrig.OwnerHouseholdName {
+		t.Errorf("entry = %v", entry)
+	}
+	if entry["id"] == "" || entry["id"] == nil {
+		t.Error("entry carried no id")
+	}
+}
+
+func TestHouseholdRoutesRequireASession(t *testing.T) {
+	app := testrig.App(t)
+	app.CompleteSetup(t)
+
+	for _, tc := range []struct{ method, path string }{
+		{http.MethodGet, "/api/households/me"},
+		{http.MethodPost, "/api/households"},
+		{http.MethodPost, "/api/households/" + testrig.OwnerHouseholdSlug + "/leave"},
+	} {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			var body any
+			if tc.path == "/api/households" {
+				body = map[string]any{"slug": "otra", "displayName": "Otra"}
+			}
+			rec := app.Do(t, tc.method, tc.path, body)
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+			}
+			if got := app.JSON(t, rec)["error"]; got != "Unauthorized" {
+				t.Errorf("error = %q", got)
+			}
+		})
+	}
+}
+
+// The first case of household-creation.test.ts: the installation owner may
+// create more households; a member of one may not.
+func TestCreateHouseholdInstallationOwnerMayButMemberMayNot(t *testing.T) {
+	app := testrig.App(t)
+	ownerCookie, slug := app.CompleteSetup(t)
+	memberCookie := app.CreateMember(t, slug, memberEmail, "Member", "member")
+
+	created := app.Do(t, http.MethodPost, "/api/households",
+		map[string]any{"slug": "cabin", "displayName": "Cabin"},
+		testrig.WithCookie(ownerCookie))
+	if created.Code != http.StatusCreated {
+		t.Fatalf("owner create: %d %s", created.Code, created.Body.String())
+	}
+	household, _ := app.JSON(t, created)["household"].(map[string]any)
+	if household["slug"] != "cabin" || household["role"] != "owner" || household["displayName"] != "Cabin" {
+		t.Errorf("household = %v", household)
+	}
+	// The switcher entry's keys plus the timestamps, so the SPA can use the
+	// body without a refetch.
+	for _, key := range []string{"id", "createdAt", "updatedAt"} {
+		if value, ok := household[key].(string); !ok || value == "" {
+			t.Errorf("household[%q] = %v", key, household[key])
+		}
+	}
+
+	refused := createHousehold(t, app, memberCookie, "mine")
+	if refused.StatusCode != http.StatusForbidden {
+		t.Fatalf("member create: %d", refused.StatusCode)
+	}
+	if got := app.Count(t, "households", "TRUE"); got != 2 {
+		t.Errorf("households = %d, want 2", got)
+	}
+}
+
+func TestCreateHouseholdRefusalMessage(t *testing.T) {
+	app := testrig.App(t)
+	_, slug := app.CompleteSetup(t)
+	memberCookie := app.CreateMember(t, slug, memberEmail, "Member", "member")
+
+	rec := app.Do(t, http.MethodPost, "/api/households",
+		map[string]any{"slug": "mine", "displayName": "Mine"},
+		testrig.WithCookie(memberCookie))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	want := "Only the installation owner can create additional households. " +
+		"Ask them to create it and invite you."
+	if got := app.JSON(t, rec)["error"]; got != want {
+		t.Errorf("error = %q", got)
+	}
+}
+
+// The second case: somebody with no household at all may create their first,
+// so a user whose only household was removed can recover — but only one.
+func TestCreateHouseholdFirstOneIsAllowedSecondIsNot(t *testing.T) {
+	app := testrig.App(t)
+	_, cookie := signUp(t, app, "solo@example.com", "Solo")
+
+	if first := createHousehold(t, app, cookie, "solo"); first.StatusCode != http.StatusCreated {
+		t.Fatalf("first create: %d", first.StatusCode)
+	}
+	if second := createHousehold(t, app, cookie, "solo-two"); second.StatusCode != http.StatusForbidden {
+		t.Fatalf("second create: %d", second.StatusCode)
+	}
+}
+
+// The third case: REF §A3's slug rules apply at creation, and nothing is
+// written when they fail.
+func TestCreateHouseholdRejectsReservedOrMalformedSlugs(t *testing.T) {
+	app := testrig.App(t)
+	_, cookie := signUp(t, app, "solo@example.com", "Solo")
+
+	for _, slug := range []string{"members", "settings", "api", "-bad", "x"} {
+		t.Run(slug, func(t *testing.T) {
+			rec := app.Do(t, http.MethodPost, "/api/households",
+				map[string]any{"slug": slug, "displayName": "Nope"},
+				testrig.WithCookie(cookie))
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+			}
+			// The message the SPA renders next to the input, filed under the
+			// field it belongs to.
+			fields, _ := app.JSON(t, rec)["fields"].(map[string]any)
+			if message, _ := fields["slug"].(string); message == "" {
+				t.Errorf("fields = %v, want a message for slug", fields)
+			}
+		})
+	}
+
+	if got := app.Count(t, "households", "TRUE"); got != 0 {
+		t.Errorf("households = %d, want 0", got)
+	}
+}
+
+func TestCreateHouseholdRejectsAnEmptyDisplayName(t *testing.T) {
+	app := testrig.App(t)
+	_, cookie := signUp(t, app, "solo@example.com", "Solo")
+
+	rec := app.Do(t, http.MethodPost, "/api/households",
+		map[string]any{"slug": "solo", "displayName": "   "},
+		testrig.WithCookie(cookie))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	fields, _ := app.JSON(t, rec)["fields"].(map[string]any)
+	if got := fields["displayName"]; got != "displayName is required" {
+		t.Errorf("fields[displayName] = %v", got)
+	}
+}
+
+func TestCreateHouseholdSlugAlreadyExists(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+
+	rec := app.Do(t, http.MethodPost, "/api/households",
+		map[string]any{"slug": strings.ToUpper(slug), "displayName": "Casa Again"},
+		testrig.WithCookie(cookie))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	if got := app.JSON(t, rec)["error"]; got != "Household slug already exists" {
+		t.Errorf("error = %q", got)
+	}
+	if got := app.Count(t, "households", "TRUE"); got != 1 {
+		t.Errorf("households = %d, want 1", got)
+	}
+}
+
+func TestCreateHouseholdRecordsAnAudit(t *testing.T) {
+	app := testrig.App(t)
+	cookie, _ := app.CompleteSetup(t)
+
+	if rec := createHousehold(t, app, cookie, "cabin"); rec.StatusCode != http.StatusCreated {
+		t.Fatalf("create: %d", rec.StatusCode)
+	}
+	if got := app.Count(t, "audit_events",
+		`"action" = 'household.created' AND "details"->>'slug' = 'cabin'`); got != 1 {
+		t.Errorf("household.created audits = %d, want 1", got)
+	}
+}
+
+func TestCreateHouseholdIsRateLimited(t *testing.T) {
+	app := testrig.App(t)
+	cookie, _ := app.CompleteSetup(t)
+
+	// 10 per hour. The installation owner is the only caller who can spend
+	// the budget on successes, which is exactly why the limit exists.
+	var last *http.Response
+	for i := range 11 {
+		last = createHousehold(t, app, cookie, "cabin-"+string(rune('a'+i)))
+	}
+	if last.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("eleventh create: %d", last.StatusCode)
+	}
+	if last.Header.Get("Retry-After") == "" {
+		t.Error("a 429 carried no Retry-After header")
+	}
+}
+
+// The leave cases of membership-removal.test.ts.
+func TestLeaveHouseholdRefusesTheOnlyOwner(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	app.CreateMember(t, slug, memberEmail, "Member", "member")
+
+	rec := app.Do(t, http.MethodPost, "/api/households/"+slug+"/leave", nil, testrig.WithCookie(cookie))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	want := "You are the only owner of this household. Make another member an owner first."
+	if got := app.JSON(t, rec)["error"]; got != want {
+		t.Errorf("error = %q", got)
+	}
+	if got := app.Count(t, "household_memberships", "TRUE"); got != 2 {
+		t.Errorf("memberships = %d, want 2", got)
+	}
+}
+
+func TestLeaveHouseholdMemberLeavesAndProviderAccessCascades(t *testing.T) {
+	app := testrig.App(t)
+	_, slug := app.CompleteSetup(t)
+	memberCookie := app.CreateMember(t, slug, memberEmail, "Member", "member")
+
+	// A member with provider access: the grant hangs off the membership, so
+	// leaving must take it with it.
+	household, err := app.Deps.Repo.GetHouseholdBySlug(t.Context(), slug)
+	if err != nil || household == nil {
+		t.Fatalf("household %q: %v", slug, err)
+	}
+	provider, err := app.Deps.Repo.CreateProvider(t.Context(), household.ID, "netflix", "Netflix")
+	if err != nil {
+		t.Fatalf("create provider: %v", err)
+	}
+	member, err := app.Deps.Repo.FindUserByEmail(t.Context(), memberEmail)
+	if err != nil || member == nil {
+		t.Fatalf("member: %v", err)
+	}
+	if err := app.Deps.Repo.GrantProviderAccess(t.Context(), household.ID, member.ID, provider.ID); err != nil {
+		t.Fatalf("grant access: %v", err)
+	}
+	if got := app.Count(t, "household_member_provider_access", "TRUE"); got != 1 {
+		t.Fatalf("provider access rows = %d, want 1", got)
+	}
+
+	logs := &bytes.Buffer{}
+	applog.SetOutput(logs)
+	t.Cleanup(func() { applog.SetOutput(nil) })
+
+	rec := app.Do(t, http.MethodPost, "/api/households/"+slug+"/leave", nil, testrig.WithCookie(memberCookie))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	if got := app.JSON(t, rec)["ok"]; got != true {
+		t.Errorf("body = %s", rec.Body.String())
+	}
+	if got := app.Count(t, "household_memberships", "TRUE"); got != 1 {
+		t.Errorf("memberships = %d, want 1", got)
+	}
+	if got := app.Count(t, "household_member_provider_access", "TRUE"); got != 0 {
+		t.Errorf("provider access rows = %d, want 0", got)
+	}
+	if got := app.Count(t, "audit_events", `"action" = 'member.left'`); got != 1 {
+		t.Errorf("member.left audits = %d, want 1", got)
+	}
+	if !strings.Contains(logs.String(), `"event":"member_left"`) {
+		t.Errorf("logs = %s, want a member_left event", logs.String())
+	}
+
+	// The tenancy guard answers a former member exactly as it answers a
+	// stranger: 403, never 404, so nobody can enumerate households.
+	again := app.Do(t, http.MethodPost, "/api/households/"+slug+"/leave", nil, testrig.WithCookie(memberCookie))
+	if again.Code != http.StatusForbidden {
+		t.Fatalf("leaving twice: %d %s", again.Code, again.Body.String())
+	}
+}
+
+func TestLeaveHouseholdOwnerMayLeaveOnceAnotherOwnerExists(t *testing.T) {
+	app := testrig.App(t)
+	ownerCookie, slug := app.CompleteSetup(t)
+	app.CreateMember(t, slug, memberEmail, "Member", "owner")
+
+	rec := app.Do(t, http.MethodPost, "/api/households/"+slug+"/leave", nil, testrig.WithCookie(ownerCookie))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	if got := app.Count(t, "household_memberships", `"role" = 'owner'`); got != 1 {
+		t.Errorf("owners = %d, want 1", got)
+	}
+}
+
+func TestLeaveHouseholdUnknownSlugIsForbidden(t *testing.T) {
+	app := testrig.App(t)
+	cookie, _ := app.CompleteSetup(t)
+
+	rec := app.Do(t, http.MethodPost, "/api/households/nowhere/leave", nil, testrig.WithCookie(cookie))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	if got := app.JSON(t, rec)["error"]; got != "Forbidden" {
+		t.Errorf("error = %q", got)
+	}
+}
+
+// A slug that could never name a household is refused the same way any other
+// non-membership is: the tenancy guard's 403, not a validation error that
+// would distinguish "no such household" from "not yours".
+func TestLeaveHouseholdImplausibleSlugIsForbidden(t *testing.T) {
+	app := testrig.App(t)
+	cookie, _ := app.CompleteSetup(t)
+
+	for _, slug := range []string{"x", strings.Repeat("s", 60)} {
+		rec := app.Do(t, http.MethodPost, "/api/households/"+slug+"/leave", nil, testrig.WithCookie(cookie))
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("%q: status = %d %s", slug, rec.Code, rec.Body.String())
+		}
+	}
+}

--- a/apps/server/internal/api/mi-casa.yaml
+++ b/apps/server/internal/api/mi-casa.yaml
@@ -513,6 +513,818 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/audit:
+    get:
+      operationId: listAuditEvents
+      summary: >-
+        The household's audit trail, newest 100 first. Owner-only: it names
+        who did what to whom, which is exactly the sort of thing a member has
+        no business reading about the rest of the household.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      responses:
+        "200":
+          description: The trail.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuditEventList"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/settings:
+    get:
+      operationId: getHouseholdSettings
+      summary: >-
+        The household's own settings: its name and the inbound address
+        providers must be told to send codes to.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      responses:
+        "200":
+          description: The settings.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HouseholdSettingsResult"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: The household is gone.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    patch:
+      operationId: updateHouseholdSettings
+      summary: Rename the household. The slug — and therefore the inbound address — never changes.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HouseholdSettingsRequest"
+      responses:
+        "200":
+          description: The settings, as they now stand.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HouseholdSettingsResult"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: The household is gone.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/providers:
+    get:
+      operationId: listProviderConfigurations
+      summary: >-
+        Every provider in the household with the number of sender rules that
+        point at it, plus the rules themselves — the two halves of the
+        provider settings screen in one request.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      responses:
+        "200":
+          description: The providers and their sender rules.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProviderConfigurationList"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      operationId: createProvider
+      summary: Add a provider — the mailbox a set of sender rules files messages into.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProviderRequest"
+      responses:
+        "201":
+          description: The provider.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProviderResult"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: A provider with that key already exists in this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/providers/{providerId}:
+    patch:
+      operationId: updateProvider
+      summary: Rename a provider or change its key.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/ProviderId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProviderRequest"
+      responses:
+        "200":
+          description: The provider, as it now stands.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProviderResult"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No such provider in this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Another provider in this household already has that key.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      operationId: deleteProvider
+      summary: >-
+        Remove a provider. Its sender rules, its stored messages and every
+        member's access to it go with it — the foreign keys cascade, which is
+        the point: a deleted provider must not leave readable messages behind.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/ProviderId"
+      responses:
+        "200":
+          description: The provider and everything filed under it are gone.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ok"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No such provider in this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/provider-rules:
+    post:
+      operationId: createSenderRule
+      summary: >-
+        Add a sender rule: the address or domain whose mail files into a
+        provider. Exact rules beat domain rules, and the most specific domain
+        rule wins among those.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SenderRuleRequest"
+      responses:
+        "201":
+          description: The rule.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SenderRuleResult"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No such provider in this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: This household already has a rule for that match type and value.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/provider-rules/{ruleId}:
+    patch:
+      operationId: updateSenderRule
+      summary: Repoint a sender rule, or change what it matches.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/SenderRuleId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SenderRuleRequest"
+      responses:
+        "200":
+          description: The rule, as it now stands.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SenderRuleResult"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No such provider, or no such rule, in this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: This household already has a rule for that match type and value.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      operationId: deleteSenderRule
+      summary: Remove a sender rule. Messages already filed under its provider stay.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/SenderRuleId"
+      responses:
+        "200":
+          description: The rule is gone.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ok"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No such rule in this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/members:
+    get:
+      operationId: listMembers
+      summary: >-
+        Everybody in the household with the providers each of them may read,
+        plus the household's providers so the screen can offer the rest.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      responses:
+        "200":
+          description: The members and the household's providers.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MemberList"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      operationId: createMember
+      summary: >-
+        "Add a member" — which is an invitation with no provider scope, not an
+        account this endpoint creates. Nobody may be given a password by
+        somebody else, so the invitee always sets their own.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateMemberRequest"
+      responses:
+        "201":
+          description: >-
+            The invitation, its link, and whether the email carrying that link
+            was delivered. A failed delivery is not an error (REF §A3) — the
+            owner can share `inviteUrl` by hand.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InvitationResult"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/members/{userId}:
+    delete:
+      operationId: removeMember
+      summary: >-
+        Remove somebody else from the household. Refused for the last owner,
+        and refused for yourself — "leave household" is the route for that, so
+        that giving up your own access is never a click away from removing
+        somebody else's.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/MemberUserId"
+      responses:
+        "200":
+          description: The membership is gone; provider access cascaded with it.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ok"
+        "400":
+          description: The caller asked to remove themselves.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: That user is not a member of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: That member is the household's only owner.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/members/{userId}/role:
+    patch:
+      operationId: updateMemberRole
+      summary: >-
+        Promote or demote somebody else. Refused for yourself: an owner who
+        could demote themselves could leave a household with no owner at all,
+        and the answer names the other owners as the way out.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/MemberUserId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RoleChangeRequest"
+      responses:
+        "200":
+          description: The role is changed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ok"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner, or asked to change their own role.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: That user is not a member of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/members/{userId}/provider-access:
+    post:
+      operationId: grantProviderAccess
+      summary: >-
+        Let a member read one provider's messages. Idempotent: granting twice
+        is the same as granting once, so a double-click is not an error.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/MemberUserId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProviderAccessRequest"
+      responses:
+        "200":
+          description: The member may now read that provider.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ok"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No such provider, or that user is not a member of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/members/{userId}/provider-access/{providerKey}:
+    delete:
+      operationId: revokeProviderAccess
+      summary: >-
+        Take a provider away from a member. The key is a path parameter and
+        only a path parameter — the TypeScript also read it from a JSON body
+        on DELETE, which is a shape no client sends and every proxy is
+        entitled to drop.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/MemberUserId"
+        - name: providerKey
+          in: path
+          required: true
+          description: >-
+            The provider's key. REF §A4's `providerAccess` rules (1..40, and
+            lower-cased before the lookup) are stated here rather than in Go,
+            because a path parameter has no `fields` entry to render against
+            and REF §A2 asks for this one to be spec-validated.
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 40
+      responses:
+        "200":
+          description: The member can no longer read that provider.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ok"
+        "400":
+          description: The provider key is not a usable key.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No such provider, or that user is not a member of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/invitations:
+    get:
+      operationId: listInvitations
+      summary: >-
+        Every invitation this household has issued, newest first. Invitations
+        past their expiry are marked expired before the list is read, so the
+        screen never shows a pending invitation whose link no longer works.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      responses:
+        "200":
+          description: The invitations.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InvitationList"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      operationId: createInvitation
+      summary: >-
+        Invite somebody, optionally scoped to a set of providers they will be
+        able to read the moment they accept.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InvitationRequest"
+      responses:
+        "201":
+          description: >-
+            The invitation, its link, and whether the email carrying that link
+            was delivered. A failed delivery is not an error (REF §A3).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InvitationResult"
+        "400":
+          description: >-
+            The request was rejected — a bad field, or a provider that belongs
+            to another household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/invitations/{invitationId}/resend:
+    post:
+      operationId: resendInvitation
+      summary: >-
+        Issue a fresh invitation to the same person with the same role and
+        provider scope, cancelling the old one. A new token, so the link in
+        the first email stops working — which is what makes "resend" safe to
+        offer after a link has been forwarded to the wrong inbox.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/InvitationId"
+      responses:
+        "200":
+          description: The replacement invitation, its link, and the delivery outcome.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InvitationResult"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No such invitation in this household, or it is no longer pending.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/invitations/{invitationId}:
+    delete:
+      operationId: cancelInvitation
+      summary: Cancel a pending invitation, which makes its link stop working.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/InvitationId"
+      responses:
+        "200":
+          description: The invitation is cancelled.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ok"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No such invitation in this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 components:
   parameters:
     HouseholdSlug:
@@ -552,6 +1364,42 @@ components:
         right size. It is mandatory in practice.
       schema:
         type: string
+    ProviderId:
+      name: providerId
+      in: path
+      required: true
+      description: A provider's id. Scoped to the household in the path, so an id from another household is a 404 rather than a leak.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 200
+    SenderRuleId:
+      name: ruleId
+      in: path
+      required: true
+      description: A sender rule's id, scoped to the household in the path.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 200
+    MemberUserId:
+      name: userId
+      in: path
+      required: true
+      description: The member's user id. Membership of the household in the path is checked before anything is done with it.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 200
+    InvitationId:
+      name: invitationId
+      in: path
+      required: true
+      description: An invitation's id, scoped to the household in the path.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 200
   schemas:
     Ok:
       type: object
@@ -976,3 +1824,318 @@ components:
               type: string
             emailMatches:
               type: boolean
+    AuditEvent:
+      type: object
+      description: >-
+        One line of the audit trail. `details` is whatever the action recorded
+        (the new role, the provider key, whether an invitation email got out),
+        parsed back from the stored JSON.
+      required:
+        [id, actorUserId, householdId, action, targetType, targetId, details, createdAt]
+      properties:
+        id:
+          type: string
+        actorUserId:
+          type: string
+          nullable: true
+        householdId:
+          type: string
+          nullable: true
+        action:
+          type: string
+        targetType:
+          type: string
+        targetId:
+          type: string
+          nullable: true
+        details:
+          type: object
+          nullable: true
+          additionalProperties: true
+        createdAt:
+          type: string
+          format: date-time
+    AuditEventList:
+      type: object
+      required: [events]
+      properties:
+        events:
+          type: array
+          items:
+            $ref: "#/components/schemas/AuditEvent"
+    HouseholdSettings:
+      type: object
+      description: >-
+        A household's own settings. `emailAddress` is `slug@EMAIL_DOMAIN` —
+        the address providers must be told to send to — and is null only if
+        the installation has no inbound domain configured.
+      required: [slug, displayName, emailAddress]
+      properties:
+        slug:
+          type: string
+        displayName:
+          type: string
+        emailAddress:
+          type: string
+          nullable: true
+    HouseholdSettingsResult:
+      type: object
+      required: [household]
+      properties:
+        household:
+          $ref: "#/components/schemas/HouseholdSettings"
+    HouseholdSettingsRequest:
+      type: object
+      description: REF §A4's `householdSettings` schema. Trimmed and length-checked in Go, for the wording.
+      required: [displayName]
+      properties:
+        displayName:
+          type: string
+          description: Trimmed, 1..80 characters.
+    Provider:
+      type: object
+      description: >-
+        One provider. snake_case keys, deliberately: it is what the TypeScript
+        returned and what the SPA reads.
+      required: [id, household_id, provider_key, display_name, created_at]
+      properties:
+        id:
+          type: string
+        household_id:
+          type: string
+        provider_key:
+          type: string
+        display_name:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+    ProviderConfiguration:
+      type: object
+      description: A provider plus how many sender rules point at it.
+      required: [id, household_id, provider_key, display_name, created_at, rule_count]
+      properties:
+        id:
+          type: string
+        household_id:
+          type: string
+        provider_key:
+          type: string
+        display_name:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        rule_count:
+          type: integer
+    SenderRule:
+      type: object
+      description: One sender rule — the address or domain whose mail files into a provider.
+      required: [id, household_id, provider_id, match_type, match_value, created_at]
+      properties:
+        id:
+          type: string
+        household_id:
+          type: string
+        provider_id:
+          type: string
+        match_type:
+          type: string
+          enum: [exact, domain]
+        match_value:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+    ProviderConfigurationList:
+      type: object
+      required: [providers, rules]
+      properties:
+        providers:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProviderConfiguration"
+        rules:
+          type: array
+          items:
+            $ref: "#/components/schemas/SenderRule"
+    ProviderResult:
+      type: object
+      required: [provider]
+      properties:
+        provider:
+          $ref: "#/components/schemas/Provider"
+    ProviderRequest:
+      type: object
+      description: >-
+        REF §A4's `provider` schema. Only the shape is stated here: the key is
+        trimmed and lower-cased before its rules run, and the message each
+        failure produces is REF §A4's wording, which a schema violation cannot
+        produce.
+      required: [providerKey, displayName]
+      properties:
+        providerKey:
+          type: string
+          description: Trimmed, lower-cased, 1..40, lowercase letters, numbers and hyphens, starting with a letter or number.
+        displayName:
+          type: string
+          description: Trimmed, 1..80 characters.
+    SenderRuleResult:
+      type: object
+      required: [rule]
+      properties:
+        rule:
+          $ref: "#/components/schemas/SenderRule"
+    SenderRuleRequest:
+      type: object
+      description: >-
+        REF §A4's `senderRule` schema. `matchType` is a plain string here
+        rather than an enum for the same reason the lengths are absent: the
+        rejection must read "matchType must be exact or domain", which is
+        checked in Go.
+      required: [providerId, matchType, matchValue]
+      properties:
+        providerId:
+          type: string
+          description: Trimmed, 1..64 characters.
+        matchType:
+          type: string
+          description: "`exact` or `domain`."
+        matchValue:
+          type: string
+          description: >-
+            Trimmed, lower-cased, 1..254. A domain rule drops any leading `@`
+            and must then be a hostname; an exact rule must be a full email
+            address.
+    MemberProviderAccess:
+      type: object
+      description: One provider a member may read.
+      required: [providerKey, displayName]
+      properties:
+        providerKey:
+          type: string
+        displayName:
+          type: string
+    HouseholdMember:
+      type: object
+      description: >-
+        One member of the household, with the providers they may read. `role`
+        duplicates `householdRole`: it carried Better Auth's global role in the
+        TypeScript server and the SPA reads both, so the Go server puts the
+        household role in each.
+      required: [id, householdRole, email, name, role, createdAt, updatedAt, providerAccess]
+      properties:
+        id:
+          type: string
+        householdRole:
+          type: string
+          enum: [owner, member]
+        email:
+          type: string
+        name:
+          type: string
+        role:
+          type: string
+          enum: [owner, member]
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        providerAccess:
+          type: array
+          items:
+            $ref: "#/components/schemas/MemberProviderAccess"
+    MemberList:
+      type: object
+      required: [members, providers]
+      properties:
+        members:
+          type: array
+          items:
+            $ref: "#/components/schemas/HouseholdMember"
+        providers:
+          type: array
+          items:
+            $ref: "#/components/schemas/Provider"
+    CreateMemberRequest:
+      type: object
+      description: >-
+        REF §A4's `createMember` schema. `role` is a plain string, defaulting
+        to member when absent: the enum would reject `admin`, which REF §A4
+        accepts and maps to owner, and its rejection would not read "role must
+        be owner or member".
+      required: [email, name]
+      properties:
+        email:
+          type: string
+          description: Trimmed, lower-cased, 3..254 characters, must look like an address.
+        name:
+          type: string
+          description: Trimmed, 1..80 characters.
+        role:
+          type: string
+          description: "`owner` or `member` (`admin` is accepted and means owner). Defaults to member."
+    RoleChangeRequest:
+      type: object
+      description: REF §A4's `roleChange` schema. See CreateMemberRequest for why `role` is not an enum here.
+      required: [role]
+      properties:
+        role:
+          type: string
+          description: "`owner` or `member` (`admin` is accepted and means owner)."
+    ProviderAccessRequest:
+      type: object
+      description: REF §A4's `providerAccess` schema.
+      required: [providerKey]
+      properties:
+        providerKey:
+          type: string
+          description: Trimmed, lower-cased, 1..40 characters.
+    InvitationList:
+      type: object
+      required: [invitations]
+      properties:
+        invitations:
+          type: array
+          items:
+            $ref: "#/components/schemas/Invitation"
+    InvitationRequest:
+      type: object
+      description: >-
+        REF §A4's `invitation` schema. See CreateMemberRequest for why `role`
+        is a plain string.
+      required: [email, name]
+      properties:
+        email:
+          type: string
+          description: Trimmed, lower-cased, 3..254 characters, must look like an address.
+        name:
+          type: string
+          description: Trimmed, 1..80 characters.
+        role:
+          type: string
+          description: "`owner` or `member` (`admin` is accepted and means owner). Defaults to member."
+        providerIds:
+          type: array
+          description: The providers the invitee may read the moment they accept. At most 50; every id must belong to this household.
+          items:
+            type: string
+    InvitationResult:
+      type: object
+      description: >-
+        A newly issued invitation, its link, and whether the email carrying
+        that link got out. A failed delivery is NOT an error (REF §A3): the
+        invitation stands and `inviteUrl` can be shared by hand, so
+        `emailSent` is false and `emailError` says what went wrong.
+      required: [invitation, inviteUrl, emailSent]
+      properties:
+        invitation:
+          $ref: "#/components/schemas/Invitation"
+        inviteUrl:
+          type: string
+        emailSent:
+          type: boolean
+        emailError:
+          type: string

--- a/apps/server/internal/api/mi-casa.yaml
+++ b/apps/server/internal/api/mi-casa.yaml
@@ -271,8 +271,268 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /api/households/me:
+    get:
+      operationId: listMyHouseholds
+      summary: >-
+        Every household the caller belongs to, for the household switcher.
+        Ordered by lower-cased display name so the list does not reshuffle
+        when somebody renames a household with a capital letter.
+      tags: [households]
+      responses:
+        "200":
+          description: The caller's households.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HouseholdList"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/households:
+    post:
+      operationId: createHousehold
+      summary: >-
+        Create a household with the caller as its owner. Restricted (REF §A2):
+        the installation owner may always; anybody else only while they belong
+        to no household at all, so a member cannot mint extra households or
+        squat inbound addresses. Rate limited (10 per hour).
+      tags: [households]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateHouseholdRequest"
+      responses:
+        "201":
+          description: >-
+            The household, in the same shape as a /api/households/me entry so
+            the client can use it without a refetch.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HouseholdResult"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller may not create a household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: The slug is taken.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limited. `Retry-After` says when to come back.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/households/{slug}/leave:
+    post:
+      operationId: leaveHousehold
+      summary: >-
+        Give up your own membership of this household. Refused for the last
+        owner, which is what keeps a household from being left with nobody who
+        can administer it.
+      tags: [households]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      responses:
+        "200":
+          description: The membership is gone; provider access cascaded with it.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ok"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not a member of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: The caller is the household's only owner.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/settings:
+    get:
+      operationId: getAccountSettings
+      summary: >-
+        The account settings screen in one request: the caller's profile with
+        their households, and their signed-in devices newest first.
+      tags: [settings]
+      responses:
+        "200":
+          description: The profile and the session list.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AccountSettings"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: The session's account no longer exists.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/settings/households:
+    get:
+      operationId: listSettingsHouseholds
+      summary: >-
+        The caller's households, the same list GET /api/households/me answers
+        with. It exists separately because the settings screen refetches it on
+        its own after leaving a household.
+      tags: [settings]
+      responses:
+        "200":
+          description: The caller's households.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HouseholdList"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/settings/profile:
+    patch:
+      operationId: updateProfile
+      summary: Update the caller's display name and avatar.
+      tags: [settings]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProfileRequest"
+      responses:
+        "200":
+          description: The profile as it now stands.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProfileResult"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: The session's account no longer exists.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/settings/sessions/others:
+    delete:
+      operationId: revokeOtherSessions
+      summary: >-
+        Sign out everywhere else: every session of this account except the one
+        this request arrived on.
+      tags: [settings]
+      responses:
+        "200":
+          description: The other sessions are gone.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ok"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/settings/sessions/{sessionId}:
+    delete:
+      operationId: revokeSession
+      summary: >-
+        Revoke one device. A session id that is not the caller's own revokes
+        nothing and still answers 200 — deliberately, so the endpoint cannot be
+        used to discover whether an id exists.
+      tags: [settings]
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 200
+      responses:
+        "200":
+          description: The session is gone, if it was the caller's.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ok"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 components:
   parameters:
+    HouseholdSlug:
+      name: slug
+      in: path
+      required: true
+      description: >-
+        The household this request acts on. Every `{slug}` route is guarded by
+        the tenancy middleware, which turns it into a membership or refuses —
+        so the parameter is also the authorization boundary, not just a lookup
+        key.
+
+        REF §A3's length bounds (2..40) are deliberately NOT stated here. A
+        slug outside them cannot name a household, so it must be answered the
+        way every other non-membership is — 403, never a validation error that
+        distinguishes "no such household" from "not yours".
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 200
     InvitationToken:
       name: X-Invitation-Token
       in: header
@@ -293,6 +553,183 @@ components:
       schema:
         type: string
   schemas:
+    Ok:
+      type: object
+      description: >-
+        The acknowledgement every "it is done, and there is nothing to show
+        for it" endpoint answers with.
+      required: [ok]
+      properties:
+        ok:
+          type: boolean
+    HouseholdSummary:
+      type: object
+      description: >-
+        One entry in the household switcher: a household plus what the caller
+        may do in it.
+      required: [id, slug, displayName, role]
+      properties:
+        id:
+          type: string
+        slug:
+          type: string
+        displayName:
+          type: string
+        role:
+          type: string
+          enum: [owner, member]
+    HouseholdList:
+      type: object
+      required: [households]
+      properties:
+        households:
+          type: array
+          items:
+            $ref: "#/components/schemas/HouseholdSummary"
+    CreateHouseholdRequest:
+      type: object
+      description: >-
+        REF §A4's `createHousehold` schema. As with SetupRequest, only the
+        shape is stated here: the slug is normalised (trimmed, lower-cased)
+        before REF §A3's rules are applied to it, and the message each failure
+        produces is the wording the SPA renders next to the input.
+      required: [slug, displayName]
+      properties:
+        slug:
+          type: string
+          description: Trimmed, lower-cased, and subject to REF §A3's slug rules.
+        displayName:
+          type: string
+          description: Trimmed, 1..80 characters.
+    HouseholdWithRole:
+      type: object
+      description: >-
+        A newly created household: the switcher entry's keys plus the
+        timestamps, so the client can drop it straight into its cache.
+      required: [id, slug, displayName, createdAt, updatedAt, role]
+      properties:
+        id:
+          type: string
+        slug:
+          type: string
+        displayName:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        role:
+          type: string
+          enum: [owner, member]
+    HouseholdResult:
+      type: object
+      required: [household]
+      properties:
+        household:
+          $ref: "#/components/schemas/HouseholdWithRole"
+    Profile:
+      type: object
+      description: >-
+        The account settings screen's view of the caller. `role` is always
+        null: it carried Better Auth's global role in the TypeScript server,
+        which the Go one has no counterpart for, and stays in the payload
+        because the SPA reads it.
+      required: [id, email, name, image, role, twoFactorEnabled, households]
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+        name:
+          type: string
+        image:
+          type: string
+          nullable: true
+        role:
+          type: string
+          nullable: true
+        twoFactorEnabled:
+          type: boolean
+        households:
+          type: array
+          items:
+            $ref: "#/components/schemas/HouseholdSummary"
+    SessionSummary:
+      type: object
+      description: >-
+        One signed-in device. The session TOKEN is a bearer secret and never
+        appears here — `isCurrent` is all the client needs to tell which row
+        it is looking through. `ipAddress` is the digest Limen stored, not a
+        readable address, and `impersonatedBy` is always null (the Go server
+        has no impersonation).
+      required:
+        [
+          id,
+          isCurrent,
+          expiresAt,
+          ipAddress,
+          userAgent,
+          createdAt,
+          updatedAt,
+          impersonatedBy,
+        ]
+      properties:
+        id:
+          type: string
+        isCurrent:
+          type: boolean
+        expiresAt:
+          type: string
+          format: date-time
+        ipAddress:
+          type: string
+          nullable: true
+        userAgent:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true
+        impersonatedBy:
+          type: string
+          nullable: true
+    AccountSettings:
+      type: object
+      required: [profile, sessions]
+      properties:
+        profile:
+          $ref: "#/components/schemas/Profile"
+        sessions:
+          type: array
+          items:
+            $ref: "#/components/schemas/SessionSummary"
+    ProfileResult:
+      type: object
+      required: [profile]
+      properties:
+        profile:
+          $ref: "#/components/schemas/Profile"
+    ProfileRequest:
+      type: object
+      description: >-
+        REF §A4's `profile` schema. `image` is optional and an empty string
+        clears the avatar; anything else must be an http(s) URL of at most
+        2048 characters, checked in Go so the message is the TypeScript's
+        ("image must be an http(s) URL").
+      required: [name]
+      properties:
+        name:
+          type: string
+          description: Trimmed, 1..80 characters.
+        image:
+          type: string
+          description: An http(s) URL, or "" to clear the avatar.
     Error:
       type: object
       description: >-

--- a/apps/server/internal/api/routes.go
+++ b/apps/server/internal/api/routes.go
@@ -76,6 +76,23 @@ var operationAuthTiers = map[string]authTier{
 	// Invitations (REF §A2, "Invitations — public"). See tierViewer.
 	"LookupInvitation": tierViewer,
 	"AcceptInvitation": tierViewer,
+
+	// Households (REF §A2, "Households — session required"). Only the leave
+	// route names a household in its path, and it is the one that needs the
+	// tenancy guard; the other two answer about the caller themselves, so
+	// their tenancy is the session.
+	"ListMyHouseholds": tierSession,
+	"CreateHousehold":  tierSession,
+	"LeaveHousehold":   tierHousehold,
+
+	// Settings (REF §A2, "Settings — session required"). Every one of these is
+	// about the caller's own account — there is no user id in any path — so
+	// the session is both the authentication and the subject.
+	"GetAccountSettings":     tierSession,
+	"ListSettingsHouseholds": tierSession,
+	"UpdateProfile":          tierSession,
+	"RevokeOtherSessions":    tierSession,
+	"RevokeSession":          tierSession,
 }
 
 // operationRateLimits maps an operationID to the rule its route is limited by.
@@ -85,6 +102,11 @@ var operationRateLimits = map[string]ratelimit.Rule{
 	"CompleteSetup":    ratelimit.Setup,
 	"LookupInvitation": ratelimit.Invitations,
 	"AcceptInvitation": ratelimit.Invitations,
+
+	// Household creation carries no secret, but each one claims an inbound
+	// email address, so the budget (10 per hour) is what keeps a signed-in
+	// caller from minting them faster than a person plausibly would.
+	"CreateHousehold": ratelimit.HouseholdCreate,
 }
 
 // publicAPIAllowlist is the exhaustive set of tierPublic operations allowed to

--- a/apps/server/internal/api/routes.go
+++ b/apps/server/internal/api/routes.go
@@ -93,6 +93,33 @@ var operationAuthTiers = map[string]authTier{
 	"UpdateProfile":          tierSession,
 	"RevokeOtherSessions":    tierSession,
 	"RevokeSession":          tierSession,
+
+	// Admin (REF §A2, "Admin — owner of :slug"). Every one of them, without
+	// exception: the TypeScript mounted requireHouseholdContext and
+	// requireOwner on `/:slug/*` for the whole admin router, so "owner" was a
+	// property of that ROUTER, and it is a property of this block here. A
+	// future admin route wanting a lesser tier is a decision to argue for in
+	// review, not a line to slip in.
+	"ListAuditEvents":            tierOwner,
+	"GetHouseholdSettings":       tierOwner,
+	"UpdateHouseholdSettings":    tierOwner,
+	"ListProviderConfigurations": tierOwner,
+	"CreateProvider":             tierOwner,
+	"UpdateProvider":             tierOwner,
+	"DeleteProvider":             tierOwner,
+	"CreateSenderRule":           tierOwner,
+	"UpdateSenderRule":           tierOwner,
+	"DeleteSenderRule":           tierOwner,
+	"ListMembers":                tierOwner,
+	"CreateMember":               tierOwner,
+	"RemoveMember":               tierOwner,
+	"UpdateMemberRole":           tierOwner,
+	"GrantProviderAccess":        tierOwner,
+	"RevokeProviderAccess":       tierOwner,
+	"ListInvitations":            tierOwner,
+	"CreateInvitation":           tierOwner,
+	"ResendInvitation":           tierOwner,
+	"CancelInvitation":           tierOwner,
 }
 
 // operationRateLimits maps an operationID to the rule its route is limited by.

--- a/apps/server/internal/api/settings.go
+++ b/apps/server/internal/api/settings.go
@@ -1,0 +1,208 @@
+package api
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/andersro93/mi-casa-su-casa/server/internal/api/gen"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/repo"
+)
+
+// Ports src/server/routes/settings.ts and the repository underneath it,
+// src/server/db/repositories/settings.ts (REF §A2, "Settings").
+//
+// Everything here is about the caller's OWN account — the profile, the
+// households they belong to, and the devices they are signed in on. There is
+// no user id in any path: the session is the subject, which is what makes
+// "revoke that device" safe to expose at all.
+//
+// The device list is the delicate part. A session's token is a bearer secret:
+// possession of it IS the sign-in, so it never appears in a response. The
+// screen gets the row id instead, plus `isCurrent` so it can tell the viewer
+// which line is the browser they are reading it in.
+
+// GetAccountSettings answers the whole settings screen in one request.
+func (s server) GetAccountSettings(ctx context.Context, _ gen.GetAccountSettingsRequestObject) (gen.GetAccountSettingsResponseObject, error) {
+	viewer := viewerFrom(ctx)
+	if viewer == nil {
+		return gen.GetAccountSettings401JSONResponse(errorBody("Unauthorized")), nil
+	}
+
+	profile, err := s.Repo.GetUserProfile(ctx, viewer.UserID)
+	if err != nil {
+		return nil, err
+	}
+	if profile == nil {
+		return gen.GetAccountSettings404JSONResponse(errorBody("User not found")), nil
+	}
+
+	sessions, err := s.Repo.ListUserSessions(ctx, viewer.UserID)
+	if err != nil {
+		return nil, err
+	}
+
+	return gen.GetAccountSettings200JSONResponse{
+		Profile:  profileBody(*profile),
+		Sessions: sessionSummaries(sessions, viewer.SessionID),
+	}, nil
+}
+
+// ListSettingsHouseholds is the same list GET /api/households/me answers with.
+// It exists separately because the settings screen refetches it on its own
+// after leaving a household, and the SPA has called this path since the
+// Workers deployment.
+func (s server) ListSettingsHouseholds(ctx context.Context, _ gen.ListSettingsHouseholdsRequestObject) (gen.ListSettingsHouseholdsResponseObject, error) {
+	viewer := viewerFrom(ctx)
+	if viewer == nil {
+		return gen.ListSettingsHouseholds401JSONResponse(errorBody("Unauthorized")), nil
+	}
+
+	households, err := s.Repo.ListHouseholdsForUser(ctx, viewer.UserID)
+	if err != nil {
+		return nil, err
+	}
+	return gen.ListSettingsHouseholds200JSONResponse{Households: householdSummaries(households)}, nil
+}
+
+// UpdateProfile writes the caller's display name and avatar.
+func (s server) UpdateProfile(ctx context.Context, request gen.UpdateProfileRequestObject) (gen.UpdateProfileResponseObject, error) {
+	viewer := viewerFrom(ctx)
+	if viewer == nil {
+		return gen.UpdateProfile401JSONResponse(errorBody("Unauthorized")), nil
+	}
+
+	name := strings.TrimSpace(request.Body.Name)
+	image, problems := normalizeProfileImage(request.Body.Image)
+	problems = appendTextProblems(problems, "name", name, 80)
+	if len(problems) > 0 {
+		summary, fields := envelopeFor(problems)
+		return gen.UpdateProfile400JSONResponse(errorFieldsBody(summary, fields)), nil
+	}
+
+	profile, err := s.Repo.UpdateUserProfile(ctx, viewer.UserID, name, image)
+	if err != nil {
+		return nil, err
+	}
+	if profile == nil {
+		return gen.UpdateProfile404JSONResponse(errorBody("User not found")), nil
+	}
+	return gen.UpdateProfile200JSONResponse{Profile: profileBody(*profile)}, nil
+}
+
+// RevokeOtherSessions is "sign out everywhere else".
+//
+// It deletes the rows rather than flagging them: the session token is checked
+// against that table on every request, so a deleted row is a cookie that no
+// longer signs anybody in — which is the whole point of the button.
+func (s server) RevokeOtherSessions(ctx context.Context, _ gen.RevokeOtherSessionsRequestObject) (gen.RevokeOtherSessionsResponseObject, error) {
+	viewer := viewerFrom(ctx)
+	if viewer == nil {
+		return gen.RevokeOtherSessions401JSONResponse(errorBody("Unauthorized")), nil
+	}
+
+	if err := s.Repo.DeleteOtherSessions(ctx, viewer.UserID, viewer.SessionID); err != nil {
+		return nil, err
+	}
+	// No household: this is an account-level event, and filing it under one
+	// household would put it in an audit log the other households cannot see.
+	s.Repo.RecordAudit(ctx, repo.AuditEventInput{
+		ActorUserID: &viewer.UserID,
+		Action:      "session.revoked_others",
+		TargetType:  "user",
+		TargetID:    &viewer.UserID,
+	})
+
+	return gen.RevokeOtherSessions200JSONResponse(okBody()), nil
+}
+
+// RevokeSession revokes one device.
+//
+// A session id belonging to somebody else deletes nothing and still answers
+// 200 (the delete is scoped to the caller's own user id): a 404 would turn
+// this into an oracle for which session ids exist, and there is nothing the
+// caller could do about the difference anyway.
+func (s server) RevokeSession(ctx context.Context, request gen.RevokeSessionRequestObject) (gen.RevokeSessionResponseObject, error) {
+	viewer := viewerFrom(ctx)
+	if viewer == nil {
+		return gen.RevokeSession401JSONResponse(errorBody("Unauthorized")), nil
+	}
+
+	if err := s.Repo.DeleteSession(ctx, viewer.UserID, request.SessionId); err != nil {
+		return nil, err
+	}
+	s.Repo.RecordAudit(ctx, repo.AuditEventInput{
+		ActorUserID: &viewer.UserID,
+		Action:      "session.revoked",
+		TargetType:  "session",
+		TargetID:    &request.SessionId,
+	})
+
+	return gen.RevokeSession200JSONResponse(okBody()), nil
+}
+
+// profileBody maps the repository's profile onto the wire shape. `role` is
+// always null: it carried Better Auth's global role in the TypeScript server,
+// which has no Go counterpart, and stays in the payload because the SPA reads
+// it.
+func profileBody(profile repo.UserProfile) gen.Profile {
+	return gen.Profile{
+		Id:               profile.ID,
+		Email:            profile.Email,
+		Name:             profile.Name,
+		Image:            profile.Image,
+		Role:             nil,
+		TwoFactorEnabled: profile.TwoFactorEnabled,
+		Households:       householdSummaries(profile.Households),
+	}
+}
+
+// sessionSummaries maps the device list, flagging the row the request itself
+// arrived on. `impersonatedBy` is always null — this server has no
+// impersonation — and `ipAddress` is the digest Limen stored rather than a
+// readable address, so the screen can distinguish two devices without
+// publishing where either one is.
+func sessionSummaries(sessions []repo.Session, currentID string) []gen.SessionSummary {
+	summaries := make([]gen.SessionSummary, 0, len(sessions))
+	for _, session := range sessions {
+		summaries = append(summaries, gen.SessionSummary{
+			Id:             session.ID,
+			IsCurrent:      session.ID == currentID,
+			ExpiresAt:      session.ExpiresAt,
+			IpAddress:      session.IPAddress,
+			UserAgent:      session.UserAgent,
+			CreatedAt:      session.CreatedAt,
+			UpdatedAt:      session.LastAccess,
+			ImpersonatedBy: nil,
+		})
+	}
+	return summaries
+}
+
+// normalizeProfileImage is REF §A4's `image` rule: absent or empty clears the
+// avatar, anything else must be an http(s) URL of at most 2048 characters.
+//
+// The scheme check is explicit rather than left to url.Parse, which happily
+// accepts "not a url" as a relative reference and would let a javascript: URL
+// through — this value ends up in an <img src>, so only http and https may
+// reach it.
+func normalizeProfileImage(raw *string) (*string, []problem) {
+	if raw == nil {
+		return nil, nil
+	}
+	image := strings.TrimSpace(*raw)
+	if image == "" {
+		return nil, nil
+	}
+	if utf8.RuneCountInString(image) > 2048 {
+		return nil, []problem{{field: "image", message: "image must be at most 2048 characters"}}
+	}
+
+	parsed, err := url.Parse(image)
+	if err != nil || parsed.Host == "" ||
+		(!strings.EqualFold(parsed.Scheme, "http") && !strings.EqualFold(parsed.Scheme, "https")) {
+		return nil, []problem{{field: "image", message: "image must be an http(s) URL"}}
+	}
+	return &image, nil
+}

--- a/apps/server/internal/api/settings_test.go
+++ b/apps/server/internal/api/settings_test.go
@@ -1,0 +1,357 @@
+package api_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/andersro93/mi-casa-su-casa/server/internal/testrig"
+)
+
+// Ports test/integration/settings-route.test.ts, the profile half of
+// test/integration/two-factor.test.ts, and the session-revocation cases of
+// test/integration/auth.test.ts and audit-log.test.ts.
+
+// settings reads GET /api/settings, failing the test when it does not answer.
+func settings(t *testing.T, app *testrig.AppRig, cookie string) map[string]any {
+	t.Helper()
+
+	rec := app.Do(t, http.MethodGet, "/api/settings", nil, testrig.WithCookie(cookie))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/settings: %d %s", rec.Code, rec.Body.String())
+	}
+	return app.JSON(t, rec)
+}
+
+// sessionsOf is the session list from GET /api/settings.
+func sessionsOf(t *testing.T, body map[string]any) []map[string]any {
+	t.Helper()
+
+	raw, ok := body["sessions"].([]any)
+	if !ok {
+		t.Fatalf("sessions = %v", body["sessions"])
+	}
+	sessions := make([]map[string]any, 0, len(raw))
+	for _, entry := range raw {
+		session, ok := entry.(map[string]any)
+		if !ok {
+			t.Fatalf("session entry = %v", entry)
+		}
+		sessions = append(sessions, session)
+	}
+	return sessions
+}
+
+func TestSettingsRequireASession(t *testing.T) {
+	app := testrig.App(t)
+	app.CompleteSetup(t)
+
+	for _, tc := range []struct {
+		method, path string
+		body         any
+	}{
+		{http.MethodGet, "/api/settings", nil},
+		{http.MethodGet, "/api/settings/households", nil},
+		{http.MethodPatch, "/api/settings/profile", map[string]any{"name": "Nobody"}},
+		{http.MethodDelete, "/api/settings/sessions/others", nil},
+		{http.MethodDelete, "/api/settings/sessions/whatever", nil},
+	} {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			rec := app.Do(t, tc.method, tc.path, tc.body)
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+			}
+			if got := app.JSON(t, rec)["error"]; got != "Unauthorized" {
+				t.Errorf("error = %q", got)
+			}
+		})
+	}
+}
+
+// settings-route.test.ts: the device list flags the current session and never
+// carries a token.
+func TestSettingsListsSessionsWithoutTokensAndFlagsTheCurrentOne(t *testing.T) {
+	app := testrig.App(t)
+	cookie, _ := app.CompleteSetup(t)
+
+	body := settings(t, app, cookie)
+	sessions := sessionsOf(t, body)
+	if len(sessions) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(sessions))
+	}
+	if sessions[0]["isCurrent"] != true {
+		t.Errorf("isCurrent = %v", sessions[0]["isCurrent"])
+	}
+	for _, key := range []string{"id", "expiresAt", "createdAt"} {
+		if value, ok := sessions[0][key].(string); !ok || value == "" {
+			t.Errorf("session[%q] = %v", key, sessions[0][key])
+		}
+	}
+	// REF §A2: impersonation has no Go counterpart, and the ip digest is
+	// opaque rather than an address.
+	if _, present := sessions[0]["impersonatedBy"]; !present || sessions[0]["impersonatedBy"] != nil {
+		t.Errorf("impersonatedBy = %v, want null", sessions[0]["impersonatedBy"])
+	}
+	for _, key := range []string{"ipAddress", "userAgent", "updatedAt"} {
+		if _, present := sessions[0][key]; !present {
+			t.Errorf("session is missing %q", key)
+		}
+	}
+
+	// A session token is a bearer secret: it never leaves the server.
+	if strings.Contains(strings.ToLower(rawBody(t, app, cookie)), "token") {
+		t.Errorf("settings body mentions a token: %s", rawBody(t, app, cookie))
+	}
+}
+
+// rawBody is GET /api/settings as it went on the wire, for the "no token
+// anywhere in this payload" assertion.
+func rawBody(t *testing.T, app *testrig.AppRig, cookie string) string {
+	t.Helper()
+	return app.Do(t, http.MethodGet, "/api/settings", nil, testrig.WithCookie(cookie)).Body.String()
+}
+
+func TestSettingsProfile(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+
+	profile, ok := settings(t, app, cookie)["profile"].(map[string]any)
+	if !ok {
+		t.Fatalf("profile missing")
+	}
+	if profile["email"] != testrig.OwnerEmail || profile["name"] != "Owner" {
+		t.Errorf("profile = %v", profile)
+	}
+	if profile["image"] != nil {
+		t.Errorf("image = %v, want null", profile["image"])
+	}
+	// REF §A2: `role` carried Better Auth's global role and is always null
+	// here, but stays in the payload because the SPA reads it.
+	if value, present := profile["role"]; !present || value != nil {
+		t.Errorf("role = %v, want null", value)
+	}
+	if profile["twoFactorEnabled"] != false {
+		t.Errorf("twoFactorEnabled = %v, want false", profile["twoFactorEnabled"])
+	}
+
+	households, _ := profile["households"].([]any)
+	if len(households) != 1 {
+		t.Fatalf("households = %v", profile["households"])
+	}
+	entry, _ := households[0].(map[string]any)
+	if entry["slug"] != slug || entry["role"] != "owner" {
+		t.Errorf("household entry = %v", entry)
+	}
+}
+
+// two-factor.test.ts's half of the profile: the flag Limen's two-factor plugin
+// maintains is what the settings screen reads.
+func TestSettingsProfileReportsTwoFactorEnabled(t *testing.T) {
+	app := testrig.App(t)
+	cookie, _ := app.CompleteSetup(t)
+
+	if _, err := app.Rig.Pool.Exec(t.Context(),
+		`UPDATE "users" SET "two_factor_enabled" = true WHERE "email" = $1`, testrig.OwnerEmail,
+	); err != nil {
+		t.Fatalf("enable two-factor: %v", err)
+	}
+
+	profile, _ := settings(t, app, cookie)["profile"].(map[string]any)
+	if profile["twoFactorEnabled"] != true {
+		t.Errorf("twoFactorEnabled = %v, want true", profile["twoFactorEnabled"])
+	}
+}
+
+func TestSettingsHouseholds(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+
+	rec := app.Do(t, http.MethodGet, "/api/settings/households", nil, testrig.WithCookie(cookie))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	households, _ := app.JSON(t, rec)["households"].([]any)
+	if len(households) != 1 {
+		t.Fatalf("households = %v", app.JSON(t, rec)["households"])
+	}
+	entry, _ := households[0].(map[string]any)
+	if entry["slug"] != slug || entry["role"] != "owner" {
+		t.Errorf("entry = %v", entry)
+	}
+}
+
+func TestUpdateProfile(t *testing.T) {
+	app := testrig.App(t)
+	cookie, _ := app.CompleteSetup(t)
+
+	rec := app.Do(t, http.MethodPatch, "/api/settings/profile",
+		map[string]any{"name": "  Renamed  ", "image": "https://example.com/avatar.png"},
+		testrig.WithCookie(cookie))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	profile, _ := app.JSON(t, rec)["profile"].(map[string]any)
+	if profile["name"] != "Renamed" {
+		t.Errorf("name = %v, want the trimmed value", profile["name"])
+	}
+	if profile["image"] != "https://example.com/avatar.png" {
+		t.Errorf("image = %v", profile["image"])
+	}
+
+	// The empty string is how the SPA clears an avatar (REF §A4).
+	cleared := app.Do(t, http.MethodPatch, "/api/settings/profile",
+		map[string]any{"name": "Renamed", "image": ""}, testrig.WithCookie(cookie))
+	if cleared.Code != http.StatusOK {
+		t.Fatalf("clear: %d %s", cleared.Code, cleared.Body.String())
+	}
+	profile, _ = app.JSON(t, cleared)["profile"].(map[string]any)
+	if profile["image"] != nil {
+		t.Errorf("image = %v, want null", profile["image"])
+	}
+
+	// Omitting the key entirely does the same, which is what the TypeScript's
+	// optional-then-transform schema did.
+	omitted := app.Do(t, http.MethodPatch, "/api/settings/profile",
+		map[string]any{"name": "Renamed"}, testrig.WithCookie(cookie))
+	if omitted.Code != http.StatusOK {
+		t.Fatalf("omitted image: %d %s", omitted.Code, omitted.Body.String())
+	}
+}
+
+func TestUpdateProfileRejectsBadInput(t *testing.T) {
+	app := testrig.App(t)
+	cookie, _ := app.CompleteSetup(t)
+
+	for _, tc := range []struct {
+		name  string
+		body  map[string]any
+		field string
+		want  string
+	}{
+		{"blank name", map[string]any{"name": "   "}, "name", "name is required"},
+		{
+			"long name",
+			map[string]any{"name": strings.Repeat("x", 81)},
+			"name", "name must be at most 80 characters",
+		},
+		{
+			"non-http image",
+			map[string]any{"name": "Owner", "image": "ftp://example.com/a.png"},
+			"image", "image must be an http(s) URL",
+		},
+		{
+			"unparseable image",
+			map[string]any{"name": "Owner", "image": "not a url"},
+			"image", "image must be an http(s) URL",
+		},
+		{
+			"long image",
+			map[string]any{"name": "Owner", "image": "https://example.com/" + strings.Repeat("a", 2048)},
+			"image", "image must be at most 2048 characters",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := app.Do(t, http.MethodPatch, "/api/settings/profile", tc.body, testrig.WithCookie(cookie))
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+			}
+			fields, _ := app.JSON(t, rec)["fields"].(map[string]any)
+			if got := fields[tc.field]; got != tc.want {
+				t.Errorf("fields[%q] = %v, want %q", tc.field, got, tc.want)
+			}
+		})
+	}
+}
+
+// auth.test.ts's revocation case: signing out everywhere else really does stop
+// the other cookie working.
+func TestRevokeOtherSessions(t *testing.T) {
+	app := testrig.App(t)
+	first, _ := app.CompleteSetup(t)
+	second := app.SignIn(t, testrig.OwnerEmail, testrig.Password)
+
+	if got := len(sessionsOf(t, settings(t, app, second))); got != 2 {
+		t.Fatalf("sessions = %d, want 2", got)
+	}
+
+	rec := app.Do(t, http.MethodDelete, "/api/settings/sessions/others", nil, testrig.WithCookie(second))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	if got := app.JSON(t, rec)["ok"]; got != true {
+		t.Errorf("body = %s", rec.Body.String())
+	}
+
+	// The revoked cookie is a cookie for a session that no longer exists.
+	stale := app.Do(t, http.MethodGet, "/api/settings", nil, testrig.WithCookie(first))
+	if stale.Code != http.StatusUnauthorized {
+		t.Fatalf("the revoked cookie still works: %d %s", stale.Code, stale.Body.String())
+	}
+	if got := len(sessionsOf(t, settings(t, app, second))); got != 1 {
+		t.Errorf("sessions after revoking = %d, want 1", got)
+	}
+	if got := app.Count(t, "audit_events", `"action" = 'session.revoked_others'`); got != 1 {
+		t.Errorf("session.revoked_others audits = %d, want 1", got)
+	}
+}
+
+func TestRevokeOneSession(t *testing.T) {
+	app := testrig.App(t)
+	first, _ := app.CompleteSetup(t)
+	second := app.SignIn(t, testrig.OwnerEmail, testrig.Password)
+
+	// The one that is not the caller's own is the session the first cookie
+	// belongs to — the id is all the screen ever has to address a device by.
+	var target string
+	for _, session := range sessionsOf(t, settings(t, app, second)) {
+		if session["isCurrent"] != true {
+			target, _ = session["id"].(string)
+		}
+	}
+	if target == "" {
+		t.Fatal("no other session to revoke")
+	}
+
+	rec := app.Do(t, http.MethodDelete, "/api/settings/sessions/"+target, nil, testrig.WithCookie(second))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+
+	stale := app.Do(t, http.MethodGet, "/api/settings", nil, testrig.WithCookie(first))
+	if stale.Code != http.StatusUnauthorized {
+		t.Fatalf("the revoked cookie still works: %d %s", stale.Code, stale.Body.String())
+	}
+	if got := len(sessionsOf(t, settings(t, app, second))); got != 1 {
+		t.Errorf("sessions after revoking = %d, want 1", got)
+	}
+	if got := app.Count(t, "audit_events",
+		`"action" = 'session.revoked' AND "target_id" = $1`, target); got != 1 {
+		t.Errorf("session.revoked audits = %d, want 1", got)
+	}
+}
+
+// A session id that is not the caller's own revokes nothing and still answers
+// 200: a different status would say whether the id exists.
+func TestRevokeSessionOfSomebodyElseIsANoOp(t *testing.T) {
+	app := testrig.App(t)
+	ownerCookie, slug := app.CompleteSetup(t)
+	memberCookie := app.CreateMember(t, slug, memberEmail, "Member", "member")
+
+	var memberSession string
+	for _, session := range sessionsOf(t, settings(t, app, memberCookie)) {
+		memberSession, _ = session["id"].(string)
+	}
+	if memberSession == "" {
+		t.Fatal("the member has no session")
+	}
+
+	rec := app.Do(t, http.MethodDelete, "/api/settings/sessions/"+memberSession, nil,
+		testrig.WithCookie(ownerCookie))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	if survived := app.Do(t, http.MethodGet, "/api/settings", nil,
+		testrig.WithCookie(memberCookie)); survived.Code != http.StatusOK {
+		t.Errorf("the member's session was revoked by somebody else: %d", survived.Code)
+	}
+}

--- a/apps/server/internal/invite/invite.go
+++ b/apps/server/internal/invite/invite.go
@@ -1,0 +1,195 @@
+// Package invite is the invitation service three admin routes share: "invite
+// somebody", "add a member" and "resend" are the same act with different
+// inputs.
+//
+// It is deliberately NOT part of internal/domain, where the rest of this
+// application's rules live. internal/repo and internal/mail both import
+// domain (for the classification types), so a domain package reaching back
+// for a repository and a mailer would be an import cycle — and the rule this
+// package carries is a workflow over two collaborators rather than a pure
+// function over values, which makes a package of its own the honest home for
+// it.
+package invite
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	applog "github.com/andersro93/mi-casa-su-casa/server/internal/log"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/mail"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/repo"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/security"
+)
+
+// Ports src/server/domain/invitations.ts (REF §A3, "Invitations"): minting an
+// invitation, mailing it, and reissuing one. The one rule worth stating out
+// loud is this:
+//
+//	A FAILED EMAIL IS NOT A FAILED INVITATION.
+//
+// The record is written before the mail is attempted, and a transport that
+// refuses the message is reported as `emailSent:false` plus `emailError`
+// rather than raised. The owner still has `inviteUrl` and can paste it into
+// whatever chat the household actually uses — which is the difference between
+// a self-hosted installation with no SMTP credentials being usable and being
+// bricked.
+
+// InvitationTTL is REF §A3's invitation lifetime.
+const TTL = 7 * 24 * time.Hour
+
+// Inviter is the person issuing the invitation, as the invitation mail needs
+// to name them.
+type Inviter struct {
+	ID    string
+	Name  string
+	Email string
+}
+
+// InviteInput is what an invitation is made of: who it is for, what they will
+// be, and which providers they may read the moment they accept.
+type Input struct {
+	Email       string
+	Name        string
+	Role        string
+	ProviderIDs []string
+}
+
+// InviteResult is the invitation, the link, and how delivery went. The link is
+// the only place the plaintext token ever appears — the database holds its
+// SHA-256 — so a caller that drops this value cannot recover it.
+type Result struct {
+	Invitation repo.Invitation
+	InviteURL  string
+	EmailSent  bool
+	EmailError string
+}
+
+// InviteDeps is what inviting needs of the outside world: the store, the
+// transport, the clock, and the base URL an invite link is built on. It is a
+// struct rather than four parameters because two of the four (Now, AppURL) are
+// easy to swap by accident when they are positional.
+type Deps struct {
+	Repo *repo.Repo
+	Mail mail.Sender
+	Now  func() time.Time
+
+	// AppURL is the SPA's origin. A trailing slash is tolerated (the
+	// TypeScript stripped one too), because an operator setting APP_URL by
+	// hand will eventually type one.
+	AppURL string
+}
+
+// Create writes a pending invitation, mails the link, and reports both.
+//
+// The order matters: the record is created first, so a transport failure
+// leaves an invitation the owner can still act on. Its inverse — mail first,
+// record second — would send links that point at nothing.
+func Create(ctx context.Context, deps Deps, householdID string, inviter Inviter, in Input) (*Result, error) {
+	token, tokenHash, err := security.NewInvitationToken()
+	if err != nil {
+		return nil, err
+	}
+
+	expiresAt := deps.Now().Add(TTL)
+	invitationID, err := deps.Repo.CreateInvitation(ctx, repo.CreateInvitationInput{
+		HouseholdID:     householdID,
+		Email:           in.Email,
+		Name:            in.Name,
+		Role:            in.Role,
+		TokenHash:       tokenHash,
+		InvitedByUserID: inviter.ID,
+		ExpiresAt:       expiresAt,
+		ProviderIDs:     in.ProviderIDs,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	invitation, err := deps.Repo.GetInvitationByID(ctx, householdID, invitationID)
+	if err != nil {
+		return nil, err
+	}
+	if invitation == nil {
+		// The row was written a statement ago and is scoped to the same
+		// household; nil here means something removed it in between, which is
+		// the TypeScript's `return null` — the route answers 500.
+		return nil, nil
+	}
+
+	result := &Result{
+		Invitation: *invitation,
+		InviteURL:  URL(deps.AppURL, token),
+		EmailSent:  true,
+	}
+
+	err = deps.Mail.Send(ctx, mail.Invitation(mail.InvitationMail{
+		To:           invitation.Email,
+		InviteeName:  invitation.Name,
+		InviterName:  inviter.Name,
+		InviterEmail: inviter.Email,
+		InviteURL:    result.InviteURL,
+		// The same instant the record carries, in the same spelling the
+		// invitation list shows.
+		ExpiresAt: expiresAt.UTC().Format(time.RFC3339),
+		Role:      invitation.Role,
+	}))
+	if err != nil {
+		// REF §A3: reported, not raised. The log line is REF §A7's
+		// `invitation_email_failed`; the address is in it because an operator
+		// chasing "the invite never arrived" needs to know which one, and no
+		// part of the token or the link is, because a log is not a place to
+		// keep a credential.
+		applog.Event(applog.LevelError, "invitation_email_failed", map[string]any{
+			"invitationId": invitation.ID,
+			"to":           invitation.Email,
+			"error":        err.Error(),
+		})
+		result.EmailSent = false
+		result.EmailError = err.Error()
+	}
+
+	return result, nil
+}
+
+// Resend cancels a pending invitation and issues a fresh one to the
+// same person with the same role and provider scope.
+//
+// The old token stops working, which is the point rather than a side effect:
+// "resend" is what an owner reaches for when the first link went to the wrong
+// inbox, and leaving it live would make the button useless for exactly that.
+//
+// nil, nil means there was no pending invitation with that id in this
+// household — the route answers 404 without saying which of the two it was.
+func Resend(ctx context.Context, deps Deps, householdID string, inviter Inviter, invitationID string) (*Result, error) {
+	existing, err := deps.Repo.GetInvitationByID(ctx, householdID, invitationID)
+	if err != nil {
+		return nil, err
+	}
+	if existing == nil || existing.Status != repo.InvitationPending {
+		return nil, nil
+	}
+
+	if err := deps.Repo.CancelInvitation(ctx, householdID, invitationID); err != nil {
+		return nil, err
+	}
+
+	providerIDs := make([]string, 0, len(existing.Providers))
+	for _, provider := range existing.Providers {
+		providerIDs = append(providerIDs, provider.ID)
+	}
+
+	return Create(ctx, deps, householdID, inviter, Input{
+		Email:       existing.Email,
+		Name:        existing.Name,
+		Role:        existing.Role,
+		ProviderIDs: providerIDs,
+	})
+}
+
+// URL is where an invitation link points: REF §A3's
+// `APP_URL/invite/<token>`, with any trailing slash on the base removed so the
+// path never doubles up.
+func URL(appURL, token string) string {
+	return strings.TrimSuffix(appURL, "/") + "/invite/" + token
+}

--- a/apps/server/internal/invite/invite_test.go
+++ b/apps/server/internal/invite/invite_test.go
@@ -1,0 +1,22 @@
+package invite_test
+
+import (
+	"testing"
+
+	"github.com/andersro93/mi-casa-su-casa/server/internal/invite"
+)
+
+// The rest of this package is exercised end to end through the admin routes
+// (internal/api/admin_invitations_test.go). What is left is the one rule those
+// tests cannot reach, because the test rig's APP_URL has no trailing slash.
+
+func TestURLToleratesATrailingSlashOnTheAppURL(t *testing.T) {
+	const token = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	want := "https://casa.example/invite/" + token
+
+	for _, appURL := range []string{"https://casa.example", "https://casa.example/"} {
+		if got := invite.URL(appURL, token); got != want {
+			t.Errorf("URL(%q) = %q, want %q", appURL, got, want)
+		}
+	}
+}

--- a/openapi/mi-casa.yaml
+++ b/openapi/mi-casa.yaml
@@ -513,6 +513,818 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/audit:
+    get:
+      operationId: listAuditEvents
+      summary: >-
+        The household's audit trail, newest 100 first. Owner-only: it names
+        who did what to whom, which is exactly the sort of thing a member has
+        no business reading about the rest of the household.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      responses:
+        "200":
+          description: The trail.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuditEventList"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/settings:
+    get:
+      operationId: getHouseholdSettings
+      summary: >-
+        The household's own settings: its name and the inbound address
+        providers must be told to send codes to.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      responses:
+        "200":
+          description: The settings.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HouseholdSettingsResult"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: The household is gone.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    patch:
+      operationId: updateHouseholdSettings
+      summary: Rename the household. The slug — and therefore the inbound address — never changes.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HouseholdSettingsRequest"
+      responses:
+        "200":
+          description: The settings, as they now stand.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HouseholdSettingsResult"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: The household is gone.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/providers:
+    get:
+      operationId: listProviderConfigurations
+      summary: >-
+        Every provider in the household with the number of sender rules that
+        point at it, plus the rules themselves — the two halves of the
+        provider settings screen in one request.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      responses:
+        "200":
+          description: The providers and their sender rules.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProviderConfigurationList"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      operationId: createProvider
+      summary: Add a provider — the mailbox a set of sender rules files messages into.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProviderRequest"
+      responses:
+        "201":
+          description: The provider.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProviderResult"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: A provider with that key already exists in this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/providers/{providerId}:
+    patch:
+      operationId: updateProvider
+      summary: Rename a provider or change its key.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/ProviderId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProviderRequest"
+      responses:
+        "200":
+          description: The provider, as it now stands.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProviderResult"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No such provider in this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Another provider in this household already has that key.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      operationId: deleteProvider
+      summary: >-
+        Remove a provider. Its sender rules, its stored messages and every
+        member's access to it go with it — the foreign keys cascade, which is
+        the point: a deleted provider must not leave readable messages behind.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/ProviderId"
+      responses:
+        "200":
+          description: The provider and everything filed under it are gone.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ok"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No such provider in this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/provider-rules:
+    post:
+      operationId: createSenderRule
+      summary: >-
+        Add a sender rule: the address or domain whose mail files into a
+        provider. Exact rules beat domain rules, and the most specific domain
+        rule wins among those.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SenderRuleRequest"
+      responses:
+        "201":
+          description: The rule.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SenderRuleResult"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No such provider in this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: This household already has a rule for that match type and value.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/provider-rules/{ruleId}:
+    patch:
+      operationId: updateSenderRule
+      summary: Repoint a sender rule, or change what it matches.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/SenderRuleId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SenderRuleRequest"
+      responses:
+        "200":
+          description: The rule, as it now stands.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SenderRuleResult"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No such provider, or no such rule, in this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: This household already has a rule for that match type and value.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      operationId: deleteSenderRule
+      summary: Remove a sender rule. Messages already filed under its provider stay.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/SenderRuleId"
+      responses:
+        "200":
+          description: The rule is gone.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ok"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No such rule in this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/members:
+    get:
+      operationId: listMembers
+      summary: >-
+        Everybody in the household with the providers each of them may read,
+        plus the household's providers so the screen can offer the rest.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      responses:
+        "200":
+          description: The members and the household's providers.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MemberList"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      operationId: createMember
+      summary: >-
+        "Add a member" — which is an invitation with no provider scope, not an
+        account this endpoint creates. Nobody may be given a password by
+        somebody else, so the invitee always sets their own.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateMemberRequest"
+      responses:
+        "201":
+          description: >-
+            The invitation, its link, and whether the email carrying that link
+            was delivered. A failed delivery is not an error (REF §A3) — the
+            owner can share `inviteUrl` by hand.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InvitationResult"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/members/{userId}:
+    delete:
+      operationId: removeMember
+      summary: >-
+        Remove somebody else from the household. Refused for the last owner,
+        and refused for yourself — "leave household" is the route for that, so
+        that giving up your own access is never a click away from removing
+        somebody else's.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/MemberUserId"
+      responses:
+        "200":
+          description: The membership is gone; provider access cascaded with it.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ok"
+        "400":
+          description: The caller asked to remove themselves.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: That user is not a member of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: That member is the household's only owner.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/members/{userId}/role:
+    patch:
+      operationId: updateMemberRole
+      summary: >-
+        Promote or demote somebody else. Refused for yourself: an owner who
+        could demote themselves could leave a household with no owner at all,
+        and the answer names the other owners as the way out.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/MemberUserId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RoleChangeRequest"
+      responses:
+        "200":
+          description: The role is changed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ok"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner, or asked to change their own role.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: That user is not a member of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/members/{userId}/provider-access:
+    post:
+      operationId: grantProviderAccess
+      summary: >-
+        Let a member read one provider's messages. Idempotent: granting twice
+        is the same as granting once, so a double-click is not an error.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/MemberUserId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProviderAccessRequest"
+      responses:
+        "200":
+          description: The member may now read that provider.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ok"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No such provider, or that user is not a member of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/members/{userId}/provider-access/{providerKey}:
+    delete:
+      operationId: revokeProviderAccess
+      summary: >-
+        Take a provider away from a member. The key is a path parameter and
+        only a path parameter — the TypeScript also read it from a JSON body
+        on DELETE, which is a shape no client sends and every proxy is
+        entitled to drop.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/MemberUserId"
+        - name: providerKey
+          in: path
+          required: true
+          description: >-
+            The provider's key. REF §A4's `providerAccess` rules (1..40, and
+            lower-cased before the lookup) are stated here rather than in Go,
+            because a path parameter has no `fields` entry to render against
+            and REF §A2 asks for this one to be spec-validated.
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 40
+      responses:
+        "200":
+          description: The member can no longer read that provider.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ok"
+        "400":
+          description: The provider key is not a usable key.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No such provider, or that user is not a member of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/invitations:
+    get:
+      operationId: listInvitations
+      summary: >-
+        Every invitation this household has issued, newest first. Invitations
+        past their expiry are marked expired before the list is read, so the
+        screen never shows a pending invitation whose link no longer works.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      responses:
+        "200":
+          description: The invitations.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InvitationList"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      operationId: createInvitation
+      summary: >-
+        Invite somebody, optionally scoped to a set of providers they will be
+        able to read the moment they accept.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InvitationRequest"
+      responses:
+        "201":
+          description: >-
+            The invitation, its link, and whether the email carrying that link
+            was delivered. A failed delivery is not an error (REF §A3).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InvitationResult"
+        "400":
+          description: >-
+            The request was rejected — a bad field, or a provider that belongs
+            to another household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/invitations/{invitationId}/resend:
+    post:
+      operationId: resendInvitation
+      summary: >-
+        Issue a fresh invitation to the same person with the same role and
+        provider scope, cancelling the old one. A new token, so the link in
+        the first email stops working — which is what makes "resend" safe to
+        offer after a link has been forwarded to the wrong inbox.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/InvitationId"
+      responses:
+        "200":
+          description: The replacement invitation, its link, and the delivery outcome.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InvitationResult"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No such invitation in this household, or it is no longer pending.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/admin/{slug}/invitations/{invitationId}:
+    delete:
+      operationId: cancelInvitation
+      summary: Cancel a pending invitation, which makes its link stop working.
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/InvitationId"
+      responses:
+        "200":
+          description: The invitation is cancelled.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ok"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No such invitation in this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 components:
   parameters:
     HouseholdSlug:
@@ -552,6 +1364,42 @@ components:
         right size. It is mandatory in practice.
       schema:
         type: string
+    ProviderId:
+      name: providerId
+      in: path
+      required: true
+      description: A provider's id. Scoped to the household in the path, so an id from another household is a 404 rather than a leak.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 200
+    SenderRuleId:
+      name: ruleId
+      in: path
+      required: true
+      description: A sender rule's id, scoped to the household in the path.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 200
+    MemberUserId:
+      name: userId
+      in: path
+      required: true
+      description: The member's user id. Membership of the household in the path is checked before anything is done with it.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 200
+    InvitationId:
+      name: invitationId
+      in: path
+      required: true
+      description: An invitation's id, scoped to the household in the path.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 200
   schemas:
     Ok:
       type: object
@@ -976,3 +1824,318 @@ components:
               type: string
             emailMatches:
               type: boolean
+    AuditEvent:
+      type: object
+      description: >-
+        One line of the audit trail. `details` is whatever the action recorded
+        (the new role, the provider key, whether an invitation email got out),
+        parsed back from the stored JSON.
+      required:
+        [id, actorUserId, householdId, action, targetType, targetId, details, createdAt]
+      properties:
+        id:
+          type: string
+        actorUserId:
+          type: string
+          nullable: true
+        householdId:
+          type: string
+          nullable: true
+        action:
+          type: string
+        targetType:
+          type: string
+        targetId:
+          type: string
+          nullable: true
+        details:
+          type: object
+          nullable: true
+          additionalProperties: true
+        createdAt:
+          type: string
+          format: date-time
+    AuditEventList:
+      type: object
+      required: [events]
+      properties:
+        events:
+          type: array
+          items:
+            $ref: "#/components/schemas/AuditEvent"
+    HouseholdSettings:
+      type: object
+      description: >-
+        A household's own settings. `emailAddress` is `slug@EMAIL_DOMAIN` —
+        the address providers must be told to send to — and is null only if
+        the installation has no inbound domain configured.
+      required: [slug, displayName, emailAddress]
+      properties:
+        slug:
+          type: string
+        displayName:
+          type: string
+        emailAddress:
+          type: string
+          nullable: true
+    HouseholdSettingsResult:
+      type: object
+      required: [household]
+      properties:
+        household:
+          $ref: "#/components/schemas/HouseholdSettings"
+    HouseholdSettingsRequest:
+      type: object
+      description: REF §A4's `householdSettings` schema. Trimmed and length-checked in Go, for the wording.
+      required: [displayName]
+      properties:
+        displayName:
+          type: string
+          description: Trimmed, 1..80 characters.
+    Provider:
+      type: object
+      description: >-
+        One provider. snake_case keys, deliberately: it is what the TypeScript
+        returned and what the SPA reads.
+      required: [id, household_id, provider_key, display_name, created_at]
+      properties:
+        id:
+          type: string
+        household_id:
+          type: string
+        provider_key:
+          type: string
+        display_name:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+    ProviderConfiguration:
+      type: object
+      description: A provider plus how many sender rules point at it.
+      required: [id, household_id, provider_key, display_name, created_at, rule_count]
+      properties:
+        id:
+          type: string
+        household_id:
+          type: string
+        provider_key:
+          type: string
+        display_name:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        rule_count:
+          type: integer
+    SenderRule:
+      type: object
+      description: One sender rule — the address or domain whose mail files into a provider.
+      required: [id, household_id, provider_id, match_type, match_value, created_at]
+      properties:
+        id:
+          type: string
+        household_id:
+          type: string
+        provider_id:
+          type: string
+        match_type:
+          type: string
+          enum: [exact, domain]
+        match_value:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+    ProviderConfigurationList:
+      type: object
+      required: [providers, rules]
+      properties:
+        providers:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProviderConfiguration"
+        rules:
+          type: array
+          items:
+            $ref: "#/components/schemas/SenderRule"
+    ProviderResult:
+      type: object
+      required: [provider]
+      properties:
+        provider:
+          $ref: "#/components/schemas/Provider"
+    ProviderRequest:
+      type: object
+      description: >-
+        REF §A4's `provider` schema. Only the shape is stated here: the key is
+        trimmed and lower-cased before its rules run, and the message each
+        failure produces is REF §A4's wording, which a schema violation cannot
+        produce.
+      required: [providerKey, displayName]
+      properties:
+        providerKey:
+          type: string
+          description: Trimmed, lower-cased, 1..40, lowercase letters, numbers and hyphens, starting with a letter or number.
+        displayName:
+          type: string
+          description: Trimmed, 1..80 characters.
+    SenderRuleResult:
+      type: object
+      required: [rule]
+      properties:
+        rule:
+          $ref: "#/components/schemas/SenderRule"
+    SenderRuleRequest:
+      type: object
+      description: >-
+        REF §A4's `senderRule` schema. `matchType` is a plain string here
+        rather than an enum for the same reason the lengths are absent: the
+        rejection must read "matchType must be exact or domain", which is
+        checked in Go.
+      required: [providerId, matchType, matchValue]
+      properties:
+        providerId:
+          type: string
+          description: Trimmed, 1..64 characters.
+        matchType:
+          type: string
+          description: "`exact` or `domain`."
+        matchValue:
+          type: string
+          description: >-
+            Trimmed, lower-cased, 1..254. A domain rule drops any leading `@`
+            and must then be a hostname; an exact rule must be a full email
+            address.
+    MemberProviderAccess:
+      type: object
+      description: One provider a member may read.
+      required: [providerKey, displayName]
+      properties:
+        providerKey:
+          type: string
+        displayName:
+          type: string
+    HouseholdMember:
+      type: object
+      description: >-
+        One member of the household, with the providers they may read. `role`
+        duplicates `householdRole`: it carried Better Auth's global role in the
+        TypeScript server and the SPA reads both, so the Go server puts the
+        household role in each.
+      required: [id, householdRole, email, name, role, createdAt, updatedAt, providerAccess]
+      properties:
+        id:
+          type: string
+        householdRole:
+          type: string
+          enum: [owner, member]
+        email:
+          type: string
+        name:
+          type: string
+        role:
+          type: string
+          enum: [owner, member]
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        providerAccess:
+          type: array
+          items:
+            $ref: "#/components/schemas/MemberProviderAccess"
+    MemberList:
+      type: object
+      required: [members, providers]
+      properties:
+        members:
+          type: array
+          items:
+            $ref: "#/components/schemas/HouseholdMember"
+        providers:
+          type: array
+          items:
+            $ref: "#/components/schemas/Provider"
+    CreateMemberRequest:
+      type: object
+      description: >-
+        REF §A4's `createMember` schema. `role` is a plain string, defaulting
+        to member when absent: the enum would reject `admin`, which REF §A4
+        accepts and maps to owner, and its rejection would not read "role must
+        be owner or member".
+      required: [email, name]
+      properties:
+        email:
+          type: string
+          description: Trimmed, lower-cased, 3..254 characters, must look like an address.
+        name:
+          type: string
+          description: Trimmed, 1..80 characters.
+        role:
+          type: string
+          description: "`owner` or `member` (`admin` is accepted and means owner). Defaults to member."
+    RoleChangeRequest:
+      type: object
+      description: REF §A4's `roleChange` schema. See CreateMemberRequest for why `role` is not an enum here.
+      required: [role]
+      properties:
+        role:
+          type: string
+          description: "`owner` or `member` (`admin` is accepted and means owner)."
+    ProviderAccessRequest:
+      type: object
+      description: REF §A4's `providerAccess` schema.
+      required: [providerKey]
+      properties:
+        providerKey:
+          type: string
+          description: Trimmed, lower-cased, 1..40 characters.
+    InvitationList:
+      type: object
+      required: [invitations]
+      properties:
+        invitations:
+          type: array
+          items:
+            $ref: "#/components/schemas/Invitation"
+    InvitationRequest:
+      type: object
+      description: >-
+        REF §A4's `invitation` schema. See CreateMemberRequest for why `role`
+        is a plain string.
+      required: [email, name]
+      properties:
+        email:
+          type: string
+          description: Trimmed, lower-cased, 3..254 characters, must look like an address.
+        name:
+          type: string
+          description: Trimmed, 1..80 characters.
+        role:
+          type: string
+          description: "`owner` or `member` (`admin` is accepted and means owner). Defaults to member."
+        providerIds:
+          type: array
+          description: The providers the invitee may read the moment they accept. At most 50; every id must belong to this household.
+          items:
+            type: string
+    InvitationResult:
+      type: object
+      description: >-
+        A newly issued invitation, its link, and whether the email carrying
+        that link got out. A failed delivery is NOT an error (REF §A3): the
+        invitation stands and `inviteUrl` can be shared by hand, so
+        `emailSent` is false and `emailError` says what went wrong.
+      required: [invitation, inviteUrl, emailSent]
+      properties:
+        invitation:
+          $ref: "#/components/schemas/Invitation"
+        inviteUrl:
+          type: string
+        emailSent:
+          type: boolean
+        emailError:
+          type: string

--- a/openapi/mi-casa.yaml
+++ b/openapi/mi-casa.yaml
@@ -271,8 +271,268 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /api/households/me:
+    get:
+      operationId: listMyHouseholds
+      summary: >-
+        Every household the caller belongs to, for the household switcher.
+        Ordered by lower-cased display name so the list does not reshuffle
+        when somebody renames a household with a capital letter.
+      tags: [households]
+      responses:
+        "200":
+          description: The caller's households.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HouseholdList"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/households:
+    post:
+      operationId: createHousehold
+      summary: >-
+        Create a household with the caller as its owner. Restricted (REF §A2):
+        the installation owner may always; anybody else only while they belong
+        to no household at all, so a member cannot mint extra households or
+        squat inbound addresses. Rate limited (10 per hour).
+      tags: [households]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateHouseholdRequest"
+      responses:
+        "201":
+          description: >-
+            The household, in the same shape as a /api/households/me entry so
+            the client can use it without a refetch.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HouseholdResult"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller may not create a household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: The slug is taken.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limited. `Retry-After` says when to come back.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/households/{slug}/leave:
+    post:
+      operationId: leaveHousehold
+      summary: >-
+        Give up your own membership of this household. Refused for the last
+        owner, which is what keeps a household from being left with nobody who
+        can administer it.
+      tags: [households]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      responses:
+        "200":
+          description: The membership is gone; provider access cascaded with it.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ok"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not a member of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: The caller is the household's only owner.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/settings:
+    get:
+      operationId: getAccountSettings
+      summary: >-
+        The account settings screen in one request: the caller's profile with
+        their households, and their signed-in devices newest first.
+      tags: [settings]
+      responses:
+        "200":
+          description: The profile and the session list.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AccountSettings"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: The session's account no longer exists.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/settings/households:
+    get:
+      operationId: listSettingsHouseholds
+      summary: >-
+        The caller's households, the same list GET /api/households/me answers
+        with. It exists separately because the settings screen refetches it on
+        its own after leaving a household.
+      tags: [settings]
+      responses:
+        "200":
+          description: The caller's households.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HouseholdList"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/settings/profile:
+    patch:
+      operationId: updateProfile
+      summary: Update the caller's display name and avatar.
+      tags: [settings]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProfileRequest"
+      responses:
+        "200":
+          description: The profile as it now stands.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProfileResult"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: The session's account no longer exists.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/settings/sessions/others:
+    delete:
+      operationId: revokeOtherSessions
+      summary: >-
+        Sign out everywhere else: every session of this account except the one
+        this request arrived on.
+      tags: [settings]
+      responses:
+        "200":
+          description: The other sessions are gone.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ok"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/settings/sessions/{sessionId}:
+    delete:
+      operationId: revokeSession
+      summary: >-
+        Revoke one device. A session id that is not the caller's own revokes
+        nothing and still answers 200 — deliberately, so the endpoint cannot be
+        used to discover whether an id exists.
+      tags: [settings]
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 200
+      responses:
+        "200":
+          description: The session is gone, if it was the caller's.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ok"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 components:
   parameters:
+    HouseholdSlug:
+      name: slug
+      in: path
+      required: true
+      description: >-
+        The household this request acts on. Every `{slug}` route is guarded by
+        the tenancy middleware, which turns it into a membership or refuses —
+        so the parameter is also the authorization boundary, not just a lookup
+        key.
+
+        REF §A3's length bounds (2..40) are deliberately NOT stated here. A
+        slug outside them cannot name a household, so it must be answered the
+        way every other non-membership is — 403, never a validation error that
+        distinguishes "no such household" from "not yours".
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 200
     InvitationToken:
       name: X-Invitation-Token
       in: header
@@ -293,6 +553,183 @@ components:
       schema:
         type: string
   schemas:
+    Ok:
+      type: object
+      description: >-
+        The acknowledgement every "it is done, and there is nothing to show
+        for it" endpoint answers with.
+      required: [ok]
+      properties:
+        ok:
+          type: boolean
+    HouseholdSummary:
+      type: object
+      description: >-
+        One entry in the household switcher: a household plus what the caller
+        may do in it.
+      required: [id, slug, displayName, role]
+      properties:
+        id:
+          type: string
+        slug:
+          type: string
+        displayName:
+          type: string
+        role:
+          type: string
+          enum: [owner, member]
+    HouseholdList:
+      type: object
+      required: [households]
+      properties:
+        households:
+          type: array
+          items:
+            $ref: "#/components/schemas/HouseholdSummary"
+    CreateHouseholdRequest:
+      type: object
+      description: >-
+        REF §A4's `createHousehold` schema. As with SetupRequest, only the
+        shape is stated here: the slug is normalised (trimmed, lower-cased)
+        before REF §A3's rules are applied to it, and the message each failure
+        produces is the wording the SPA renders next to the input.
+      required: [slug, displayName]
+      properties:
+        slug:
+          type: string
+          description: Trimmed, lower-cased, and subject to REF §A3's slug rules.
+        displayName:
+          type: string
+          description: Trimmed, 1..80 characters.
+    HouseholdWithRole:
+      type: object
+      description: >-
+        A newly created household: the switcher entry's keys plus the
+        timestamps, so the client can drop it straight into its cache.
+      required: [id, slug, displayName, createdAt, updatedAt, role]
+      properties:
+        id:
+          type: string
+        slug:
+          type: string
+        displayName:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        role:
+          type: string
+          enum: [owner, member]
+    HouseholdResult:
+      type: object
+      required: [household]
+      properties:
+        household:
+          $ref: "#/components/schemas/HouseholdWithRole"
+    Profile:
+      type: object
+      description: >-
+        The account settings screen's view of the caller. `role` is always
+        null: it carried Better Auth's global role in the TypeScript server,
+        which the Go one has no counterpart for, and stays in the payload
+        because the SPA reads it.
+      required: [id, email, name, image, role, twoFactorEnabled, households]
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+        name:
+          type: string
+        image:
+          type: string
+          nullable: true
+        role:
+          type: string
+          nullable: true
+        twoFactorEnabled:
+          type: boolean
+        households:
+          type: array
+          items:
+            $ref: "#/components/schemas/HouseholdSummary"
+    SessionSummary:
+      type: object
+      description: >-
+        One signed-in device. The session TOKEN is a bearer secret and never
+        appears here — `isCurrent` is all the client needs to tell which row
+        it is looking through. `ipAddress` is the digest Limen stored, not a
+        readable address, and `impersonatedBy` is always null (the Go server
+        has no impersonation).
+      required:
+        [
+          id,
+          isCurrent,
+          expiresAt,
+          ipAddress,
+          userAgent,
+          createdAt,
+          updatedAt,
+          impersonatedBy,
+        ]
+      properties:
+        id:
+          type: string
+        isCurrent:
+          type: boolean
+        expiresAt:
+          type: string
+          format: date-time
+        ipAddress:
+          type: string
+          nullable: true
+        userAgent:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true
+        impersonatedBy:
+          type: string
+          nullable: true
+    AccountSettings:
+      type: object
+      required: [profile, sessions]
+      properties:
+        profile:
+          $ref: "#/components/schemas/Profile"
+        sessions:
+          type: array
+          items:
+            $ref: "#/components/schemas/SessionSummary"
+    ProfileResult:
+      type: object
+      required: [profile]
+      properties:
+        profile:
+          $ref: "#/components/schemas/Profile"
+    ProfileRequest:
+      type: object
+      description: >-
+        REF §A4's `profile` schema. `image` is optional and an empty string
+        clears the avatar; anything else must be an http(s) URL of at most
+        2048 characters, checked in Go so the message is the TypeScript's
+        ("image must be an http(s) URL").
+      required: [name]
+      properties:
+        name:
+          type: string
+          description: Trimmed, 1..80 characters.
+        image:
+          type: string
+          description: An http(s) URL, or "" to clear the avatar.
     Error:
       type: object
       description: >-


### PR DESCRIPTION
Phase P4 of the Go backend migration. Closes #214.

- `/api/households/me|create|{slug}/leave` with the installation-owner/first-household rule and the sole-owner guard
- `/api/settings` profile, households and sessions; revoking a session really invalidates its cookie (tested end to end)
- `/api/admin/{slug}/*`: providers and sender rules, members (remove, role, provider access), invitations (create, resend, cancel; delivery failure reported as `emailSent:false`, never thrown), household settings, audit log — all twenty operations owner-only and household-scoped, each driven by tests
- `internal/invite` service; global unique-violation → 409 mapping and the unhandled-error handler wired into the strict server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yS5kEFd3AcfSkVidBs4Fj