### PR TITLE
feat(server): inbox and quarantine routes (P5)

### DIFF
--- a/apps/server/internal/api/admin_invitations.go
+++ b/apps/server/internal/api/admin_invitations.go
@@ -30,7 +30,7 @@ import (
 // pending invitation whose link has already stopped working — the expiry is a
 // timestamp, and nothing else would notice it had passed.
 func (s server) ListInvitations(ctx context.Context, _ gen.ListInvitationsRequestObject) (gen.ListInvitationsResponseObject, error) {
-	_, household, ok := s.adminContext(ctx)
+	_, household, ok := s.householdContext(ctx)
 	if !ok {
 		return gen.ListInvitations403JSONResponse(errorBody("Forbidden")), nil
 	}
@@ -52,7 +52,7 @@ func (s server) ListInvitations(ctx context.Context, _ gen.ListInvitationsReques
 
 // CreateInvitation invites somebody, optionally scoped to a set of providers.
 func (s server) CreateInvitation(ctx context.Context, request gen.CreateInvitationRequestObject) (gen.CreateInvitationResponseObject, error) {
-	viewer, household, ok := s.adminContext(ctx)
+	viewer, household, ok := s.householdContext(ctx)
 	if !ok {
 		return gen.CreateInvitation403JSONResponse(errorBody("Forbidden")), nil
 	}
@@ -90,7 +90,7 @@ func (s server) CreateInvitation(ctx context.Context, request gen.CreateInvitati
 // scope — the same handler body as CreateInvitation minus the scope, and the
 // same `invitation.created` audit entry, exactly as the TypeScript had it.
 func (s server) CreateMember(ctx context.Context, request gen.CreateMemberRequestObject) (gen.CreateMemberResponseObject, error) {
-	viewer, household, ok := s.adminContext(ctx)
+	viewer, household, ok := s.householdContext(ctx)
 	if !ok {
 		return gen.CreateMember403JSONResponse(errorBody("Forbidden")), nil
 	}
@@ -113,7 +113,7 @@ func (s server) CreateMember(ctx context.Context, request gen.CreateMemberReques
 
 // ResendInvitation reissues a pending invitation with a new token.
 func (s server) ResendInvitation(ctx context.Context, request gen.ResendInvitationRequestObject) (gen.ResendInvitationResponseObject, error) {
-	viewer, household, ok := s.adminContext(ctx)
+	viewer, household, ok := s.householdContext(ctx)
 	if !ok {
 		return gen.ResendInvitation403JSONResponse(errorBody("Forbidden")), nil
 	}
@@ -146,7 +146,7 @@ func (s server) ResendInvitation(ctx context.Context, request gen.ResendInvitati
 
 // CancelInvitation makes an invitation's link stop working.
 func (s server) CancelInvitation(ctx context.Context, request gen.CancelInvitationRequestObject) (gen.CancelInvitationResponseObject, error) {
-	viewer, household, ok := s.adminContext(ctx)
+	viewer, household, ok := s.householdContext(ctx)
 	if !ok {
 		return gen.CancelInvitation403JSONResponse(errorBody("Forbidden")), nil
 	}

--- a/apps/server/internal/api/admin_members.go
+++ b/apps/server/internal/api/admin_members.go
@@ -28,7 +28,7 @@ import (
 // providers each may read, and the household's providers so the screen can
 // offer the rest.
 func (s server) ListMembers(ctx context.Context, _ gen.ListMembersRequestObject) (gen.ListMembersResponseObject, error) {
-	_, household, ok := s.adminContext(ctx)
+	_, household, ok := s.householdContext(ctx)
 	if !ok {
 		return gen.ListMembers403JSONResponse(errorBody("Forbidden")), nil
 	}
@@ -89,7 +89,7 @@ func (s server) ListMembers(ctx context.Context, _ gen.ListMembersRequestObject)
 
 // RemoveMember takes somebody else out of the household.
 func (s server) RemoveMember(ctx context.Context, request gen.RemoveMemberRequestObject) (gen.RemoveMemberResponseObject, error) {
-	viewer, household, ok := s.adminContext(ctx)
+	viewer, household, ok := s.householdContext(ctx)
 	if !ok {
 		return gen.RemoveMember403JSONResponse(errorBody("Forbidden")), nil
 	}
@@ -138,7 +138,7 @@ func (s server) RemoveMember(ctx context.Context, request gen.RemoveMemberReques
 // owner asking to change their own role gets the same answer whether or not
 // they also sent a valid role, because the refusal is about who, not what.
 func (s server) UpdateMemberRole(ctx context.Context, request gen.UpdateMemberRoleRequestObject) (gen.UpdateMemberRoleResponseObject, error) {
-	viewer, household, ok := s.adminContext(ctx)
+	viewer, household, ok := s.householdContext(ctx)
 	if !ok {
 		return gen.UpdateMemberRole403JSONResponse(errorBody("Forbidden")), nil
 	}
@@ -176,7 +176,7 @@ func (s server) UpdateMemberRole(ctx context.Context, request gen.UpdateMemberRo
 // point of the product: a housemate who needs the streaming codes does not
 // thereby get to read the bank's.
 func (s server) GrantProviderAccess(ctx context.Context, request gen.GrantProviderAccessRequestObject) (gen.GrantProviderAccessResponseObject, error) {
-	viewer, household, ok := s.adminContext(ctx)
+	viewer, household, ok := s.householdContext(ctx)
 	if !ok {
 		return gen.GrantProviderAccess403JSONResponse(errorBody("Forbidden")), nil
 	}
@@ -214,7 +214,7 @@ func (s server) GrantProviderAccess(ctx context.Context, request gen.GrantProvid
 // and one that intermediaries are entitled to discard — so the Go route drops
 // that half and lets the spec validate the parameter instead.
 func (s server) RevokeProviderAccess(ctx context.Context, request gen.RevokeProviderAccessRequestObject) (gen.RevokeProviderAccessResponseObject, error) {
-	viewer, household, ok := s.adminContext(ctx)
+	viewer, household, ok := s.householdContext(ctx)
 	if !ok {
 		return gen.RevokeProviderAccess403JSONResponse(errorBody("Forbidden")), nil
 	}

--- a/apps/server/internal/api/admin_providers.go
+++ b/apps/server/internal/api/admin_providers.go
@@ -46,7 +46,7 @@ var leadingAts = regexp.MustCompile(`^@+`)
 // ListProviderConfigurations answers the provider settings screen: every
 // provider with its rule count, and every rule.
 func (s server) ListProviderConfigurations(ctx context.Context, _ gen.ListProviderConfigurationsRequestObject) (gen.ListProviderConfigurationsResponseObject, error) {
-	_, household, ok := s.adminContext(ctx)
+	_, household, ok := s.householdContext(ctx)
 	if !ok {
 		return gen.ListProviderConfigurations403JSONResponse(errorBody("Forbidden")), nil
 	}
@@ -68,7 +68,7 @@ func (s server) ListProviderConfigurations(ctx context.Context, _ gen.ListProvid
 
 // CreateProvider adds a provider.
 func (s server) CreateProvider(ctx context.Context, request gen.CreateProviderRequestObject) (gen.CreateProviderResponseObject, error) {
-	viewer, household, ok := s.adminContext(ctx)
+	viewer, household, ok := s.householdContext(ctx)
 	if !ok {
 		return gen.CreateProvider403JSONResponse(errorBody("Forbidden")), nil
 	}
@@ -102,7 +102,7 @@ func (s server) CreateProvider(ctx context.Context, request gen.CreateProviderRe
 
 // UpdateProvider renames a provider or changes its key.
 func (s server) UpdateProvider(ctx context.Context, request gen.UpdateProviderRequestObject) (gen.UpdateProviderResponseObject, error) {
-	viewer, household, ok := s.adminContext(ctx)
+	viewer, household, ok := s.householdContext(ctx)
 	if !ok {
 		return gen.UpdateProvider403JSONResponse(errorBody("Forbidden")), nil
 	}
@@ -151,7 +151,7 @@ func (s server) UpdateProvider(ctx context.Context, request gen.UpdateProviderRe
 // carry verification codes, and leaving them readable after the mailbox they
 // belonged to was deleted would be the opposite of what the owner asked for.
 func (s server) DeleteProvider(ctx context.Context, request gen.DeleteProviderRequestObject) (gen.DeleteProviderResponseObject, error) {
-	viewer, household, ok := s.adminContext(ctx)
+	viewer, household, ok := s.householdContext(ctx)
 	if !ok {
 		return gen.DeleteProvider403JSONResponse(errorBody("Forbidden")), nil
 	}
@@ -174,7 +174,7 @@ func (s server) DeleteProvider(ctx context.Context, request gen.DeleteProviderRe
 
 // CreateSenderRule points an address or a domain at a provider.
 func (s server) CreateSenderRule(ctx context.Context, request gen.CreateSenderRuleRequestObject) (gen.CreateSenderRuleResponseObject, error) {
-	viewer, household, ok := s.adminContext(ctx)
+	viewer, household, ok := s.householdContext(ctx)
 	if !ok {
 		return gen.CreateSenderRule403JSONResponse(errorBody("Forbidden")), nil
 	}
@@ -214,7 +214,7 @@ func (s server) CreateSenderRule(ctx context.Context, request gen.CreateSenderRu
 
 // UpdateSenderRule repoints a rule or changes what it matches.
 func (s server) UpdateSenderRule(ctx context.Context, request gen.UpdateSenderRuleRequestObject) (gen.UpdateSenderRuleResponseObject, error) {
-	viewer, household, ok := s.adminContext(ctx)
+	viewer, household, ok := s.householdContext(ctx)
 	if !ok {
 		return gen.UpdateSenderRule403JSONResponse(errorBody("Forbidden")), nil
 	}
@@ -261,7 +261,7 @@ func (s server) UpdateSenderRule(ctx context.Context, request gen.UpdateSenderRu
 // DeleteSenderRule removes a rule. Messages already filed under its provider
 // stay: the rule decided where new mail goes, not who owns what arrived.
 func (s server) DeleteSenderRule(ctx context.Context, request gen.DeleteSenderRuleRequestObject) (gen.DeleteSenderRuleResponseObject, error) {
-	viewer, household, ok := s.adminContext(ctx)
+	viewer, household, ok := s.householdContext(ctx)
 	if !ok {
 		return gen.DeleteSenderRule403JSONResponse(errorBody("Forbidden")), nil
 	}

--- a/apps/server/internal/api/admin_settings.go
+++ b/apps/server/internal/api/admin_settings.go
@@ -28,7 +28,7 @@ const auditLimit = 100
 
 // ListAuditEvents answers the audit screen.
 func (s server) ListAuditEvents(ctx context.Context, _ gen.ListAuditEventsRequestObject) (gen.ListAuditEventsResponseObject, error) {
-	_, household, ok := s.adminContext(ctx)
+	_, household, ok := s.householdContext(ctx)
 	if !ok {
 		return gen.ListAuditEvents403JSONResponse(errorBody("Forbidden")), nil
 	}
@@ -56,7 +56,7 @@ func (s server) ListAuditEvents(ctx context.Context, _ gen.ListAuditEventsReques
 
 // GetHouseholdSettings answers the household settings screen.
 func (s server) GetHouseholdSettings(ctx context.Context, _ gen.GetHouseholdSettingsRequestObject) (gen.GetHouseholdSettingsResponseObject, error) {
-	_, household, ok := s.adminContext(ctx)
+	_, household, ok := s.householdContext(ctx)
 	if !ok {
 		return gen.GetHouseholdSettings403JSONResponse(errorBody("Forbidden")), nil
 	}
@@ -80,7 +80,7 @@ func (s server) GetHouseholdSettings(ctx context.Context, _ gen.GetHouseholdSett
 // sender rule a provider has already been pointed at — and would free the old
 // address for somebody else to claim.
 func (s server) UpdateHouseholdSettings(ctx context.Context, request gen.UpdateHouseholdSettingsRequestObject) (gen.UpdateHouseholdSettingsResponseObject, error) {
-	viewer, household, ok := s.adminContext(ctx)
+	viewer, household, ok := s.householdContext(ctx)
 	if !ok {
 		return gen.UpdateHouseholdSettings403JSONResponse(errorBody("Forbidden")), nil
 	}
@@ -140,22 +140,6 @@ func auditDetails(raw json.RawMessage) *map[string]any {
 		return nil
 	}
 	return &details
-}
-
-// adminContext is the pair every admin handler opens with: the caller and the
-// household the tenancy guard resolved.
-//
-// ok is false only if an admin route were ever mounted without tierOwner, in
-// which case refusing is the failure that leaks nothing. Each handler answers
-// its own 403 rather than sharing one, because the generated response types
-// are per-operation.
-func (s server) adminContext(ctx context.Context) (*auth.Session, *middleware.Household, bool) {
-	viewer := viewerFrom(ctx)
-	household := householdFrom(ctx)
-	if viewer == nil || household == nil {
-		return nil, nil, false
-	}
-	return viewer, household, true
 }
 
 // audit records one owner action against the current household — the Go

--- a/apps/server/internal/api/gen/server.gen.go
+++ b/apps/server/internal/api/gen/server.gen.go
@@ -89,6 +89,26 @@ type ServerInterface interface {
 	// LeaveHousehold Give up your own membership of this household. Refused for the last owner, which is what keeps a household from being left with nobody who can administer it.
 	// (POST /api/households/{slug}/leave)
 	LeaveHousehold(w http.ResponseWriter, r *http.Request, slug HouseholdSlug)
+	// UpdateMessageStatus Mark one message new, used or expired — the "I have used this code" button.
+	// The message is looked up before the body is validated, deliberately: a status the server does not know, sent for a message that is not this household's, is answered 404 rather than 400, so the route never confirms the existence of a message the caller may not read.
+	// (PATCH /api/inbox/{slug}/messages/{messageId}/status)
+	UpdateMessageStatus(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, messageId MessageId)
+	// ListInboxProviders The inbox landing page: one tile per provider the caller may read, with its message counts and a preview of the newest message.
+	// A member route rather than an owner one, with the per-provider check INSIDE it: an owner sees every provider in the household, a member only the ones they have been granted. That is the whole point of provider access — the household's mail is split per mailbox, not per role.
+	// (GET /api/inbox/{slug}/providers)
+	ListInboxProviders(w http.ResponseWriter, r *http.Request, slug HouseholdSlug)
+	// ListProviderMessages One provider's inbox, newest first, one keyset page at a time.
+	// The 403 for a member without access to this provider is answered BEFORE the provider is looked up, so a member cannot use the difference between 403 and 404 to enumerate which providers the household has.
+	// (GET /api/inbox/{slug}/providers/{providerKey})
+	ListProviderMessages(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, providerKey string, params ListProviderMessagesParams)
+	// ListQuarantine The needs-review queue: mail that could not be attributed to a provider, unreviewed rows only, newest first.
+	// Owner-only. Quarantined mail is by definition mail nobody has decided who may read yet, so it cannot be shown behind per-provider access.
+	// (GET /api/inbox/{slug}/quarantine)
+	ListQuarantine(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, params ListQuarantineParams)
+	// ReviewQuarantineMessage Work through one needs-review row: dismiss it, or release it into a provider's inbox.
+	// A release copies the row into that provider's messages — keeping the original received_at and delete_after, so releasing does not extend retention — and marks the quarantine row reviewed, in one transaction. Owner-only, and audited either way.
+	// (POST /api/inbox/{slug}/quarantine/{messageId}/review)
+	ReviewQuarantineMessage(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, messageId MessageId)
 	// AcceptInvitation Accept an invitation, as the signed-in user or by creating the invited account. Rate limited with the lookup above.
 	// (POST /api/invitations/accept)
 	AcceptInvitation(w http.ResponseWriter, r *http.Request, params AcceptInvitationParams)
@@ -806,6 +826,221 @@ func (siw *ServerInterfaceWrapper) LeaveHousehold(w http.ResponseWriter, r *http
 	handler.ServeHTTP(w, r)
 }
 
+// UpdateMessageStatus operation middleware
+func (siw *ServerInterfaceWrapper) UpdateMessageStatus(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "messageId" -------------
+	var messageId MessageId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "messageId", r.PathValue("messageId"), &messageId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "messageId", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateMessageStatus(w, r, slug, messageId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListInboxProviders operation middleware
+func (siw *ServerInterfaceWrapper) ListInboxProviders(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListInboxProviders(w, r, slug)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListProviderMessages operation middleware
+func (siw *ServerInterfaceWrapper) ListProviderMessages(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "providerKey" -------------
+	var providerKey string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "providerKey", r.PathValue("providerKey"), &providerKey, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "providerKey", Err: err})
+		return
+	}
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListProviderMessagesParams
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "before" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "before", r.URL.Query(), &params.Before, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "before"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "before", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListProviderMessages(w, r, slug, providerKey, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListQuarantine operation middleware
+func (siw *ServerInterfaceWrapper) ListQuarantine(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListQuarantineParams
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "before" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "before", r.URL.Query(), &params.Before, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "before"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "before", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListQuarantine(w, r, slug, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ReviewQuarantineMessage operation middleware
+func (siw *ServerInterfaceWrapper) ReviewQuarantineMessage(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "slug" -------------
+	var slug HouseholdSlug
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", r.PathValue("slug"), &slug, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "slug", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "messageId" -------------
+	var messageId MessageId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "messageId", r.PathValue("messageId"), &messageId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "messageId", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ReviewQuarantineMessage(w, r, slug, messageId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // AcceptInvitation operation middleware
 func (siw *ServerInterfaceWrapper) AcceptInvitation(w http.ResponseWriter, r *http.Request) {
 
@@ -1155,6 +1390,11 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/households/me", wrapper.ListMyHouseholds)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/households", wrapper.CreateHousehold)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/households/{slug}/leave", wrapper.LeaveHousehold)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/inbox/{slug}/providers", wrapper.ListInboxProviders)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/inbox/{slug}/providers/{providerKey}", wrapper.ListProviderMessages)
+	m.HandleFunc(http.MethodPatch+" "+options.BaseURL+"/api/inbox/{slug}/messages/{messageId}/status", wrapper.UpdateMessageStatus)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/inbox/{slug}/quarantine", wrapper.ListQuarantine)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/inbox/{slug}/quarantine/{messageId}/review", wrapper.ReviewQuarantineMessage)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/settings", wrapper.GetAccountSettings)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/settings/households", wrapper.ListSettingsHouseholds)
 	m.HandleFunc(http.MethodPatch+" "+options.BaseURL+"/api/settings/profile", wrapper.UpdateProfile)
@@ -2801,6 +3041,361 @@ func (response LeaveHousehold409JSONResponse) VisitLeaveHouseholdResponse(w http
 	return err
 }
 
+type UpdateMessageStatusRequestObject struct {
+	Slug      HouseholdSlug `json:"slug"`
+	MessageId MessageId     `json:"messageId"`
+	Body      *UpdateMessageStatusJSONRequestBody
+}
+
+type UpdateMessageStatusResponseObject interface {
+	VisitUpdateMessageStatusResponse(w http.ResponseWriter) error
+}
+
+type UpdateMessageStatus200JSONResponse InboxMessageResult
+
+func (response UpdateMessageStatus200JSONResponse) VisitUpdateMessageStatusResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateMessageStatus400JSONResponse Error
+
+func (response UpdateMessageStatus400JSONResponse) VisitUpdateMessageStatusResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateMessageStatus401JSONResponse Error
+
+func (response UpdateMessageStatus401JSONResponse) VisitUpdateMessageStatusResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateMessageStatus403JSONResponse Error
+
+func (response UpdateMessageStatus403JSONResponse) VisitUpdateMessageStatusResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateMessageStatus404JSONResponse Error
+
+func (response UpdateMessageStatus404JSONResponse) VisitUpdateMessageStatusResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListInboxProvidersRequestObject struct {
+	Slug HouseholdSlug `json:"slug"`
+}
+
+type ListInboxProvidersResponseObject interface {
+	VisitListInboxProvidersResponse(w http.ResponseWriter) error
+}
+
+type ListInboxProviders200JSONResponse ProviderSummaryList
+
+func (response ListInboxProviders200JSONResponse) VisitListInboxProvidersResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListInboxProviders401JSONResponse Error
+
+func (response ListInboxProviders401JSONResponse) VisitListInboxProvidersResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListInboxProviders403JSONResponse Error
+
+func (response ListInboxProviders403JSONResponse) VisitListInboxProvidersResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListProviderMessagesRequestObject struct {
+	Slug        HouseholdSlug `json:"slug"`
+	ProviderKey string        `json:"providerKey"`
+	Params      ListProviderMessagesParams
+}
+
+type ListProviderMessagesResponseObject interface {
+	VisitListProviderMessagesResponse(w http.ResponseWriter) error
+}
+
+type ListProviderMessages200JSONResponse InboxMessagePage
+
+func (response ListProviderMessages200JSONResponse) VisitListProviderMessagesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListProviderMessages400JSONResponse Error
+
+func (response ListProviderMessages400JSONResponse) VisitListProviderMessagesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListProviderMessages401JSONResponse Error
+
+func (response ListProviderMessages401JSONResponse) VisitListProviderMessagesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListProviderMessages403JSONResponse Error
+
+func (response ListProviderMessages403JSONResponse) VisitListProviderMessagesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListProviderMessages404JSONResponse Error
+
+func (response ListProviderMessages404JSONResponse) VisitListProviderMessagesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListQuarantineRequestObject struct {
+	Slug   HouseholdSlug `json:"slug"`
+	Params ListQuarantineParams
+}
+
+type ListQuarantineResponseObject interface {
+	VisitListQuarantineResponse(w http.ResponseWriter) error
+}
+
+type ListQuarantine200JSONResponse QuarantineMessagePage
+
+func (response ListQuarantine200JSONResponse) VisitListQuarantineResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListQuarantine400JSONResponse Error
+
+func (response ListQuarantine400JSONResponse) VisitListQuarantineResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListQuarantine401JSONResponse Error
+
+func (response ListQuarantine401JSONResponse) VisitListQuarantineResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListQuarantine403JSONResponse Error
+
+func (response ListQuarantine403JSONResponse) VisitListQuarantineResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ReviewQuarantineMessageRequestObject struct {
+	Slug      HouseholdSlug `json:"slug"`
+	MessageId MessageId     `json:"messageId"`
+	Body      *ReviewQuarantineMessageJSONRequestBody
+}
+
+type ReviewQuarantineMessageResponseObject interface {
+	VisitReviewQuarantineMessageResponse(w http.ResponseWriter) error
+}
+
+type ReviewQuarantineMessage200JSONResponse QuarantineReviewResult
+
+func (response ReviewQuarantineMessage200JSONResponse) VisitReviewQuarantineMessageResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ReviewQuarantineMessage400JSONResponse Error
+
+func (response ReviewQuarantineMessage400JSONResponse) VisitReviewQuarantineMessageResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ReviewQuarantineMessage401JSONResponse Error
+
+func (response ReviewQuarantineMessage401JSONResponse) VisitReviewQuarantineMessageResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ReviewQuarantineMessage403JSONResponse Error
+
+func (response ReviewQuarantineMessage403JSONResponse) VisitReviewQuarantineMessageResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ReviewQuarantineMessage404JSONResponse Error
+
+func (response ReviewQuarantineMessage404JSONResponse) VisitReviewQuarantineMessageResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
 type AcceptInvitationRequestObject struct {
 	Params AcceptInvitationParams
 	Body   *AcceptInvitationJSONRequestBody
@@ -3489,6 +4084,26 @@ type StrictServerInterface interface {
 	// LeaveHousehold Give up your own membership of this household. Refused for the last owner, which is what keeps a household from being left with nobody who can administer it.
 	// (POST /api/households/{slug}/leave)
 	LeaveHousehold(ctx context.Context, request LeaveHouseholdRequestObject) (LeaveHouseholdResponseObject, error)
+	// UpdateMessageStatus Mark one message new, used or expired — the "I have used this code" button.
+	// The message is looked up before the body is validated, deliberately: a status the server does not know, sent for a message that is not this household's, is answered 404 rather than 400, so the route never confirms the existence of a message the caller may not read.
+	// (PATCH /api/inbox/{slug}/messages/{messageId}/status)
+	UpdateMessageStatus(ctx context.Context, request UpdateMessageStatusRequestObject) (UpdateMessageStatusResponseObject, error)
+	// ListInboxProviders The inbox landing page: one tile per provider the caller may read, with its message counts and a preview of the newest message.
+	// A member route rather than an owner one, with the per-provider check INSIDE it: an owner sees every provider in the household, a member only the ones they have been granted. That is the whole point of provider access — the household's mail is split per mailbox, not per role.
+	// (GET /api/inbox/{slug}/providers)
+	ListInboxProviders(ctx context.Context, request ListInboxProvidersRequestObject) (ListInboxProvidersResponseObject, error)
+	// ListProviderMessages One provider's inbox, newest first, one keyset page at a time.
+	// The 403 for a member without access to this provider is answered BEFORE the provider is looked up, so a member cannot use the difference between 403 and 404 to enumerate which providers the household has.
+	// (GET /api/inbox/{slug}/providers/{providerKey})
+	ListProviderMessages(ctx context.Context, request ListProviderMessagesRequestObject) (ListProviderMessagesResponseObject, error)
+	// ListQuarantine The needs-review queue: mail that could not be attributed to a provider, unreviewed rows only, newest first.
+	// Owner-only. Quarantined mail is by definition mail nobody has decided who may read yet, so it cannot be shown behind per-provider access.
+	// (GET /api/inbox/{slug}/quarantine)
+	ListQuarantine(ctx context.Context, request ListQuarantineRequestObject) (ListQuarantineResponseObject, error)
+	// ReviewQuarantineMessage Work through one needs-review row: dismiss it, or release it into a provider's inbox.
+	// A release copies the row into that provider's messages — keeping the original received_at and delete_after, so releasing does not extend retention — and marks the quarantine row reviewed, in one transaction. Owner-only, and audited either way.
+	// (POST /api/inbox/{slug}/quarantine/{messageId}/review)
+	ReviewQuarantineMessage(ctx context.Context, request ReviewQuarantineMessageRequestObject) (ReviewQuarantineMessageResponseObject, error)
 	// AcceptInvitation Accept an invitation, as the signed-in user or by creating the invited account. Rate limited with the lookup above.
 	// (POST /api/invitations/accept)
 	AcceptInvitation(ctx context.Context, request AcceptInvitationRequestObject) (AcceptInvitationResponseObject, error)
@@ -4231,6 +4846,155 @@ func (sh *strictHandler) LeaveHousehold(w http.ResponseWriter, r *http.Request, 
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(LeaveHouseholdResponseObject); ok {
 		if err := validResponse.VisitLeaveHouseholdResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// UpdateMessageStatus operation middleware
+func (sh *strictHandler) UpdateMessageStatus(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, messageId MessageId) {
+	var request UpdateMessageStatusRequestObject
+
+	request.Slug = slug
+	request.MessageId = messageId
+
+	var body UpdateMessageStatusJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.UpdateMessageStatus(ctx, request.(UpdateMessageStatusRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "UpdateMessageStatus")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(UpdateMessageStatusResponseObject); ok {
+		if err := validResponse.VisitUpdateMessageStatusResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// ListInboxProviders operation middleware
+func (sh *strictHandler) ListInboxProviders(w http.ResponseWriter, r *http.Request, slug HouseholdSlug) {
+	var request ListInboxProvidersRequestObject
+
+	request.Slug = slug
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListInboxProviders(ctx, request.(ListInboxProvidersRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListInboxProviders")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListInboxProvidersResponseObject); ok {
+		if err := validResponse.VisitListInboxProvidersResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// ListProviderMessages operation middleware
+func (sh *strictHandler) ListProviderMessages(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, providerKey string, params ListProviderMessagesParams) {
+	var request ListProviderMessagesRequestObject
+
+	request.Slug = slug
+	request.ProviderKey = providerKey
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListProviderMessages(ctx, request.(ListProviderMessagesRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListProviderMessages")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListProviderMessagesResponseObject); ok {
+		if err := validResponse.VisitListProviderMessagesResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// ListQuarantine operation middleware
+func (sh *strictHandler) ListQuarantine(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, params ListQuarantineParams) {
+	var request ListQuarantineRequestObject
+
+	request.Slug = slug
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListQuarantine(ctx, request.(ListQuarantineRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListQuarantine")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListQuarantineResponseObject); ok {
+		if err := validResponse.VisitListQuarantineResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// ReviewQuarantineMessage operation middleware
+func (sh *strictHandler) ReviewQuarantineMessage(w http.ResponseWriter, r *http.Request, slug HouseholdSlug, messageId MessageId) {
+	var request ReviewQuarantineMessageRequestObject
+
+	request.Slug = slug
+	request.MessageId = messageId
+
+	var body ReviewQuarantineMessageJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ReviewQuarantineMessage(ctx, request.(ReviewQuarantineMessageRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ReviewQuarantineMessage")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ReviewQuarantineMessageResponseObject); ok {
+		if err := validResponse.VisitReviewQuarantineMessageResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {

--- a/apps/server/internal/api/gen/types.gen.go
+++ b/apps/server/internal/api/gen/types.gen.go
@@ -79,6 +79,27 @@ func (e HouseholdWithRoleRole) Valid() bool {
 	}
 }
 
+// Defines values for InboxMessageStatus.
+const (
+	InboxMessageStatusExpired InboxMessageStatus = "expired"
+	InboxMessageStatusNew     InboxMessageStatus = "new"
+	InboxMessageStatusUsed    InboxMessageStatus = "used"
+)
+
+// Valid indicates whether the value is a known member of the InboxMessageStatus enum.
+func (e InboxMessageStatus) Valid() bool {
+	switch e {
+	case InboxMessageStatusExpired:
+		return true
+	case InboxMessageStatusNew:
+		return true
+	case InboxMessageStatusUsed:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for InvitationRole.
 const (
 	InvitationRoleMember InvitationRole = "member"
@@ -365,6 +386,47 @@ type HouseholdWithRole struct {
 // HouseholdWithRoleRole defines model for HouseholdWithRole.Role.
 type HouseholdWithRoleRole string
 
+// InboxMessage One message in a provider's inbox. snake_case keys, as above.
+type InboxMessage struct {
+	ExtractedCode       *string            `json:"extracted_code"`
+	FromHeader          *string            `json:"from_header"`
+	HouseholdSlug       string             `json:"household_slug"`
+	Id                  string             `json:"id"`
+	ProviderDisplayName string             `json:"provider_display_name"`
+	ProviderKey         string             `json:"provider_key"`
+	ReceivedAt          time.Time          `json:"received_at"`
+	Status              InboxMessageStatus `json:"status"`
+	Subject             *string            `json:"subject"`
+	TextBody            string             `json:"text_body"`
+}
+
+// InboxMessageStatus defines model for InboxMessage.Status.
+type InboxMessageStatus string
+
+// InboxMessagePage defines model for InboxMessagePage.
+type InboxMessagePage struct {
+	Messages []InboxMessage `json:"messages"`
+
+	// Page The keyset page the server actually served: the limit it applied (after clamping) and the cursor for the next, older page.
+	// `nextBefore` is null when this was the last page, which is what the SPA checks to decide whether to offer "load more".
+	Page PageInfo `json:"page"`
+
+	// Provider Which provider a page of messages belongs to. camelCase here while the rows below are snake_case, because that is the shape the SPA has read since the Workers deployment.
+	Provider InboxProvider `json:"provider"`
+}
+
+// InboxMessageResult defines model for InboxMessageResult.
+type InboxMessageResult struct {
+	// Message One message in a provider's inbox. snake_case keys, as above.
+	Message InboxMessage `json:"message"`
+}
+
+// InboxProvider Which provider a page of messages belongs to. camelCase here while the rows below are snake_case, because that is the shape the SPA has read since the Workers deployment.
+type InboxProvider struct {
+	DisplayName string `json:"displayName"`
+	ProviderKey string `json:"providerKey"`
+}
+
 // Invitation One invitation record. The token itself never appears — only its SHA-256 is stored, and the plaintext lives solely in the link.
 type Invitation struct {
 	AcceptedAt       *time.Time           `json:"acceptedAt"`
@@ -478,9 +540,22 @@ type MembershipResult struct {
 	Member Member `json:"member"`
 }
 
+// MessageStatusRequest REF §A4's `messageStatus` schema. `status` is a plain string rather than an enum for the same reason `matchType` is (see SenderRuleRequest): the rejection must read "status must be new, used or expired", and an enum violation cannot say that.
+type MessageStatusRequest struct {
+	// Status `new`, `used` or `expired`.
+	Status string `json:"status"`
+}
+
 // Ok The acknowledgement every "it is done, and there is nothing to show for it" endpoint answers with.
 type Ok struct {
 	Ok bool `json:"ok"`
+}
+
+// PageInfo The keyset page the server actually served: the limit it applied (after clamping) and the cursor for the next, older page.
+// `nextBefore` is null when this was the last page, which is what the SPA checks to decide whether to offer "load more".
+type PageInfo struct {
+	Limit      int        `json:"limit"`
+	NextBefore *time.Time `json:"nextBefore"`
 }
 
 // Profile The account settings screen's view of the caller. `role` is always null: it carried Better Auth's global role in the TypeScript server, which the Go one has no counterpart for, and stays in the payload because the SPA reads it.
@@ -553,6 +628,66 @@ type ProviderRequest struct {
 type ProviderResult struct {
 	// Provider One provider. snake_case keys, deliberately: it is what the TypeScript returned and what the SPA reads.
 	Provider Provider `json:"provider"`
+}
+
+// ProviderSummary One provider's tile on the inbox landing page: its counts plus a preview of the newest message. snake_case keys, deliberately: it is what the TypeScript returned and what the SPA reads.
+// The `latest_*` fields are null — present and null, never missing — for a provider that has received nothing yet.
+type ProviderSummary struct {
+	DisplayName      string     `json:"display_name"`
+	HouseholdSlug    string     `json:"household_slug"`
+	LatestCode       *string    `json:"latest_code"`
+	LatestMessageId  *string    `json:"latest_message_id"`
+	LatestReceivedAt *time.Time `json:"latest_received_at"`
+	LatestStatus     *string    `json:"latest_status"`
+	LatestSubject    *string    `json:"latest_subject"`
+	MessageCount     int        `json:"message_count"`
+	NewCount         int        `json:"new_count"`
+	ProviderKey      string     `json:"provider_key"`
+}
+
+// ProviderSummaryList defines model for ProviderSummaryList.
+type ProviderSummaryList struct {
+	Providers []ProviderSummary `json:"providers"`
+}
+
+// QuarantineMessage One row of the needs-review queue. `provider_key` and `provider_display_name` are the literals "quarantine" and "Quarantine" so the SPA can render it with the same component as an inbox row, and `envelope_from` is included because who the mail server said sent it is the main thing an owner reviews.
+type QuarantineMessage struct {
+	EnvelopeFrom        string    `json:"envelope_from"`
+	ExtractedCode       *string   `json:"extracted_code"`
+	FromHeader          *string   `json:"from_header"`
+	HouseholdSlug       string    `json:"household_slug"`
+	Id                  string    `json:"id"`
+	ProviderDisplayName string    `json:"provider_display_name"`
+	ProviderKey         string    `json:"provider_key"`
+	QuarantineReason    string    `json:"quarantine_reason"`
+	ReceivedAt          time.Time `json:"received_at"`
+	Status              string    `json:"status"`
+	Subject             *string   `json:"subject"`
+	TextBody            string    `json:"text_body"`
+}
+
+// QuarantineMessagePage defines model for QuarantineMessagePage.
+type QuarantineMessagePage struct {
+	Messages []QuarantineMessage `json:"messages"`
+
+	// Page The keyset page the server actually served: the limit it applied (after clamping) and the cursor for the next, older page.
+	// `nextBefore` is null when this was the last page, which is what the SPA checks to decide whether to offer "load more".
+	Page PageInfo `json:"page"`
+}
+
+// QuarantineReviewRequest REF §A4's `quarantineReview` schema. `action` is a plain string for the reason MessageStatusRequest's `status` is; `providerKey` is required in practice for a release, but the 400 that says so is the handler's, because it names the field.
+type QuarantineReviewRequest struct {
+	// Action `dismiss` or `release`.
+	Action string `json:"action"`
+
+	// ProviderKey The provider to release into. Trimmed, lower-cased, 1..40. Required for a release, ignored for a dismissal.
+	ProviderKey *string `json:"providerKey,omitempty"`
+}
+
+// QuarantineReviewResult The outcome of one review. `releasedMessage` is the stored copy for a release and null for a dismissal — present and null, never missing.
+type QuarantineReviewResult struct {
+	ReleasedMessage *InboxMessage `json:"releasedMessage"`
+	ReviewedAt      time.Time     `json:"reviewedAt"`
 }
 
 // RoleChangeRequest REF §A4's `roleChange` schema. See CreateMemberRequest for why `role` is not an enum here.
@@ -655,11 +790,44 @@ type InvitationToken = string
 // MemberUserId defines model for MemberUserId.
 type MemberUserId = string
 
+// MessageId defines model for MessageId.
+type MessageId = string
+
+// PageBefore defines model for PageBefore.
+type PageBefore = string
+
+// PageLimit defines model for PageLimit.
+type PageLimit = int
+
 // ProviderId defines model for ProviderId.
 type ProviderId = string
 
 // SenderRuleId defines model for SenderRuleId.
 type SenderRuleId = string
+
+// ListProviderMessagesParams defines parameters for ListProviderMessages.
+type ListProviderMessagesParams struct {
+	// Limit How many rows to return. Clamped to 1..200 in Go, with 50 for a missing value.
+	// Deliberately declared WITHOUT `minimum`/`maximum`: the TypeScript clamped an out-of-range limit rather than rejecting it, and a client that asks for 9999 should get 200 rows, not a validation error on a page it can no longer navigate away from.
+	// The type IS stated, which is the one place this diverges from that predecessor: `limit=abc` is a 400 from request validation here, where the TypeScript's `Number(...)` turned it into NaN and fell back to the default. Saying "integer" is worth that — a client sending a non-number is broken, and every value a working client sends is clamped rather than refused.
+	Limit *PageLimit `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Before The keyset cursor: return only rows older than this instant, which is the previous page's `nextBefore`.
+	// Declared as a plain string rather than `format: date-time` for the same reason `limit` has no bounds: a cursor that does not parse is IGNORED (the newest page is returned) rather than rejected, exactly as the TypeScript's normalizePageOptions did.
+	Before *PageBefore `form:"before,omitempty" json:"before,omitempty"`
+}
+
+// ListQuarantineParams defines parameters for ListQuarantine.
+type ListQuarantineParams struct {
+	// Limit How many rows to return. Clamped to 1..200 in Go, with 50 for a missing value.
+	// Deliberately declared WITHOUT `minimum`/`maximum`: the TypeScript clamped an out-of-range limit rather than rejecting it, and a client that asks for 9999 should get 200 rows, not a validation error on a page it can no longer navigate away from.
+	// The type IS stated, which is the one place this diverges from that predecessor: `limit=abc` is a 400 from request validation here, where the TypeScript's `Number(...)` turned it into NaN and fell back to the default. Saying "integer" is worth that — a client sending a non-number is broken, and every value a working client sends is clamped rather than refused.
+	Limit *PageLimit `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Before The keyset cursor: return only rows older than this instant, which is the previous page's `nextBefore`.
+	// Declared as a plain string rather than `format: date-time` for the same reason `limit` has no bounds: a cursor that does not parse is IGNORED (the newest page is returned) rather than rejected, exactly as the TypeScript's normalizePageOptions did.
+	Before *PageBefore `form:"before,omitempty" json:"before,omitempty"`
+}
 
 // AcceptInvitationParams defines parameters for AcceptInvitation.
 type AcceptInvitationParams struct {
@@ -713,6 +881,12 @@ type UpdateHouseholdSettingsJSONRequestBody = HouseholdSettingsRequest
 
 // CreateHouseholdJSONRequestBody defines body for CreateHousehold for application/json ContentType.
 type CreateHouseholdJSONRequestBody = CreateHouseholdRequest
+
+// UpdateMessageStatusJSONRequestBody defines body for UpdateMessageStatus for application/json ContentType.
+type UpdateMessageStatusJSONRequestBody = MessageStatusRequest
+
+// ReviewQuarantineMessageJSONRequestBody defines body for ReviewQuarantineMessage for application/json ContentType.
+type ReviewQuarantineMessageJSONRequestBody = QuarantineReviewRequest
 
 // AcceptInvitationJSONRequestBody defines body for AcceptInvitation for application/json ContentType.
 type AcceptInvitationJSONRequestBody = AcceptInvitationRequest

--- a/apps/server/internal/api/helpers.go
+++ b/apps/server/internal/api/helpers.go
@@ -70,6 +70,22 @@ func householdFrom(ctx context.Context) *middleware.Household {
 	return middleware.HouseholdFrom(r)
 }
 
+// householdContext is the pair every household-scoped handler opens with: the
+// caller and the household the tenancy guard resolved.
+//
+// ok is false only if such a route were ever mounted without tierHousehold or
+// tierOwner, in which case refusing is the failure that leaks nothing. Each
+// handler answers its own 403 rather than sharing one, because the generated
+// response types are per-operation.
+func (s server) householdContext(ctx context.Context) (*auth.Session, *middleware.Household, bool) {
+	viewer := viewerFrom(ctx)
+	household := householdFrom(ctx)
+	if viewer == nil || household == nil {
+		return nil, nil, false
+	}
+	return viewer, household, true
+}
+
 // emailPattern is REF §A4's email rule verbatim: deliberately loose, because
 // the authoritative test of an address is whether mail to it arrives, and a
 // stricter pattern only rejects addresses that work.

--- a/apps/server/internal/api/inbox.go
+++ b/apps/server/internal/api/inbox.go
@@ -1,0 +1,370 @@
+package api
+
+import (
+	"context"
+	"strings"
+
+	"github.com/andersro93/mi-casa-su-casa/server/internal/api/gen"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/api/middleware"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/repo"
+)
+
+// Ports src/server/routes/inbox.ts (REF §A2, "Inbox"): reading the household's
+// mail, and working through the mail that could not be filed.
+//
+// The tiers are not uniform across this file, and that is the design rather
+// than an oversight (see routes.go):
+//
+//   - The three message routes are MEMBER routes with a per-provider check
+//     inside them. An owner sees every provider; a member sees only what they
+//     have been granted, because a household splits its mail per mailbox and
+//     not per role.
+//   - Both quarantine routes are OWNER routes. A quarantined message has no
+//     provider — that is precisely why it is quarantined — so there is no
+//     access grant that could scope it to a member.
+//
+// Two orderings are load-bearing:
+//
+//   - On the messages route the access check runs BEFORE the provider lookup,
+//     so a member cannot tell "this provider exists but is not yours" (403)
+//     from "no such provider" (404) and enumerate the household's mailboxes.
+//   - On the status route the message lookup runs BEFORE the body is
+//     validated, so a malformed status sent for a message the caller may not
+//     read is answered 404 rather than 400.
+
+// ListInboxProviders answers the inbox landing page.
+func (s server) ListInboxProviders(ctx context.Context, _ gen.ListInboxProvidersRequestObject) (gen.ListInboxProvidersResponseObject, error) {
+	viewer, household, ok := s.householdContext(ctx)
+	if !ok {
+		return gen.ListInboxProviders403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	// The per-provider filter is inside the query rather than applied here:
+	// the same statement that counts a provider's messages decides whether
+	// this caller may see it at all.
+	summaries, err := s.Repo.ListProviderSummariesForUser(ctx, household.ID, viewer.UserID)
+	if err != nil {
+		return nil, err
+	}
+	return gen.ListInboxProviders200JSONResponse{Providers: providerSummaryBodies(summaries)}, nil
+}
+
+// ListProviderMessages answers one page of a provider's inbox.
+func (s server) ListProviderMessages(ctx context.Context, request gen.ListProviderMessagesRequestObject) (gen.ListProviderMessagesResponseObject, error) {
+	viewer, household, ok := s.householdContext(ctx)
+	if !ok {
+		return gen.ListProviderMessages403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	allowed, err := s.mayReadProvider(ctx, viewer.UserID, household, request.ProviderKey)
+	if err != nil {
+		return nil, err
+	}
+	if !allowed {
+		return gen.ListProviderMessages403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	provider, err := s.Repo.GetProviderByKey(ctx, household.ID, request.ProviderKey)
+	if err != nil {
+		return nil, err
+	}
+	if provider == nil {
+		return gen.ListProviderMessages404JSONResponse(errorBody("Provider not found")), nil
+	}
+
+	page := pageFrom(request.Params.Limit, request.Params.Before)
+	result, err := s.Repo.ListMessagesForProvider(ctx, household.ID, request.ProviderKey, page)
+	if err != nil {
+		return nil, err
+	}
+
+	return gen.ListProviderMessages200JSONResponse{
+		Provider: gen.InboxProvider{
+			ProviderKey: provider.ProviderKey,
+			DisplayName: provider.DisplayName,
+		},
+		Messages: inboxMessageBodies(result.Items),
+		Page:     gen.PageInfo{Limit: page.Limit, NextBefore: result.NextBefore},
+	}, nil
+}
+
+// UpdateMessageStatus marks one message new, used or expired.
+func (s server) UpdateMessageStatus(ctx context.Context, request gen.UpdateMessageStatusRequestObject) (gen.UpdateMessageStatusResponseObject, error) {
+	viewer, household, ok := s.householdContext(ctx)
+	if !ok {
+		return gen.UpdateMessageStatus403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	// Scoped to the household, so a message id from somewhere else is a 404
+	// and never a status this caller gets to change.
+	existing, err := s.Repo.FindMessageByID(ctx, household.ID, request.MessageId)
+	if err != nil {
+		return nil, err
+	}
+	if existing == nil {
+		return gen.UpdateMessageStatus404JSONResponse(errorBody("Message not found")), nil
+	}
+
+	allowed, err := s.mayReadProvider(ctx, viewer.UserID, household, existing.ProviderKey)
+	if err != nil {
+		return nil, err
+	}
+	if !allowed {
+		return gen.UpdateMessageStatus403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	status, problems := normalizeMessageStatus(request.Body.Status)
+	if len(problems) > 0 {
+		summary, fields := envelopeFor(problems)
+		return gen.UpdateMessageStatus400JSONResponse(errorFieldsBody(summary, fields)), nil
+	}
+
+	message, err := s.Repo.UpdateMessageStatus(ctx, household.ID, request.MessageId, status)
+	if err != nil {
+		return nil, err
+	}
+	if message == nil {
+		// The row went between the lookup above and the update — a retention
+		// sweep, or the provider being deleted. The caller is told the same
+		// thing they would have been told a moment earlier.
+		return gen.UpdateMessageStatus404JSONResponse(errorBody("Message not found")), nil
+	}
+
+	return gen.UpdateMessageStatus200JSONResponse{Message: inboxMessageBody(*message)}, nil
+}
+
+// ListQuarantine answers one page of the needs-review queue.
+func (s server) ListQuarantine(ctx context.Context, request gen.ListQuarantineRequestObject) (gen.ListQuarantineResponseObject, error) {
+	_, household, ok := s.householdContext(ctx)
+	if !ok {
+		return gen.ListQuarantine403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	page := pageFrom(request.Params.Limit, request.Params.Before)
+	result, err := s.Repo.ListQuarantine(ctx, household.ID, page)
+	if err != nil {
+		return nil, err
+	}
+
+	return gen.ListQuarantine200JSONResponse{
+		Messages: quarantineMessageBodies(result.Items),
+		Page:     gen.PageInfo{Limit: page.Limit, NextBefore: result.NextBefore},
+	}, nil
+}
+
+// ReviewQuarantineMessage dismisses or releases one needs-review row.
+func (s server) ReviewQuarantineMessage(ctx context.Context, request gen.ReviewQuarantineMessageRequestObject) (gen.ReviewQuarantineMessageResponseObject, error) {
+	viewer, household, ok := s.householdContext(ctx)
+	if !ok {
+		return gen.ReviewQuarantineMessage403JSONResponse(errorBody("Forbidden")), nil
+	}
+
+	action, providerKey, problems := normalizeQuarantineReviewBody(request.Body.Action, request.Body.ProviderKey)
+	if len(problems) > 0 {
+		summary, fields := envelopeFor(problems)
+		return gen.ReviewQuarantineMessage400JSONResponse(errorFieldsBody(summary, fields)), nil
+	}
+
+	var providerID string
+	if action == repo.ReviewRelease {
+		// Refused before the message is looked up: "release it, but nowhere"
+		// is a broken request whatever row it names.
+		if providerKey == "" {
+			return gen.ReviewQuarantineMessage400JSONResponse(errorBody(
+				"providerKey is required to release a message")), nil
+		}
+		provider, err := s.Repo.GetProviderByKey(ctx, household.ID, providerKey)
+		if err != nil {
+			return nil, err
+		}
+		if provider == nil {
+			return gen.ReviewQuarantineMessage404JSONResponse(errorBody("Provider not found")), nil
+		}
+		providerID = provider.ID
+	}
+
+	// One 404 covers both "no such row in this household" and "somebody has
+	// already reviewed it", which is what makes a double submit harmless
+	// rather than a second copy in the provider's inbox.
+	review, err := s.Repo.ReviewQuarantine(ctx, household.ID, request.MessageId, action, providerID)
+	if err != nil {
+		return nil, err
+	}
+	if review == nil {
+		return gen.ReviewQuarantineMessage404JSONResponse(errorBody("Quarantine message not found")), nil
+	}
+
+	var details map[string]any
+	if providerKey != "" {
+		details = map[string]any{"providerKey": providerKey}
+	}
+	s.audit(ctx, viewer, household, "quarantine."+action, "quarantine_message", &request.MessageId, details)
+
+	return gen.ReviewQuarantineMessage200JSONResponse{
+		ReviewedAt:      review.ReviewedAt,
+		ReleasedMessage: releasedMessageBody(review.ReleasedMessage),
+	}, nil
+}
+
+// mayReadProvider is the per-provider access check the three message routes
+// share: an owner may read every provider in their household, a member only
+// the ones they have been granted.
+//
+// A provider key that names nothing is simply not granted, so a member asking
+// after one is refused with the same 403 as a member asking after a real
+// provider they may not read — which is the point.
+func (s server) mayReadProvider(ctx context.Context, userID string, household *middleware.Household, providerKey string) (bool, error) {
+	if household.Role == repo.RoleOwner {
+		return true, nil
+	}
+	return s.Repo.UserHasProviderAccess(ctx, household.ID, userID, providerKey)
+}
+
+// messageStatuses is REF §A4's `messageStatus` enum, in the order its message
+// names them.
+var messageStatuses = []string{repo.StatusNew, repo.StatusUsed, repo.StatusExpired}
+
+// normalizeMessageStatus applies REF §A4's `messageStatus` schema. The check
+// is here rather than an OpenAPI enum for the reason the spec states: an enum
+// violation cannot say "status must be new, used or expired", and that wording
+// is what the SPA renders.
+func normalizeMessageStatus(raw string) (status string, problems []problem) {
+	status = strings.TrimSpace(raw)
+	for _, known := range messageStatuses {
+		if status == known {
+			return status, nil
+		}
+	}
+	return status, []problem{{
+		field:   "status",
+		message: "status must be new, used or expired",
+	}}
+}
+
+// normalizeQuarantineReviewBody applies REF §A4's `quarantineReview` schema.
+// The provider key is trimmed and lower-cased before its bounds are checked,
+// so what is validated is what will be looked up.
+//
+// An absent providerKey is NOT a problem here even for a release: that
+// refusal is the handler's, because its message names the field and the
+// action together.
+func normalizeQuarantineReviewBody(rawAction string, rawProviderKey *string) (action, providerKey string, problems []problem) {
+	action = strings.TrimSpace(rawAction)
+	switch action {
+	case repo.ReviewDismiss, repo.ReviewRelease:
+	default:
+		problems = append(problems, problem{
+			field:   "action",
+			message: "action must be dismiss or release",
+		})
+	}
+
+	if rawProviderKey != nil {
+		providerKey = strings.ToLower(strings.TrimSpace(*rawProviderKey))
+		problems = appendTextProblems(problems, "providerKey", providerKey, 40)
+	}
+	return action, providerKey, problems
+}
+
+// pageFrom turns the two optional query parameters into a normalised page.
+//
+// The clamping lives in Go rather than in the spec (see the PageLimit
+// parameter): an out-of-range limit is clamped and an unparseable cursor is
+// ignored, both carried over from the TypeScript's normalizePageOptions, so a
+// client can never end up on a page it cannot navigate away from.
+//
+// The one wrinkle is `limit=0`. repo.NormalizePage reads 0 as "absent" and
+// answers with the default 50, which is right for a caller that passed
+// nothing — but a query parameter that IS present and says zero meant zero,
+// and the TypeScript clamped that up to 1. Passing it on as a negative is how
+// the two cases stay distinguishable through a single int.
+func pageFrom(limit *gen.PageLimit, before *gen.PageBefore) repo.Page {
+	value := 0
+	if limit != nil {
+		value = *limit
+		if value == 0 {
+			value = -1
+		}
+	}
+	cursor := ""
+	if before != nil {
+		cursor = *before
+	}
+	return repo.NormalizePage(value, cursor)
+}
+
+// providerSummaryBodies maps the inbox landing page onto the wire shape,
+// non-nil even when empty so the key marshals as `[]` rather than as null.
+func providerSummaryBodies(summaries []repo.ProviderSummary) []gen.ProviderSummary {
+	rows := make([]gen.ProviderSummary, 0, len(summaries))
+	for _, summary := range summaries {
+		rows = append(rows, gen.ProviderSummary{
+			HouseholdSlug:    summary.HouseholdSlug,
+			ProviderKey:      summary.ProviderKey,
+			DisplayName:      summary.DisplayName,
+			MessageCount:     summary.MessageCount,
+			NewCount:         summary.NewCount,
+			LatestReceivedAt: summary.LatestReceivedAt,
+			LatestMessageId:  summary.LatestMessageID,
+			LatestSubject:    summary.LatestSubject,
+			LatestCode:       summary.LatestCode,
+			LatestStatus:     summary.LatestStatus,
+		})
+	}
+	return rows
+}
+
+// inboxMessageBody maps one inbox row onto the wire shape.
+func inboxMessageBody(message repo.InboxMessage) gen.InboxMessage {
+	return gen.InboxMessage{
+		Id:                  message.ID,
+		HouseholdSlug:       message.HouseholdSlug,
+		ProviderKey:         message.ProviderKey,
+		ProviderDisplayName: message.ProviderDisplayName,
+		Subject:             message.Subject,
+		FromHeader:          message.FromHeader,
+		TextBody:            message.TextBody,
+		ExtractedCode:       message.ExtractedCode,
+		Status:              gen.InboxMessageStatus(message.Status),
+		ReceivedAt:          message.ReceivedAt,
+	}
+}
+
+func inboxMessageBodies(messages []repo.InboxMessage) []gen.InboxMessage {
+	rows := make([]gen.InboxMessage, 0, len(messages))
+	for _, message := range messages {
+		rows = append(rows, inboxMessageBody(message))
+	}
+	return rows
+}
+
+// releasedMessageBody preserves nil: a dismissal answers with
+// `releasedMessage: null` rather than omitting the key.
+func releasedMessageBody(message *repo.InboxMessage) *gen.InboxMessage {
+	if message == nil {
+		return nil
+	}
+	body := inboxMessageBody(*message)
+	return &body
+}
+
+func quarantineMessageBodies(messages []repo.QuarantineMessage) []gen.QuarantineMessage {
+	rows := make([]gen.QuarantineMessage, 0, len(messages))
+	for _, message := range messages {
+		rows = append(rows, gen.QuarantineMessage{
+			Id:                  message.ID,
+			HouseholdSlug:       message.HouseholdSlug,
+			ProviderKey:         message.ProviderKey,
+			ProviderDisplayName: message.ProviderDisplayName,
+			Subject:             message.Subject,
+			FromHeader:          message.FromHeader,
+			EnvelopeFrom:        message.EnvelopeFrom,
+			TextBody:            message.TextBody,
+			ExtractedCode:       message.ExtractedCode,
+			Status:              message.Status,
+			QuarantineReason:    message.QuarantineReason,
+			ReceivedAt:          message.ReceivedAt,
+		})
+	}
+	return rows
+}

--- a/apps/server/internal/api/inbox_test.go
+++ b/apps/server/internal/api/inbox_test.go
@@ -1,0 +1,709 @@
+package api_test
+
+import (
+	"net/http"
+	neturl "net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/andersro93/mi-casa-su-casa/server/internal/repo"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/testrig"
+)
+
+// Ports the inbox half of test/inbox-routes.test.ts, the route half of
+// test/integration/pagination.test.ts, the release path of
+// test/integration/messages-repository.test.ts and the visibility assertions
+// of test/integration/provider-summaries.test.ts — against a real database
+// and the whole handler chain.
+//
+// Messages are seeded through repo.InsertMessage/InsertQuarantine rather than
+// over HTTP because the inbound endpoint belongs to a later phase: there is no
+// route that creates a message yet.
+
+// inboxPath builds an /api/inbox/{slug}/… URL.
+func inboxPath(slug, suffix string) string { return "/api/inbox/" + slug + suffix }
+
+// seedAt is the instant the seeded fixtures are dated from. Fixed rather than
+// "now" so a cursor in an assertion is readable and the ordering is not at the
+// mercy of how fast the test runs.
+var seedAt = time.Date(2026, time.May, 10, 12, 0, 0, 0, time.UTC)
+
+// householdID resolves a slug the way every seeding helper below needs it.
+func householdID(t *testing.T, app *testrig.AppRig, slug string) string {
+	t.Helper()
+	household, err := app.Deps.Repo.GetHouseholdBySlug(t.Context(), slug)
+	if err != nil || household == nil {
+		t.Fatalf("household %q: %v", slug, err)
+	}
+	return household.ID
+}
+
+// parsedEmail is the minimum a stored message needs: the fields the inbox rows
+// actually show, plus the envelope the quarantine rows show as well.
+func parsedEmail(messageID, subject, from string) repo.ParsedEmail {
+	fromHeader := "Netflix <" + from + ">"
+	return repo.ParsedEmail{
+		EnvelopeFrom: from,
+		EnvelopeTo:   "casa@" + testrig.EmailDomain,
+		FromHeader:   &fromHeader,
+		Subject:      &subject,
+		MessageID:    "<" + messageID + "@test>",
+		TextBody:     "Body of " + messageID,
+		RawSize:      len(messageID),
+	}
+}
+
+// seedMessage stores one classified message and returns its id.
+func seedMessage(t *testing.T, app *testrig.AppRig, hid, providerID, messageID, subject string, code *string, receivedAt time.Time) string {
+	t.Helper()
+	id, err := app.Deps.Repo.InsertMessage(t.Context(),
+		parsedEmail(messageID, subject, "no-reply@netflix.com"),
+		hid, providerID, code, "rule_match", receivedAt)
+	if err != nil {
+		t.Fatalf("seedMessage(%q): %v", messageID, err)
+	}
+	return id
+}
+
+// seedQuarantine stores one unattributed message and returns its id.
+func seedQuarantine(t *testing.T, app *testrig.AppRig, hid, messageID, subject, reason string, receivedAt time.Time) string {
+	t.Helper()
+	id, err := app.Deps.Repo.InsertQuarantine(t.Context(),
+		parsedEmail(messageID, subject, "unknown@example.com"),
+		hid, nil, reason, receivedAt)
+	if err != nil {
+		t.Fatalf("seedQuarantine(%q): %v", messageID, err)
+	}
+	return id
+}
+
+// grantAccess gives a member one provider, through the owner's admin route.
+func grantAccess(t *testing.T, app *testrig.AppRig, ownerCookie, slug, email, providerKey string) {
+	t.Helper()
+	member, err := app.Deps.Repo.FindUserByEmail(t.Context(), email)
+	if err != nil || member == nil {
+		t.Fatalf("member %q: %v", email, err)
+	}
+	rec := app.Do(t, http.MethodPost, adminPath(slug, "/members/"+member.ID+"/provider-access"),
+		map[string]any{"providerKey": providerKey}, testrig.WithCookie(ownerCookie))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("grant %q: %d %s", providerKey, rec.Code, rec.Body.String())
+	}
+}
+
+// Ports provider-summaries.test.ts: the newest message's id, subject, code and
+// status appear on the tile, and a provider that has received nothing has null
+// latest fields rather than missing keys.
+func TestListInboxProvidersSummarisesTheNewestMessage(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	hid := householdID(t, app, slug)
+	netflix := createProvider(t, app, cookie, slug, "netflix", "Netflix")
+	createProvider(t, app, cookie, slug, "spotify", "Spotify")
+
+	// Dated from AFTER both providers were created, so the tile with mail
+	// really is the more recently active one: the ordering key is
+	// COALESCE(max(received_at), created_at), and an empty provider is sorted
+	// by the moment it was made.
+	activity := time.Now().UTC()
+	old := seedMessage(t, app, hid, netflix, "old", "Old code", ptrTo("111111"), activity.Add(-24*time.Hour))
+	seedMessage(t, app, hid, netflix, "middle", "New sign-in", nil, activity.Add(-12*time.Hour))
+	newest := seedMessage(t, app, hid, netflix, "newest", "Your Netflix verification code",
+		ptrTo("482913"), activity)
+	if _, err := app.Deps.Repo.UpdateMessageStatus(t.Context(), hid, old, repo.StatusUsed); err != nil {
+		t.Fatalf("mark used: %v", err)
+	}
+
+	rec := app.Do(t, http.MethodGet, inboxPath(slug, "/providers"), nil, testrig.WithCookie(cookie))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	providers, _ := app.JSON(t, rec)["providers"].([]any)
+	if len(providers) != 2 {
+		t.Fatalf("providers = %v, want both", providers)
+	}
+
+	// Ordered by latest activity first, so the provider with mail leads.
+	n, _ := providers[0].(map[string]any)
+	s, _ := providers[1].(map[string]any)
+
+	if n["provider_key"] != "netflix" || n["display_name"] != "Netflix" || n["household_slug"] != slug {
+		t.Fatalf("netflix tile = %v", n)
+	}
+	if n["message_count"] != float64(3) || n["new_count"] != float64(2) {
+		t.Errorf("counts = %v/%v, want 3/2", n["message_count"], n["new_count"])
+	}
+	if n["latest_message_id"] != newest {
+		t.Errorf("latest_message_id = %v, want %q", n["latest_message_id"], newest)
+	}
+	if n["latest_subject"] != "Your Netflix verification code" ||
+		n["latest_code"] != "482913" || n["latest_status"] != "new" {
+		t.Errorf("latest preview = %v", n)
+	}
+	if n["latest_received_at"] == nil {
+		t.Error("latest_received_at is null for a provider with messages")
+	}
+
+	// Present and null, never missing: the SPA renders the empty tile from
+	// these keys.
+	if s["provider_key"] != "spotify" || s["message_count"] != float64(0) {
+		t.Fatalf("spotify tile = %v", s)
+	}
+	for _, key := range []string{"latest_received_at", "latest_message_id", "latest_subject", "latest_code", "latest_status"} {
+		value, present := s[key]
+		if !present || value != nil {
+			t.Errorf("spotify %s = %v (present %v), want a null", key, value, present)
+		}
+	}
+}
+
+// The first case of inbox-routes.test.ts: a member sees the providers they
+// were granted and nothing else, while the owner sees the household's lot.
+func TestListInboxProvidersOwnerSeesAllMemberSeesGranted(t *testing.T) {
+	app := testrig.App(t)
+	ownerCookie, slug := app.CompleteSetup(t)
+	memberCookie := app.CreateMember(t, slug, memberEmail, "Member", "member")
+	hid := householdID(t, app, slug)
+	netflix := createProvider(t, app, ownerCookie, slug, "netflix", "Netflix")
+	createProvider(t, app, ownerCookie, slug, "spotify", "Spotify")
+	seedMessage(t, app, hid, netflix, "msg-1", "Your code", ptrTo("123456"), seedAt)
+	grantAccess(t, app, ownerCookie, slug, memberEmail, "netflix")
+
+	ownerRec := app.Do(t, http.MethodGet, inboxPath(slug, "/providers"), nil, testrig.WithCookie(ownerCookie))
+	if ownerRec.Code != http.StatusOK {
+		t.Fatalf("owner: %d %s", ownerRec.Code, ownerRec.Body.String())
+	}
+	if got, _ := app.JSON(t, ownerRec)["providers"].([]any); len(got) != 2 {
+		t.Errorf("owner sees %d providers, want 2", len(got))
+	}
+
+	memberRec := app.Do(t, http.MethodGet, inboxPath(slug, "/providers"), nil, testrig.WithCookie(memberCookie))
+	if memberRec.Code != http.StatusOK {
+		t.Fatalf("member: %d %s", memberRec.Code, memberRec.Body.String())
+	}
+	providers, _ := app.JSON(t, memberRec)["providers"].([]any)
+	if len(providers) != 1 {
+		t.Fatalf("member sees %v, want only netflix", providers)
+	}
+	entry, _ := providers[0].(map[string]any)
+	if entry["provider_key"] != "netflix" || entry["message_count"] != float64(1) {
+		t.Errorf("member tile = %v", entry)
+	}
+}
+
+// "denies inbox access across household boundaries": the tenancy guard answers
+// before any handler runs, and it says nothing about whether the household or
+// the provider exists.
+func TestInboxRoutesRefuseAnotherHouseholdsSlug(t *testing.T) {
+	app := testrig.App(t)
+	ownerCookie, slug := app.CompleteSetup(t)
+	createProvider(t, app, ownerCookie, slug, "netflix", "Netflix")
+
+	_, otherCookie := signUp(t, app, "other@example.com", "Other")
+	if rec := createHousehold(t, app, otherCookie, "otra"); rec.StatusCode != http.StatusCreated {
+		t.Fatalf("second household: %d", rec.StatusCode)
+	}
+
+	for _, path := range []string{"/providers", "/providers/netflix", "/quarantine"} {
+		t.Run(path, func(t *testing.T) {
+			rec := app.Do(t, http.MethodGet, inboxPath(slug, path), nil, testrig.WithCookie(otherCookie))
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+			}
+			if got := app.JSON(t, rec)["error"]; got != "Forbidden" {
+				t.Errorf("error = %q", got)
+			}
+		})
+	}
+}
+
+// A member without access to a provider is refused before the provider is
+// looked up, so 403 and 404 cannot be used to enumerate the household's
+// mailboxes.
+func TestListProviderMessagesAccessAndUnknownProvider(t *testing.T) {
+	app := testrig.App(t)
+	ownerCookie, slug := app.CompleteSetup(t)
+	memberCookie := app.CreateMember(t, slug, memberEmail, "Member", "member")
+	hid := householdID(t, app, slug)
+	netflix := createProvider(t, app, ownerCookie, slug, "netflix", "Netflix")
+	createProvider(t, app, ownerCookie, slug, "spotify", "Spotify")
+	seedMessage(t, app, hid, netflix, "msg-1", "Your code", ptrTo("123456"), seedAt)
+	grantAccess(t, app, ownerCookie, slug, memberEmail, "netflix")
+
+	rec := app.Do(t, http.MethodGet, inboxPath(slug, "/providers/netflix"), nil, testrig.WithCookie(memberCookie))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("granted provider: %d %s", rec.Code, rec.Body.String())
+	}
+	body := app.JSON(t, rec)
+	provider, _ := body["provider"].(map[string]any)
+	if provider["providerKey"] != "netflix" || provider["displayName"] != "Netflix" {
+		t.Errorf("provider = %v", provider)
+	}
+	messages, _ := body["messages"].([]any)
+	if len(messages) != 1 {
+		t.Fatalf("messages = %v", body["messages"])
+	}
+	row, _ := messages[0].(map[string]any)
+	if row["provider_display_name"] != "Netflix" || row["extracted_code"] != "123456" ||
+		row["status"] != "new" || row["household_slug"] != slug {
+		t.Errorf("message row = %v", row)
+	}
+	page, _ := body["page"].(map[string]any)
+	if page["limit"] != float64(50) || page["nextBefore"] != nil {
+		t.Errorf("page = %v, want limit 50 and a null cursor", page)
+	}
+
+	denied := app.Do(t, http.MethodGet, inboxPath(slug, "/providers/spotify"), nil, testrig.WithCookie(memberCookie))
+	if denied.Code != http.StatusForbidden {
+		t.Fatalf("ungranted provider: %d %s", denied.Code, denied.Body.String())
+	}
+	if got := app.JSON(t, denied)["error"]; got != "Forbidden" {
+		t.Errorf("error = %q", got)
+	}
+
+	// An owner may see every provider, so for them an unknown key is a 404.
+	missing := app.Do(t, http.MethodGet, inboxPath(slug, "/providers/nope"), nil, testrig.WithCookie(ownerCookie))
+	if missing.Code != http.StatusNotFound {
+		t.Fatalf("unknown provider: %d %s", missing.Code, missing.Body.String())
+	}
+	if got := app.JSON(t, missing)["error"]; got != "Provider not found" {
+		t.Errorf("error = %q", got)
+	}
+
+	// A member without access to a provider that does not exist either is
+	// still told 403, never 404.
+	hidden := app.Do(t, http.MethodGet, inboxPath(slug, "/providers/nope"), nil, testrig.WithCookie(memberCookie))
+	if hidden.Code != http.StatusForbidden {
+		t.Errorf("unknown provider for a member: %d %s", hidden.Code, hidden.Body.String())
+	}
+}
+
+// Ports pagination.test.ts's HTTP half: 60 messages come back as two keyset
+// pages, and the cursor round-trips through the query string.
+func TestProviderMessagesAndQuarantinePaginate(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	hid := householdID(t, app, slug)
+	netflix := createProvider(t, app, cookie, slug, "netflix", "Netflix")
+
+	for i := range 60 {
+		at := seedAt.Add(time.Duration(i) * time.Minute)
+		seedMessage(t, app, hid, netflix, "m-"+strconv.Itoa(i), "Code "+strconv.Itoa(i), nil, at)
+		seedQuarantine(t, app, hid, "q-"+strconv.Itoa(i), "Review "+strconv.Itoa(i), "unknown_sender", at)
+	}
+
+	first := app.Do(t, http.MethodGet, inboxPath(slug, "/providers/netflix"), nil, testrig.WithCookie(cookie))
+	if first.Code != http.StatusOK {
+		t.Fatalf("page 1: %d %s", first.Code, first.Body.String())
+	}
+	body1 := app.JSON(t, first)
+	messages1, _ := body1["messages"].([]any)
+	if len(messages1) != 50 {
+		t.Fatalf("page 1 = %d messages, want the default 50", len(messages1))
+	}
+	page1, _ := body1["page"].(map[string]any)
+	if page1["limit"] != float64(50) {
+		t.Errorf("page 1 limit = %v", page1["limit"])
+	}
+	cursor, _ := page1["nextBefore"].(string)
+	if cursor == "" {
+		t.Fatalf("page 1 nextBefore = %v, want the cursor for an older page", page1["nextBefore"])
+	}
+	// The cursor is the last row's received_at, which is what makes it a
+	// keyset rather than an offset.
+	last, _ := messages1[49].(map[string]any)
+	if last["received_at"] != cursor {
+		t.Errorf("nextBefore = %q, want the last row's received_at %v", cursor, last["received_at"])
+	}
+	newest, _ := messages1[0].(map[string]any)
+	if newest["subject"] != "Code 59" {
+		t.Errorf("page 1 leads with %v, want the newest message", newest["subject"])
+	}
+
+	second := app.Do(t, http.MethodGet,
+		inboxPath(slug, "/providers/netflix")+"?limit=50&before="+neturl.QueryEscape(cursor), nil, testrig.WithCookie(cookie))
+	if second.Code != http.StatusOK {
+		t.Fatalf("page 2: %d %s", second.Code, second.Body.String())
+	}
+	body2 := app.JSON(t, second)
+	messages2, _ := body2["messages"].([]any)
+	if len(messages2) != 10 {
+		t.Fatalf("page 2 = %d messages, want the remaining 10", len(messages2))
+	}
+	page2, _ := body2["page"].(map[string]any)
+	if page2["nextBefore"] != nil {
+		t.Errorf("page 2 nextBefore = %v, want null on the last page", page2["nextBefore"])
+	}
+	oldest, _ := messages2[9].(map[string]any)
+	if oldest["subject"] != "Code 0" {
+		t.Errorf("page 2 ends with %v, want the oldest message", oldest["subject"])
+	}
+
+	// The quarantine list pages the same way, and 200 is the whole seeded set.
+	quarantine := app.Do(t, http.MethodGet, inboxPath(slug, "/quarantine")+"?limit=200", nil, testrig.WithCookie(cookie))
+	if quarantine.Code != http.StatusOK {
+		t.Fatalf("quarantine: %d %s", quarantine.Code, quarantine.Body.String())
+	}
+	qBody := app.JSON(t, quarantine)
+	rows, _ := qBody["messages"].([]any)
+	if len(rows) != 60 {
+		t.Fatalf("quarantine = %d rows, want 60", len(rows))
+	}
+	qPage, _ := qBody["page"].(map[string]any)
+	if qPage["limit"] != float64(200) || qPage["nextBefore"] != nil {
+		t.Errorf("quarantine page = %v", qPage)
+	}
+	row, _ := rows[0].(map[string]any)
+	if row["provider_key"] != "quarantine" || row["provider_display_name"] != "Quarantine" ||
+		row["status"] != "new" || row["quarantine_reason"] != "unknown_sender" ||
+		row["envelope_from"] != "unknown@example.com" {
+		t.Errorf("quarantine row = %v", row)
+	}
+}
+
+// An out-of-range limit is clamped rather than rejected, and an unusable
+// cursor is ignored rather than rejected — both carried over from the
+// TypeScript's normalizePageOptions, so a client can never paint itself into a
+// page it cannot navigate away from.
+func TestProviderMessagesClampTheLimitAndIgnoreABadCursor(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	hid := householdID(t, app, slug)
+	netflix := createProvider(t, app, cookie, slug, "netflix", "Netflix")
+	for i := range 3 {
+		seedMessage(t, app, hid, netflix, "m-"+strconv.Itoa(i), "Code "+strconv.Itoa(i), nil,
+			seedAt.Add(time.Duration(i)*time.Minute))
+	}
+
+	cases := []struct {
+		query string
+		limit float64
+		rows  int
+	}{
+		{"?limit=9999", 200, 3},
+		{"?limit=0", 1, 1},
+		{"?limit=2", 2, 2},
+		{"?before=garbage", 50, 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.query, func(t *testing.T) {
+			rec := app.Do(t, http.MethodGet, inboxPath(slug, "/providers/netflix")+tc.query, nil, testrig.WithCookie(cookie))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+			}
+			body := app.JSON(t, rec)
+			page, _ := body["page"].(map[string]any)
+			if page["limit"] != tc.limit {
+				t.Errorf("limit = %v, want %v", page["limit"], tc.limit)
+			}
+			if rows, _ := body["messages"].([]any); len(rows) != tc.rows {
+				t.Errorf("messages = %d, want %d", len(rows), tc.rows)
+			}
+		})
+	}
+}
+
+// The one place the page parameters diverge from the TypeScript, pinned so it
+// is a decision and not a surprise: `limit` is declared as an integer in the
+// spec, so a value that is not one is a validation failure rather than the
+// silent fall-back to 50 that `Number(...)` produced. Every value a working
+// client sends is still clamped, never refused.
+func TestProviderMessagesRejectALimitThatIsNotANumber(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	createProvider(t, app, cookie, slug, "netflix", "Netflix")
+
+	rec := app.Do(t, http.MethodGet, inboxPath(slug, "/providers/netflix")+"?limit=abc", nil, testrig.WithCookie(cookie))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d %s, want 400", rec.Code, rec.Body.String())
+	}
+	fields, _ := app.JSON(t, rec)["fields"].(map[string]any)
+	if _, named := fields["limit"]; !named {
+		t.Errorf("fields = %v, want the failure named against limit", fields)
+	}
+}
+
+// "allows a permitted member to update message status in their household",
+// plus the two refusals around it.
+func TestUpdateMessageStatus(t *testing.T) {
+	app := testrig.App(t)
+	ownerCookie, slug := app.CompleteSetup(t)
+	memberCookie := app.CreateMember(t, slug, memberEmail, "Member", "member")
+	hid := householdID(t, app, slug)
+	netflix := createProvider(t, app, ownerCookie, slug, "netflix", "Netflix")
+	spotify := createProvider(t, app, ownerCookie, slug, "spotify", "Spotify")
+	granted := seedMessage(t, app, hid, netflix, "msg-1", "Your code", ptrTo("123456"), seedAt)
+	ungranted := seedMessage(t, app, hid, spotify, "msg-2", "Other code", nil, seedAt)
+	grantAccess(t, app, ownerCookie, slug, memberEmail, "netflix")
+
+	rec := app.Do(t, http.MethodPatch, inboxPath(slug, "/messages/"+granted+"/status"),
+		map[string]any{"status": "used"}, testrig.WithCookie(memberCookie))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	message, _ := app.JSON(t, rec)["message"].(map[string]any)
+	if message["id"] != granted || message["status"] != "used" {
+		t.Errorf("message = %v", message)
+	}
+
+	denied := app.Do(t, http.MethodPatch, inboxPath(slug, "/messages/"+ungranted+"/status"),
+		map[string]any{"status": "used"}, testrig.WithCookie(memberCookie))
+	if denied.Code != http.StatusForbidden {
+		t.Fatalf("without access: %d %s", denied.Code, denied.Body.String())
+	}
+	if got := app.JSON(t, denied)["error"]; got != "Forbidden" {
+		t.Errorf("error = %q", got)
+	}
+	if got := app.Count(t, "messages", `"id" = $1 AND "status" = 'new'`, ungranted); got != 1 {
+		t.Errorf("the refused message changed status")
+	}
+
+	missing := app.Do(t, http.MethodPatch, inboxPath(slug, "/messages/nope/status"),
+		map[string]any{"status": "used"}, testrig.WithCookie(ownerCookie))
+	if missing.Code != http.StatusNotFound {
+		t.Fatalf("unknown message: %d %s", missing.Code, missing.Body.String())
+	}
+	if got := app.JSON(t, missing)["error"]; got != "Message not found" {
+		t.Errorf("error = %q", got)
+	}
+}
+
+// The status is validated in Go so the rejection can name the three values —
+// and it is validated AFTER the lookup, so a bad status for somebody else's
+// message is still a 404.
+func TestUpdateMessageStatusRejectsAnUnknownStatus(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	hid := householdID(t, app, slug)
+	netflix := createProvider(t, app, cookie, slug, "netflix", "Netflix")
+	id := seedMessage(t, app, hid, netflix, "msg-1", "Your code", nil, seedAt)
+
+	rec := app.Do(t, http.MethodPatch, inboxPath(slug, "/messages/"+id+"/status"),
+		map[string]any{"status": "archived"}, testrig.WithCookie(cookie))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	body := app.JSON(t, rec)
+	if got := body["error"]; got != "status must be new, used or expired" {
+		t.Errorf("error = %q", got)
+	}
+	fields, _ := body["fields"].(map[string]any)
+	if fields["status"] != "status must be new, used or expired" {
+		t.Errorf("fields = %v", fields)
+	}
+
+	unknown := app.Do(t, http.MethodPatch, inboxPath(slug, "/messages/nope/status"),
+		map[string]any{"status": "archived"}, testrig.WithCookie(cookie))
+	if unknown.Code != http.StatusNotFound {
+		t.Errorf("a bad status on an unknown message = %d, want 404", unknown.Code)
+	}
+}
+
+// "denies quarantine review to members in the same household": quarantined
+// mail has no provider to scope it by, so it is owner-only on both routes.
+func TestQuarantineRoutesAreOwnerOnly(t *testing.T) {
+	app := testrig.App(t)
+	ownerCookie, slug := app.CompleteSetup(t)
+	memberCookie := app.CreateMember(t, slug, memberEmail, "Member", "member")
+	hid := householdID(t, app, slug)
+	createProvider(t, app, ownerCookie, slug, "netflix", "Netflix")
+	grantAccess(t, app, ownerCookie, slug, memberEmail, "netflix")
+	id := seedQuarantine(t, app, hid, "q-1", "Review this", "unknown_sender", seedAt)
+
+	list := app.Do(t, http.MethodGet, inboxPath(slug, "/quarantine"), nil, testrig.WithCookie(memberCookie))
+	if list.Code != http.StatusForbidden {
+		t.Fatalf("member list: %d %s", list.Code, list.Body.String())
+	}
+	if got := app.JSON(t, list)["error"]; got != "Forbidden" {
+		t.Errorf("error = %q", got)
+	}
+
+	review := app.Do(t, http.MethodPost, inboxPath(slug, "/quarantine/"+id+"/review"),
+		map[string]any{"action": "dismiss"}, testrig.WithCookie(memberCookie))
+	if review.Code != http.StatusForbidden {
+		t.Fatalf("member review: %d %s", review.Code, review.Body.String())
+	}
+	if got := app.Count(t, "quarantine_messages", `"reviewed_at" IS NOT NULL`); got != 0 {
+		t.Error("a member's refused review still marked the row reviewed")
+	}
+}
+
+// Ports the release path of messages-repository.test.ts through the route: the
+// copy lands in the provider's inbox with the reason that says where it came
+// from, the quarantine row is marked reviewed, and a second review of the same
+// row is a 404.
+func TestReviewQuarantineReleasesIntoAProvider(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	hid := householdID(t, app, slug)
+	createProvider(t, app, cookie, slug, "netflix", "Netflix")
+	id := seedQuarantine(t, app, hid, "q-1", "Review this", "unknown_sender", seedAt)
+
+	rec := app.Do(t, http.MethodPost, inboxPath(slug, "/quarantine/"+id+"/review"),
+		map[string]any{"action": "release", "providerKey": "netflix"}, testrig.WithCookie(cookie))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	body := app.JSON(t, rec)
+	if body["reviewedAt"] == nil {
+		t.Errorf("reviewedAt = %v", body["reviewedAt"])
+	}
+	released, _ := body["releasedMessage"].(map[string]any)
+	if released == nil {
+		t.Fatalf("releasedMessage = %v, want the stored copy", body["releasedMessage"])
+	}
+	if released["provider_key"] != "netflix" || released["status"] != "new" ||
+		released["subject"] != "Review this" {
+		t.Errorf("releasedMessage = %v", released)
+	}
+
+	// The reason records where the message came from and why it had been held.
+	if got := app.Count(t, "messages",
+		`"classification_reason" = 'Released from quarantine by owner review. Original reason: unknown_sender'`,
+	); got != 1 {
+		t.Errorf("released copy's classification_reason = %d rows, want 1", got)
+	}
+	if got := app.Count(t, "quarantine_messages", `"reviewed_at" IS NOT NULL`); got != 1 {
+		t.Errorf("reviewed rows = %d, want 1", got)
+	}
+	// Reviewed rows leave the queue.
+	list := app.Do(t, http.MethodGet, inboxPath(slug, "/quarantine"), nil, testrig.WithCookie(cookie))
+	if rows, _ := app.JSON(t, list)["messages"].([]any); len(rows) != 0 {
+		t.Errorf("quarantine still lists %v", rows)
+	}
+	if got := app.Count(t, "audit_events", `"action" = 'quarantine.release'`); got != 1 {
+		t.Errorf("quarantine.release audits = %d, want 1", got)
+	}
+	if got := app.Count(t, "audit_events",
+		`"action" = 'quarantine.release' AND "details"::jsonb ->> 'providerKey' = 'netflix'`); got != 1 {
+		t.Error("the audit does not record which provider it was released into")
+	}
+
+	// A second review of the same row finds nothing left to review.
+	again := app.Do(t, http.MethodPost, inboxPath(slug, "/quarantine/"+id+"/review"),
+		map[string]any{"action": "release", "providerKey": "netflix"}, testrig.WithCookie(cookie))
+	if again.Code != http.StatusNotFound {
+		t.Fatalf("second review: %d %s", again.Code, again.Body.String())
+	}
+	if got := app.JSON(t, again)["error"]; got != "Quarantine message not found" {
+		t.Errorf("error = %q", got)
+	}
+	if got := app.Count(t, "messages", "TRUE"); got != 1 {
+		t.Errorf("messages = %d, want the one released copy", got)
+	}
+}
+
+// A dismissal takes the row out of the queue and stores nothing.
+func TestReviewQuarantineDismisses(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	hid := householdID(t, app, slug)
+	id := seedQuarantine(t, app, hid, "q-1", "Review this", "unknown_sender", seedAt)
+
+	rec := app.Do(t, http.MethodPost, inboxPath(slug, "/quarantine/"+id+"/review"),
+		map[string]any{"action": "dismiss"}, testrig.WithCookie(cookie))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d %s", rec.Code, rec.Body.String())
+	}
+	body := app.JSON(t, rec)
+	if value, present := body["releasedMessage"]; !present || value != nil {
+		t.Errorf("releasedMessage = %v (present %v), want a null", value, present)
+	}
+	if got := app.Count(t, "messages", "TRUE"); got != 0 {
+		t.Errorf("a dismissal stored %d messages, want none", got)
+	}
+	if got := app.Count(t, "quarantine_messages", `"reviewed_at" IS NOT NULL`); got != 1 {
+		t.Errorf("reviewed rows = %d, want 1", got)
+	}
+	if got := app.Count(t, "audit_events", `"action" = 'quarantine.dismiss'`); got != 1 {
+		t.Errorf("quarantine.dismiss audits = %d, want 1", got)
+	}
+	// No provider was involved, so the audit records no key for one.
+	if got := app.Count(t, "audit_events",
+		`"action" = 'quarantine.dismiss' AND "details" IS NULL`); got != 1 {
+		t.Error("the dismissal audit carries details it should not")
+	}
+}
+
+// The three refusals of the review route, in the order the handler applies
+// them.
+func TestReviewQuarantineRefusals(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	hid := householdID(t, app, slug)
+	createProvider(t, app, cookie, slug, "netflix", "Netflix")
+	id := seedQuarantine(t, app, hid, "q-1", "Review this", "unknown_sender", seedAt)
+
+	cases := []struct {
+		name   string
+		id     string
+		body   map[string]any
+		status int
+		error  string
+	}{
+		{
+			"an unknown action", id, map[string]any{"action": "burn"},
+			http.StatusBadRequest, "action must be dismiss or release",
+		},
+		{
+			"a release with no provider", id, map[string]any{"action": "release"},
+			http.StatusBadRequest, "providerKey is required to release a message",
+		},
+		{
+			"a release into an unknown provider", id,
+			map[string]any{"action": "release", "providerKey": "nope"},
+			http.StatusNotFound, "Provider not found",
+		},
+		{
+			"an unknown message", "nope", map[string]any{"action": "dismiss"},
+			http.StatusNotFound, "Quarantine message not found",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := app.Do(t, http.MethodPost, inboxPath(slug, "/quarantine/"+tc.id+"/review"),
+				tc.body, testrig.WithCookie(cookie))
+			if rec.Code != tc.status {
+				t.Fatalf("status = %d %s, want %d", rec.Code, rec.Body.String(), tc.status)
+			}
+			if got := app.JSON(t, rec)["error"]; got != tc.error {
+				t.Errorf("error = %q, want %q", got, tc.error)
+			}
+		})
+	}
+
+	// None of them reviewed anything or recorded an audit.
+	if got := app.Count(t, "quarantine_messages", `"reviewed_at" IS NOT NULL`); got != 0 {
+		t.Errorf("reviewed rows = %d, want 0", got)
+	}
+	if got := app.Count(t, "audit_events", `"action" LIKE 'quarantine.%'`); got != 0 {
+		t.Errorf("quarantine audits = %d, want 0", got)
+	}
+}
+
+// REF §A1's header contract on the routes this task adds: nosniff on every
+// answer, and no CSP — that one belongs to the SPA (package web), where there
+// is a document to constrain.
+func TestInboxResponsesCarryNoSniffAndNoCSP(t *testing.T) {
+	app := testrig.App(t)
+	cookie, slug := app.CompleteSetup(t)
+	createProvider(t, app, cookie, slug, "netflix", "Netflix")
+
+	for _, path := range []string{"/providers", "/providers/netflix", "/providers/nope", "/quarantine"} {
+		t.Run(path, func(t *testing.T) {
+			rec := app.Do(t, http.MethodGet, inboxPath(slug, path), nil, testrig.WithCookie(cookie))
+			if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+				t.Errorf("X-Content-Type-Options = %q, want nosniff (status %d)", got, rec.Code)
+			}
+			if got := rec.Header().Get("Content-Security-Policy"); got != "" {
+				t.Errorf("Content-Security-Policy = %q, want none on an API response", got)
+			}
+		})
+	}
+}
+
+// ptrTo is the address of a value, for the optional columns a seeded message
+// carries.
+func ptrTo[T any](value T) *T { return &value }

--- a/apps/server/internal/api/mi-casa.yaml
+++ b/apps/server/internal/api/mi-casa.yaml
@@ -381,6 +381,249 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /api/inbox/{slug}/providers:
+    get:
+      operationId: listInboxProviders
+      summary: >-
+        The inbox landing page: one tile per provider the caller may read,
+        with its message counts and a preview of the newest message.
+
+        A member route rather than an owner one, with the per-provider check
+        INSIDE it: an owner sees every provider in the household, a member
+        only the ones they have been granted. That is the whole point of
+        provider access — the household's mail is split per mailbox, not
+        per role.
+      tags: [inbox]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      responses:
+        "200":
+          description: The providers this caller may read.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProviderSummaryList"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not a member of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/inbox/{slug}/providers/{providerKey}:
+    get:
+      operationId: listProviderMessages
+      summary: >-
+        One provider's inbox, newest first, one keyset page at a time.
+
+        The 403 for a member without access to this provider is answered
+        BEFORE the provider is looked up, so a member cannot use the
+        difference between 403 and 404 to enumerate which providers the
+        household has.
+      tags: [inbox]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - name: providerKey
+          in: path
+          required: true
+          description: >-
+            The provider's key, scoped to the household in the path. Bounded
+            the way `revokeProviderAccess` bounds its own copy (REF §A4's
+            `providerAccess` rules), because a path parameter has no `fields`
+            entry to render a Go-side message against.
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 40
+        - $ref: "#/components/parameters/PageLimit"
+        - $ref: "#/components/parameters/PageBefore"
+      responses:
+        "200":
+          description: The page of messages, with the cursor for the next one.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InboxMessagePage"
+        "400":
+          description: The provider key or a page parameter is not of the stated shape.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: >-
+            The caller is not a member of this household, or is a member
+            without access to this provider.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: This household has no such provider.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/inbox/{slug}/messages/{messageId}/status:
+    patch:
+      operationId: updateMessageStatus
+      summary: >-
+        Mark one message new, used or expired — the "I have used this code"
+        button.
+
+        The message is looked up before the body is validated, deliberately:
+        a status the server does not know, sent for a message that is not
+        this household's, is answered 404 rather than 400, so the route never
+        confirms the existence of a message the caller may not read.
+      tags: [inbox]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/MessageId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MessageStatusRequest"
+      responses:
+        "200":
+          description: The message as it now stands.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InboxMessageResult"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: >-
+            The caller is not a member of this household, or is a member
+            without access to the message's provider.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: This household has no such message.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/inbox/{slug}/quarantine:
+    get:
+      operationId: listQuarantine
+      summary: >-
+        The needs-review queue: mail that could not be attributed to a
+        provider, unreviewed rows only, newest first.
+
+        Owner-only. Quarantined mail is by definition mail nobody has decided
+        who may read yet, so it cannot be shown behind per-provider access.
+      tags: [inbox]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/PageLimit"
+        - $ref: "#/components/parameters/PageBefore"
+      responses:
+        "200":
+          description: The page of quarantined messages, with the cursor for the next one.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QuarantineMessagePage"
+        "400":
+          description: A page parameter is not of the stated shape.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/inbox/{slug}/quarantine/{messageId}/review:
+    post:
+      operationId: reviewQuarantineMessage
+      summary: >-
+        Work through one needs-review row: dismiss it, or release it into a
+        provider's inbox.
+
+        A release copies the row into that provider's messages — keeping the
+        original received_at and delete_after, so releasing does not extend
+        retention — and marks the quarantine row reviewed, in one
+        transaction. Owner-only, and audited either way.
+      tags: [inbox]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/MessageId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/QuarantineReviewRequest"
+      responses:
+        "200":
+          description: >-
+            The review. `releasedMessage` is the stored copy for a release
+            and null for a dismissal.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QuarantineReviewResult"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: >-
+            This household has no such provider, or no such unreviewed
+            quarantine message.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /api/settings:
     get:
       operationId: getAccountSettings
@@ -1400,6 +1643,53 @@ components:
         type: string
         minLength: 1
         maxLength: 200
+    MessageId:
+      name: messageId
+      in: path
+      required: true
+      description: >-
+        A message's id — an inbox message for the status route, a quarantined
+        one for the review route. Scoped to the household in the path, so an
+        id from another household is a 404 rather than a leak.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 200
+    PageLimit:
+      name: limit
+      in: query
+      required: false
+      description: >-
+        How many rows to return. Clamped to 1..200 in Go, with 50 for a
+        missing value.
+
+        Deliberately declared WITHOUT `minimum`/`maximum`: the TypeScript
+        clamped an out-of-range limit rather than rejecting it, and a client
+        that asks for 9999 should get 200 rows, not a validation error on a
+        page it can no longer navigate away from.
+
+        The type IS stated, which is the one place this diverges from that
+        predecessor: `limit=abc` is a 400 from request validation here, where
+        the TypeScript's `Number(...)` turned it into NaN and fell back to the
+        default. Saying "integer" is worth that — a client sending a
+        non-number is broken, and every value a working client sends is
+        clamped rather than refused.
+      schema:
+        type: integer
+    PageBefore:
+      name: before
+      in: query
+      required: false
+      description: >-
+        The keyset cursor: return only rows older than this instant, which is
+        the previous page's `nextBefore`.
+
+        Declared as a plain string rather than `format: date-time` for the
+        same reason `limit` has no bounds: a cursor that does not parse is
+        IGNORED (the newest page is returned) rather than rejected, exactly as
+        the TypeScript's normalizePageOptions did.
+      schema:
+        type: string
   schemas:
     Ok:
       type: object
@@ -2139,3 +2429,253 @@ components:
           type: boolean
         emailError:
           type: string
+    ProviderSummary:
+      type: object
+      description: >-
+        One provider's tile on the inbox landing page: its counts plus a
+        preview of the newest message. snake_case keys, deliberately: it is
+        what the TypeScript returned and what the SPA reads.
+
+        The `latest_*` fields are null — present and null, never missing —
+        for a provider that has received nothing yet.
+      required:
+        [
+          household_slug,
+          provider_key,
+          display_name,
+          message_count,
+          new_count,
+          latest_received_at,
+          latest_message_id,
+          latest_subject,
+          latest_code,
+          latest_status,
+        ]
+      properties:
+        household_slug:
+          type: string
+        provider_key:
+          type: string
+        display_name:
+          type: string
+        message_count:
+          type: integer
+        new_count:
+          type: integer
+        latest_received_at:
+          type: string
+          format: date-time
+          nullable: true
+        latest_message_id:
+          type: string
+          nullable: true
+        latest_subject:
+          type: string
+          nullable: true
+        latest_code:
+          type: string
+          nullable: true
+        latest_status:
+          type: string
+          nullable: true
+    ProviderSummaryList:
+      type: object
+      required: [providers]
+      properties:
+        providers:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProviderSummary"
+    InboxProvider:
+      type: object
+      description: >-
+        Which provider a page of messages belongs to. camelCase here while the
+        rows below are snake_case, because that is the shape the SPA has read
+        since the Workers deployment.
+      required: [providerKey, displayName]
+      properties:
+        providerKey:
+          type: string
+        displayName:
+          type: string
+    InboxMessage:
+      type: object
+      description: One message in a provider's inbox. snake_case keys, as above.
+      required:
+        [
+          id,
+          household_slug,
+          provider_key,
+          provider_display_name,
+          subject,
+          from_header,
+          text_body,
+          extracted_code,
+          status,
+          received_at,
+        ]
+      properties:
+        id:
+          type: string
+        household_slug:
+          type: string
+        provider_key:
+          type: string
+        provider_display_name:
+          type: string
+        subject:
+          type: string
+          nullable: true
+        from_header:
+          type: string
+          nullable: true
+        text_body:
+          type: string
+        extracted_code:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum: [new, used, expired]
+        received_at:
+          type: string
+          format: date-time
+    QuarantineMessage:
+      type: object
+      description: >-
+        One row of the needs-review queue. `provider_key` and
+        `provider_display_name` are the literals "quarantine" and
+        "Quarantine" so the SPA can render it with the same component as an
+        inbox row, and `envelope_from` is included because who the mail
+        server said sent it is the main thing an owner reviews.
+      required:
+        [
+          id,
+          household_slug,
+          provider_key,
+          provider_display_name,
+          subject,
+          from_header,
+          envelope_from,
+          text_body,
+          extracted_code,
+          status,
+          quarantine_reason,
+          received_at,
+        ]
+      properties:
+        id:
+          type: string
+        household_slug:
+          type: string
+        provider_key:
+          type: string
+        provider_display_name:
+          type: string
+        subject:
+          type: string
+          nullable: true
+        from_header:
+          type: string
+          nullable: true
+        envelope_from:
+          type: string
+        text_body:
+          type: string
+        extracted_code:
+          type: string
+          nullable: true
+        status:
+          type: string
+        quarantine_reason:
+          type: string
+        received_at:
+          type: string
+          format: date-time
+    PageInfo:
+      type: object
+      description: >-
+        The keyset page the server actually served: the limit it applied
+        (after clamping) and the cursor for the next, older page.
+
+        `nextBefore` is null when this was the last page, which is what the
+        SPA checks to decide whether to offer "load more".
+      required: [limit, nextBefore]
+      properties:
+        limit:
+          type: integer
+        nextBefore:
+          type: string
+          format: date-time
+          nullable: true
+    InboxMessagePage:
+      type: object
+      required: [provider, messages, page]
+      properties:
+        provider:
+          $ref: "#/components/schemas/InboxProvider"
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/InboxMessage"
+        page:
+          $ref: "#/components/schemas/PageInfo"
+    QuarantineMessagePage:
+      type: object
+      required: [messages, page]
+      properties:
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/QuarantineMessage"
+        page:
+          $ref: "#/components/schemas/PageInfo"
+    InboxMessageResult:
+      type: object
+      required: [message]
+      properties:
+        message:
+          $ref: "#/components/schemas/InboxMessage"
+    MessageStatusRequest:
+      type: object
+      description: >-
+        REF §A4's `messageStatus` schema. `status` is a plain string rather
+        than an enum for the same reason `matchType` is (see
+        SenderRuleRequest): the rejection must read "status must be new, used
+        or expired", and an enum violation cannot say that.
+      required: [status]
+      properties:
+        status:
+          type: string
+          description: "`new`, `used` or `expired`."
+    QuarantineReviewRequest:
+      type: object
+      description: >-
+        REF §A4's `quarantineReview` schema. `action` is a plain string for
+        the reason MessageStatusRequest's `status` is; `providerKey` is
+        required in practice for a release, but the 400 that says so is the
+        handler's, because it names the field.
+      required: [action]
+      properties:
+        action:
+          type: string
+          description: "`dismiss` or `release`."
+        providerKey:
+          type: string
+          description: >-
+            The provider to release into. Trimmed, lower-cased, 1..40.
+            Required for a release, ignored for a dismissal.
+    QuarantineReviewResult:
+      type: object
+      description: >-
+        The outcome of one review. `releasedMessage` is the stored copy for a
+        release and null for a dismissal — present and null, never missing.
+      required: [reviewedAt, releasedMessage]
+      properties:
+        reviewedAt:
+          type: string
+          format: date-time
+        releasedMessage:
+          nullable: true
+          allOf:
+            - $ref: "#/components/schemas/InboxMessage"

--- a/apps/server/internal/api/routes.go
+++ b/apps/server/internal/api/routes.go
@@ -94,6 +94,19 @@ var operationAuthTiers = map[string]authTier{
 	"RevokeOtherSessions":    tierSession,
 	"RevokeSession":          tierSession,
 
+	// Inbox (REF §A2, "Inbox — member of :slug"). The tiers are NOT uniform
+	// here, and the split is the point: reading mail is scoped per provider,
+	// so the three message routes are tierHousehold and check provider access
+	// INSIDE the handler (an owner sees everything; a member only what they
+	// were granted). Quarantine is tierOwner because a quarantined message is
+	// by definition one nobody has yet decided who may read — there is no
+	// provider to scope it by, so it cannot be shown to a member at all.
+	"ListInboxProviders":      tierHousehold,
+	"ListProviderMessages":    tierHousehold,
+	"UpdateMessageStatus":     tierHousehold,
+	"ListQuarantine":          tierOwner,
+	"ReviewQuarantineMessage": tierOwner,
+
 	// Admin (REF §A2, "Admin — owner of :slug"). Every one of them, without
 	// exception: the TypeScript mounted requireHouseholdContext and
 	// requireOwner on `/:slug/*` for the whole admin router, so "owner" was a

--- a/openapi/mi-casa.yaml
+++ b/openapi/mi-casa.yaml
@@ -381,6 +381,249 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /api/inbox/{slug}/providers:
+    get:
+      operationId: listInboxProviders
+      summary: >-
+        The inbox landing page: one tile per provider the caller may read,
+        with its message counts and a preview of the newest message.
+
+        A member route rather than an owner one, with the per-provider check
+        INSIDE it: an owner sees every provider in the household, a member
+        only the ones they have been granted. That is the whole point of
+        provider access — the household's mail is split per mailbox, not
+        per role.
+      tags: [inbox]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+      responses:
+        "200":
+          description: The providers this caller may read.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProviderSummaryList"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not a member of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/inbox/{slug}/providers/{providerKey}:
+    get:
+      operationId: listProviderMessages
+      summary: >-
+        One provider's inbox, newest first, one keyset page at a time.
+
+        The 403 for a member without access to this provider is answered
+        BEFORE the provider is looked up, so a member cannot use the
+        difference between 403 and 404 to enumerate which providers the
+        household has.
+      tags: [inbox]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - name: providerKey
+          in: path
+          required: true
+          description: >-
+            The provider's key, scoped to the household in the path. Bounded
+            the way `revokeProviderAccess` bounds its own copy (REF §A4's
+            `providerAccess` rules), because a path parameter has no `fields`
+            entry to render a Go-side message against.
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 40
+        - $ref: "#/components/parameters/PageLimit"
+        - $ref: "#/components/parameters/PageBefore"
+      responses:
+        "200":
+          description: The page of messages, with the cursor for the next one.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InboxMessagePage"
+        "400":
+          description: The provider key or a page parameter is not of the stated shape.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: >-
+            The caller is not a member of this household, or is a member
+            without access to this provider.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: This household has no such provider.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/inbox/{slug}/messages/{messageId}/status:
+    patch:
+      operationId: updateMessageStatus
+      summary: >-
+        Mark one message new, used or expired — the "I have used this code"
+        button.
+
+        The message is looked up before the body is validated, deliberately:
+        a status the server does not know, sent for a message that is not
+        this household's, is answered 404 rather than 400, so the route never
+        confirms the existence of a message the caller may not read.
+      tags: [inbox]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/MessageId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MessageStatusRequest"
+      responses:
+        "200":
+          description: The message as it now stands.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InboxMessageResult"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: >-
+            The caller is not a member of this household, or is a member
+            without access to the message's provider.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: This household has no such message.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/inbox/{slug}/quarantine:
+    get:
+      operationId: listQuarantine
+      summary: >-
+        The needs-review queue: mail that could not be attributed to a
+        provider, unreviewed rows only, newest first.
+
+        Owner-only. Quarantined mail is by definition mail nobody has decided
+        who may read yet, so it cannot be shown behind per-provider access.
+      tags: [inbox]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/PageLimit"
+        - $ref: "#/components/parameters/PageBefore"
+      responses:
+        "200":
+          description: The page of quarantined messages, with the cursor for the next one.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QuarantineMessagePage"
+        "400":
+          description: A page parameter is not of the stated shape.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/inbox/{slug}/quarantine/{messageId}/review:
+    post:
+      operationId: reviewQuarantineMessage
+      summary: >-
+        Work through one needs-review row: dismiss it, or release it into a
+        provider's inbox.
+
+        A release copies the row into that provider's messages — keeping the
+        original received_at and delete_after, so releasing does not extend
+        retention — and marks the quarantine row reviewed, in one
+        transaction. Owner-only, and audited either way.
+      tags: [inbox]
+      parameters:
+        - $ref: "#/components/parameters/HouseholdSlug"
+        - $ref: "#/components/parameters/MessageId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/QuarantineReviewRequest"
+      responses:
+        "200":
+          description: >-
+            The review. `releasedMessage` is the stored copy for a release
+            and null for a dismissal.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QuarantineReviewResult"
+        "400":
+          description: The request was rejected. See the envelope's `error` (and `fields`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: No session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: The caller is not an owner of this household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: >-
+            This household has no such provider, or no such unreviewed
+            quarantine message.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /api/settings:
     get:
       operationId: getAccountSettings
@@ -1400,6 +1643,53 @@ components:
         type: string
         minLength: 1
         maxLength: 200
+    MessageId:
+      name: messageId
+      in: path
+      required: true
+      description: >-
+        A message's id — an inbox message for the status route, a quarantined
+        one for the review route. Scoped to the household in the path, so an
+        id from another household is a 404 rather than a leak.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 200
+    PageLimit:
+      name: limit
+      in: query
+      required: false
+      description: >-
+        How many rows to return. Clamped to 1..200 in Go, with 50 for a
+        missing value.
+
+        Deliberately declared WITHOUT `minimum`/`maximum`: the TypeScript
+        clamped an out-of-range limit rather than rejecting it, and a client
+        that asks for 9999 should get 200 rows, not a validation error on a
+        page it can no longer navigate away from.
+
+        The type IS stated, which is the one place this diverges from that
+        predecessor: `limit=abc` is a 400 from request validation here, where
+        the TypeScript's `Number(...)` turned it into NaN and fell back to the
+        default. Saying "integer" is worth that — a client sending a
+        non-number is broken, and every value a working client sends is
+        clamped rather than refused.
+      schema:
+        type: integer
+    PageBefore:
+      name: before
+      in: query
+      required: false
+      description: >-
+        The keyset cursor: return only rows older than this instant, which is
+        the previous page's `nextBefore`.
+
+        Declared as a plain string rather than `format: date-time` for the
+        same reason `limit` has no bounds: a cursor that does not parse is
+        IGNORED (the newest page is returned) rather than rejected, exactly as
+        the TypeScript's normalizePageOptions did.
+      schema:
+        type: string
   schemas:
     Ok:
       type: object
@@ -2139,3 +2429,253 @@ components:
           type: boolean
         emailError:
           type: string
+    ProviderSummary:
+      type: object
+      description: >-
+        One provider's tile on the inbox landing page: its counts plus a
+        preview of the newest message. snake_case keys, deliberately: it is
+        what the TypeScript returned and what the SPA reads.
+
+        The `latest_*` fields are null — present and null, never missing —
+        for a provider that has received nothing yet.
+      required:
+        [
+          household_slug,
+          provider_key,
+          display_name,
+          message_count,
+          new_count,
+          latest_received_at,
+          latest_message_id,
+          latest_subject,
+          latest_code,
+          latest_status,
+        ]
+      properties:
+        household_slug:
+          type: string
+        provider_key:
+          type: string
+        display_name:
+          type: string
+        message_count:
+          type: integer
+        new_count:
+          type: integer
+        latest_received_at:
+          type: string
+          format: date-time
+          nullable: true
+        latest_message_id:
+          type: string
+          nullable: true
+        latest_subject:
+          type: string
+          nullable: true
+        latest_code:
+          type: string
+          nullable: true
+        latest_status:
+          type: string
+          nullable: true
+    ProviderSummaryList:
+      type: object
+      required: [providers]
+      properties:
+        providers:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProviderSummary"
+    InboxProvider:
+      type: object
+      description: >-
+        Which provider a page of messages belongs to. camelCase here while the
+        rows below are snake_case, because that is the shape the SPA has read
+        since the Workers deployment.
+      required: [providerKey, displayName]
+      properties:
+        providerKey:
+          type: string
+        displayName:
+          type: string
+    InboxMessage:
+      type: object
+      description: One message in a provider's inbox. snake_case keys, as above.
+      required:
+        [
+          id,
+          household_slug,
+          provider_key,
+          provider_display_name,
+          subject,
+          from_header,
+          text_body,
+          extracted_code,
+          status,
+          received_at,
+        ]
+      properties:
+        id:
+          type: string
+        household_slug:
+          type: string
+        provider_key:
+          type: string
+        provider_display_name:
+          type: string
+        subject:
+          type: string
+          nullable: true
+        from_header:
+          type: string
+          nullable: true
+        text_body:
+          type: string
+        extracted_code:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum: [new, used, expired]
+        received_at:
+          type: string
+          format: date-time
+    QuarantineMessage:
+      type: object
+      description: >-
+        One row of the needs-review queue. `provider_key` and
+        `provider_display_name` are the literals "quarantine" and
+        "Quarantine" so the SPA can render it with the same component as an
+        inbox row, and `envelope_from` is included because who the mail
+        server said sent it is the main thing an owner reviews.
+      required:
+        [
+          id,
+          household_slug,
+          provider_key,
+          provider_display_name,
+          subject,
+          from_header,
+          envelope_from,
+          text_body,
+          extracted_code,
+          status,
+          quarantine_reason,
+          received_at,
+        ]
+      properties:
+        id:
+          type: string
+        household_slug:
+          type: string
+        provider_key:
+          type: string
+        provider_display_name:
+          type: string
+        subject:
+          type: string
+          nullable: true
+        from_header:
+          type: string
+          nullable: true
+        envelope_from:
+          type: string
+        text_body:
+          type: string
+        extracted_code:
+          type: string
+          nullable: true
+        status:
+          type: string
+        quarantine_reason:
+          type: string
+        received_at:
+          type: string
+          format: date-time
+    PageInfo:
+      type: object
+      description: >-
+        The keyset page the server actually served: the limit it applied
+        (after clamping) and the cursor for the next, older page.
+
+        `nextBefore` is null when this was the last page, which is what the
+        SPA checks to decide whether to offer "load more".
+      required: [limit, nextBefore]
+      properties:
+        limit:
+          type: integer
+        nextBefore:
+          type: string
+          format: date-time
+          nullable: true
+    InboxMessagePage:
+      type: object
+      required: [provider, messages, page]
+      properties:
+        provider:
+          $ref: "#/components/schemas/InboxProvider"
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/InboxMessage"
+        page:
+          $ref: "#/components/schemas/PageInfo"
+    QuarantineMessagePage:
+      type: object
+      required: [messages, page]
+      properties:
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/QuarantineMessage"
+        page:
+          $ref: "#/components/schemas/PageInfo"
+    InboxMessageResult:
+      type: object
+      required: [message]
+      properties:
+        message:
+          $ref: "#/components/schemas/InboxMessage"
+    MessageStatusRequest:
+      type: object
+      description: >-
+        REF §A4's `messageStatus` schema. `status` is a plain string rather
+        than an enum for the same reason `matchType` is (see
+        SenderRuleRequest): the rejection must read "status must be new, used
+        or expired", and an enum violation cannot say that.
+      required: [status]
+      properties:
+        status:
+          type: string
+          description: "`new`, `used` or `expired`."
+    QuarantineReviewRequest:
+      type: object
+      description: >-
+        REF §A4's `quarantineReview` schema. `action` is a plain string for
+        the reason MessageStatusRequest's `status` is; `providerKey` is
+        required in practice for a release, but the 400 that says so is the
+        handler's, because it names the field.
+      required: [action]
+      properties:
+        action:
+          type: string
+          description: "`dismiss` or `release`."
+        providerKey:
+          type: string
+          description: >-
+            The provider to release into. Trimmed, lower-cased, 1..40.
+            Required for a release, ignored for a dismissal.
+    QuarantineReviewResult:
+      type: object
+      description: >-
+        The outcome of one review. `releasedMessage` is the stored copy for a
+        release and null for a dismissal — present and null, never missing.
+      required: [reviewedAt, releasedMessage]
+      properties:
+        reviewedAt:
+          type: string
+          format: date-time
+        releasedMessage:
+          nullable: true
+          allOf:
+            - $ref: "#/components/schemas/InboxMessage"


### PR DESCRIPTION
Phase P5 of the Go backend migration. Closes #216.

- `GET /api/inbox/{slug}/providers` (owner sees all, members only granted services), `GET /providers/{providerKey}` with keyset pagination (limit clamped 1..200, `before` cursor, `nextBefore`), `PATCH /messages/{id}/status`
- Owner-only `GET /quarantine` and `POST /quarantine/{id}/review` (dismiss, or release into a service in one transaction with the original reason preserved), audited
- Provider-access checks for members on every message-level route; cross-household isolation tested through the assembled handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yS5kEFd3AcfSkVidBs4Fj