### PR TITLE
feat(server): retention job, UTC scheduler and worker/cron modes (P7)

### DIFF
--- a/apps/server/cmd/mi-casa/main.go
+++ b/apps/server/cmd/mi-casa/main.go
@@ -17,8 +17,9 @@
 //	healthcheck            probe /healthz on this pod, exit 0/1
 //	anything else          complain, exit 2
 //
-// The scheduler itself arrives in P7; until then the `cron` and `worker`
-// modes exist so the deployment contract is fixed, but neither runs a job.
+// The scheduler (internal/cron) runs in the default and `worker` modes only,
+// never in `server`: it fires once per process, so every HTTP replica having
+// one would run the nightly purge once per replica.
 package main
 
 import (
@@ -30,6 +31,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -43,8 +45,10 @@ import (
 	"github.com/andersro93/mi-casa-su-casa/server/internal/api/respond"
 	"github.com/andersro93/mi-casa-su-casa/server/internal/auth"
 	"github.com/andersro93/mi-casa-su-casa/server/internal/config"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/cron"
 	"github.com/andersro93/mi-casa-su-casa/server/internal/db"
 	dbgen "github.com/andersro93/mi-casa-su-casa/server/internal/db/gen"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/jobs"
 	applog "github.com/andersro93/mi-casa-su-casa/server/internal/log"
 	"github.com/andersro93/mi-casa-su-casa/server/internal/mail"
 	"github.com/andersro93/mi-casa-su-casa/server/internal/ratelimit"
@@ -241,16 +245,55 @@ func migrateMode() int {
 
 // --- cron -------------------------------------------------------------
 
-// cronMode will run exactly one job and exit with a status a scheduler can
-// act on — a failed retention pass should show up as a failed job, not as a
-// line in a log nobody reads. The jobs themselves land in P7; until then
-// every invocation is a usage error, because exiting 0 having done nothing
-// is the one answer a scheduler must never get. The job name is accepted
-// and ignored for now so the signature (and the dispatch table above it)
-// does not change when the jobs land.
-func cronMode(_ string) int {
-	fmt.Fprintln(os.Stderr, "usage: mi-casa cron <retention>")
-	return 2
+// cronMode runs exactly one job and exits with a status a scheduler can act
+// on — a failed retention pass should show up as a failed job, not as a line
+// in a log nobody reads.
+//
+// An unknown (or missing) job name is a usage error and exit 2, checked
+// BEFORE any dependency is built: exiting 0 having done nothing is the one
+// answer a scheduler must never get, and a typo should fail the same way
+// whether or not the database happens to be reachable.
+//
+// No signal handling and no scheduler: this process exists to run one job
+// and leave. The context is Background for the reason migrateMode
+// documents — a SIGTERM mid-purge should not abort a batch halfway.
+func cronMode(job string) int {
+	if !cron.IsJob(job) {
+		fmt.Fprintf(os.Stderr, "usage: mi-casa cron <%s>\n", strings.Join(cron.Jobs, "|"))
+		return 2
+	}
+
+	cfg, err := config.FromOS()
+	if err != nil {
+		log.Printf("configuration error: %v", err)
+		return 1
+	}
+
+	deps, closeDeps, err := buildDeps(context.Background(), cfg)
+	if err != nil {
+		log.Printf("startup failed: %v", err)
+		return 1
+	}
+	defer closeDeps()
+
+	if err := cron.RunJob(context.Background(), job, jobDeps(deps)); err != nil {
+		log.Printf("cron %s failed: %v", job, err)
+		return 1
+	}
+	return 0
+}
+
+// jobDeps narrows the composed api.Deps to what the scheduled work needs.
+// One builder for both (buildDeps) rather than a second construction path,
+// so a job can never behave subtly differently from the same work done
+// in-process.
+func jobDeps(deps api.Deps) jobs.Deps {
+	return jobs.Deps{
+		Repo:      deps.Repo,
+		Q:         deps.Q,
+		RateLimit: deps.RateLimit,
+		Now:       deps.Now,
+	}
 }
 
 // --- serve ------------------------------------------------------------
@@ -301,24 +344,38 @@ func serveMode(migrate, scheduler bool) int {
 
 	log.Printf("mi-casa listening on http://0.0.0.0:%d", cfg.Port)
 	logStartupConfig(cfg)
+
+	// Started AFTER the listener is announced and only when this mode owns
+	// the scheduling: a `server` replica must never schedule (see run's
+	// modeServer branch), and starting it here rather than before the
+	// listener means a boot that fails to bind never leaves a timer behind.
+	stopScheduler := func() {}
 	if scheduler {
-		// P7 replaces this line with the in-process scheduler. It is logged
-		// rather than silently skipped so a single-container deployment
-		// does not look like it is running retention when it is not.
-		log.Print("  scheduler: not yet implemented (arrives in P7)")
+		stopScheduler = cron.StartScheduler(jobDeps(deps))
+		log.Printf("  scheduler: %s (UTC)", schedulerSummary())
 	}
 
-	return serveUntilSignal(sig, srv)
+	return serveUntilSignal(sig, srv, stopScheduler)
+}
+
+// schedulerSummary is the boot line's "what is scheduled" half — every job
+// and its expression, so an operator can tell from the log alone whether
+// this process is the one running the nightly purge.
+func schedulerSummary() string {
+	entries := make([]string, 0, len(cron.Jobs))
+	for _, job := range cron.Jobs {
+		entries = append(entries, fmt.Sprintf("%s at %q", job, cron.Schedules[job]))
+	}
+	return strings.Join(entries, ", ")
 }
 
 // --- worker -----------------------------------------------------------
 
-// workerMode will run ONLY the scheduler, for a deployment that scales the
-// HTTP tier (`server` mode) horizontally but still wants one long-running
-// process owning the cron-shaped work. Exactly one `worker` replica should
-// run at a time. The scheduler arrives in P7; until then this mode boots
-// its dependencies and serves nothing but the probe, which is enough to
-// pin the deployment shape.
+// workerMode runs ONLY the scheduler, for a deployment that scales the HTTP
+// tier (`server` mode) horizontally but still wants one long-running process
+// owning the cron-shaped work. Exactly one `worker` replica should run at a
+// time: the scheduler fires once per process, so two of them would run every
+// night'"'"'s purge twice.
 //
 // The bare /healthz on PORT is not optional: the image's HEALTHCHECK probes
 // /healthz regardless of mode, so without it a `worker` container would
@@ -337,11 +394,11 @@ func workerMode() int {
 	sig, stopSignals := notifyShutdown()
 	defer stopSignals()
 
-	// The dependencies are built and discarded: P7's scheduler is what will
-	// use them. Building them anyway keeps a worker that cannot reach the
-	// database from booting into a healthy-looking process that does
-	// nothing — the same boot-time failure the serving modes get.
-	_, closeDeps, err := buildDeps(context.Background(), cfg)
+	// Built through the same composition root the serving modes use, so the
+	// job cannot behave differently here than it does in-process — and so a
+	// worker that cannot reach the database fails at boot instead of coming
+	// up healthy and doing nothing.
+	deps, closeDeps, err := buildDeps(context.Background(), cfg)
 	if err != nil {
 		log.Printf("startup failed: %v", err)
 		return 1
@@ -355,11 +412,13 @@ func workerMode() int {
 		IdleTimeout:       idleTimeout,
 	}
 
+	stopScheduler := cron.StartScheduler(jobDeps(deps))
+
 	log.Printf("mi-casa worker: healthz on http://0.0.0.0:%d", cfg.Port)
-	log.Print("  scheduler: not yet implemented (arrives in P7)")
+	log.Printf("  scheduler: %s (UTC)", schedulerSummary())
 	logStartupConfig(cfg)
 
-	return serveUntilSignal(sig, srv)
+	return serveUntilSignal(sig, srv, stopScheduler)
 }
 
 // workerHandler is the worker's entire HTTP surface: liveness and nothing
@@ -433,8 +492,14 @@ func signalName(s os.Signal) string {
 }
 
 // serveUntilSignal runs srv until it fails or a shutdown signal arrives on
-// sig, then drains in-flight requests.
-func serveUntilSignal(sig <-chan os.Signal, srv *http.Server) int {
+// sig, then stops the scheduler and drains in-flight requests.
+//
+// stopScheduler runs BEFORE the HTTP drain, and runs on either exit path.
+// Order matters: stopping the scheduler first means no new job starts while
+// the server is draining, and the scheduler'"'"'s own grace period (bounded, see
+// internal/cron) overlaps nothing rather than eating into the drain window.
+// Pass a no-op for a mode that schedules nothing.
+func serveUntilSignal(sig <-chan os.Signal, srv *http.Server, stopScheduler func()) int {
 	errc := make(chan error, 1)
 	go func() {
 		errc <- srv.ListenAndServe()
@@ -442,6 +507,7 @@ func serveUntilSignal(sig <-chan os.Signal, srv *http.Server) int {
 
 	select {
 	case err := <-errc:
+		stopScheduler()
 		// The listener died on its own — a port already in use, most
 		// likely. ErrServerClosed cannot reach here (nothing has called
 		// Shutdown yet), so any error is fatal.
@@ -453,6 +519,7 @@ func serveUntilSignal(sig <-chan os.Signal, srv *http.Server) int {
 
 	case s := <-sig:
 		log.Printf("%s received, shutting down", signalName(s))
+		stopScheduler()
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
 		if err := srv.Shutdown(shutdownCtx); err != nil {

--- a/apps/server/cmd/mi-casa/main_test.go
+++ b/apps/server/cmd/mi-casa/main_test.go
@@ -31,9 +31,13 @@ func TestParseArgs(t *testing.T) {
 		{"migrations is an alias for migrate", []string{"migrations"}, dispatch{mode: modeMigrate, raw: "migrations"}},
 		{"healthcheck", []string{"healthcheck"}, dispatch{mode: modeHealthcheck, raw: "healthcheck"}},
 
-		{"cron with a job", []string{"cron", "retention"}, dispatch{mode: modeCron, raw: "cron", job: "retention"}},
+		{"cron retention", []string{"cron", "retention"}, dispatch{mode: modeCron, raw: "cron", job: "retention"}},
 		{"cron with no job at all", []string{"cron"}, dispatch{mode: modeCron, raw: "cron"}},
-		{"cron with an unknown job stays cron", []string{"cron", "hourly"}, dispatch{mode: modeCron, raw: "cron", job: "hourly"}},
+		// An unknown job stays `cron`: parseArgs does not know which jobs
+		// exist (internal/cron does), and cronMode is where the name is
+		// checked — so a bogus name reaches a usage error rather than the
+		// generic unknown-mode one, which would name the wrong thing.
+		{"cron bogus", []string{"cron", "bogus"}, dispatch{mode: modeCron, raw: "cron", job: "bogus"}},
 
 		{"a typo is not the server", []string{"migrationz"}, dispatch{mode: modeUnknown, raw: "migrationz"}},
 		{"case matters", []string{"Server"}, dispatch{mode: modeUnknown, raw: "Server"}},
@@ -49,15 +53,30 @@ func TestParseArgs(t *testing.T) {
 	}
 }
 
-// No job exists until P7, so every `cron` invocation prints usage and exits
-// 2. It must do so before building anything, which is what lets this test
-// run with no database in sight — a cronMode that constructed deps first
-// would fail here on a missing DATABASE_URL instead of returning 2.
-func TestCronModeIsUsageOnlyUntilTheSchedulerLands(t *testing.T) {
-	for _, job := range []string{"", "retention", "Retention", "nonsense"} {
+// A name that is not a job prints usage and exits 2, and does so BEFORE
+// building anything — which is what lets this test run with no database in
+// sight. A cronMode that constructed deps first would fail here on a missing
+// DATABASE_URL and return 1, turning "you typed the job name wrong" into
+// "the database is down".
+func TestCronModeRejectsAnUnknownJobBeforeTouchingAnything(t *testing.T) {
+	t.Setenv("DATABASE_URL", "")
+
+	for _, job := range []string{"", "Retention", "retention ", "nonsense"} {
 		if got := cronMode(job); got != 2 {
 			t.Errorf("cronMode(%q) = %d, want 2", job, got)
 		}
+	}
+}
+
+// A real job name goes the other way: it is accepted, and the run fails on
+// whatever comes next — here, unloadable configuration, which is exit 1 and
+// not the usage code. That is the whole distinction a scheduler acts on: 2
+// means "your manifest is wrong", 1 means "the run failed".
+func TestCronModeAcceptsAKnownJobAndFailsOnConfiguration(t *testing.T) {
+	t.Setenv("DATABASE_URL", "")
+
+	if got := cronMode("retention"); got != 1 {
+		t.Errorf("cronMode(retention) with unloadable config = %d, want 1", got)
 	}
 }
 

--- a/apps/server/go.mod
+++ b/apps/server/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/oapi-codegen/runtime v1.7.0
 	github.com/pquerna/otp v1.4.0
 	github.com/pressly/goose/v3 v3.28.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/thecodearcher/limen v0.2.1
 	github.com/thecodearcher/limen/adapters/sql v0.2.0
 	github.com/thecodearcher/limen/plugins/credential-password v0.2.0

--- a/apps/server/go.sum
+++ b/apps/server/go.sum
@@ -73,6 +73,8 @@ github.com/pressly/goose/v3 v3.28.0 h1:D2M+iL31GmpZxSHOhX8mqyqAT3CXnokUmm0eKoSP+
 github.com/pressly/goose/v3 v3.28.0/go.mod h1:v26MOuB8bL3kzzrt3Vqhb3R0PRVsl8hFQKdrht/L6Rk=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.16.0 h1:O9DK+vNMDVGLr2BeZqmpLeMjiMNkuXfcqntWbZV6S5g=
 github.com/rogpeppe/go-internal v1.16.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 h1:1EYB5IzjZawrrnELUi78f9fPu57HuXjmddZPjrls/28=

--- a/apps/server/internal/api/admin_invitations.go
+++ b/apps/server/internal/api/admin_invitations.go
@@ -35,7 +35,7 @@ func (s server) ListInvitations(ctx context.Context, _ gen.ListInvitationsReques
 		return gen.ListInvitations403JSONResponse(errorBody("Forbidden")), nil
 	}
 
-	if err := s.Repo.RefreshExpiredInvitations(ctx, s.Now(), &household.ID); err != nil {
+	if _, err := s.Repo.RefreshExpiredInvitations(ctx, s.Now(), &household.ID); err != nil {
 		return nil, err
 	}
 	invitations, err := s.Repo.ListInvitations(ctx, household.ID)
@@ -121,7 +121,7 @@ func (s server) ResendInvitation(ctx context.Context, request gen.ResendInvitati
 	// Expiring stale invitations first is what makes "not resendable" true of
 	// an invitation whose deadline has passed: the service only reissues a
 	// pending one.
-	if err := s.Repo.RefreshExpiredInvitations(ctx, s.Now(), &household.ID); err != nil {
+	if _, err := s.Repo.RefreshExpiredInvitations(ctx, s.Now(), &household.ID); err != nil {
 		return nil, err
 	}
 

--- a/apps/server/internal/cron/cron.go
+++ b/apps/server/internal/cron/cron.go
@@ -1,0 +1,154 @@
+// Package cron owns Mi Casa Su Casa's scheduled work: which jobs exist, when
+// they fire, and the in-process scheduler that fires them. internal/jobs
+// holds what each one DOES; the exit code a CLI invocation turns a run into
+// belongs to cmd/mi-casa, which owns every process exit.
+//
+// One job, matching the single cron expression the Workers deployment
+// carried in wrangler.jsonc:
+//
+//	retention  — 0 3 * * *    purge expired mail, expire invitations,
+//	                          record the run, sweep both rate limiters
+//
+// Cloudflare guaranteed exactly one invocation per schedule however many
+// isolates were warm. NOTHING guarantees that here: with several replicas,
+// an in-process timer in every one of them would run the purge once per
+// replica. The purge is idempotent, so that is wasteful rather than wrong —
+// but it is still wrong enough to design against. That is why RunJob is
+// exposed as a one-shot an external scheduler can invoke
+// (`mi-casa cron retention`), and why StartScheduler runs only under the
+// default single-container mode or the dedicated `worker` mode — never under
+// `server`, which is what replicas run.
+package cron
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"runtime/debug"
+	"time"
+
+	robfig "github.com/robfig/cron/v3"
+
+	"github.com/andersro93/mi-casa-su-casa/server/internal/jobs"
+)
+
+// Jobs is every dispatchable job name, in the order `mi-casa cron` prints
+// them in its usage line.
+var Jobs = []string{"retention"}
+
+// Schedules maps each job to its cron expression. Interpreted in UTC — see
+// StartScheduler for why that is a contract rather than a default.
+var Schedules = map[string]string{
+	"retention": "0 3 * * *",
+}
+
+// IsJob reports whether name is a dispatchable job. Exact match: "Retention"
+// and "retention " are not jobs, and a scheduled-job argument that misses by
+// a character should fail loudly rather than nearly work.
+func IsJob(name string) bool {
+	for _, job := range Jobs {
+		if job == name {
+			return true
+		}
+	}
+	return false
+}
+
+// RunJob runs one job to completion and returns the first error it hit.
+//
+// The job does its own logging (internal/jobs writes the runbook's
+// retention_completed / retention_failed lines), so there is nothing to
+// print here: this is dispatch and nothing else.
+func RunJob(ctx context.Context, name string, d jobs.Deps) error {
+	switch name {
+	case "retention":
+		_, err := jobs.Retention(ctx, d)
+		return err
+	default:
+		// Never a silent no-op: an unrecognised name is what a typo'd
+		// scheduled-job argument looks like, and a job that exits 0 having
+		// done nothing is worse than one that fails.
+		return fmt.Errorf("cron: unknown job %q (expected one of: %v)", name, Jobs)
+	}
+}
+
+// schedulerStopGrace bounds how long the stop function returned by
+// StartScheduler waits for an in-flight job before giving up on it. A purge
+// that is mid-batch when SIGTERM arrives is worth a few seconds; one wedged
+// on an unresponsive database is not worth hanging the whole shutdown for,
+// because the orchestrator's own grace period will SIGKILL us anyway and an
+// unbounded wait just turns a clean exit into a killed one. The purge is
+// batched and idempotent, so an abandoned run simply resumes tomorrow.
+const schedulerStopGrace = 10 * time.Second
+
+// StartScheduler starts the in-process scheduler and returns a function that
+// stops it.
+//
+// The location is UTC EXPLICITLY. robfig/cron defaults to time.Local and the
+// image sets no TZ, so UTC would be an accident of the base image rather
+// than a contract — while the 30-day retention window this job enforces is a
+// privacy commitment stated in UTC. "0 3 * * *" resolves to 03:00Z under UTC
+// and 01:00Z under Europe/Oslo, which is a silently wrong purge time and a
+// silently wrong retention boundary.
+//
+// Every invocation goes through runSafely: robfig/cron runs each job in its
+// own goroutine, so a panic inside one would take down the entire process
+// rather than just that run (a goroutine panic is not recoverable by the
+// caller). Catching it here turns a transient database blip into a logged
+// line instead of a pod restart loop, and the job is rescheduled normally.
+//
+// NOTE: this fires once per replica. With more than one replica, drive the
+// job from an external scheduler (or exactly one dedicated `worker` replica)
+// rather than running `server` mode with this started too — see the package
+// comment.
+func StartScheduler(d jobs.Deps) func() {
+	c := newScheduler(d)
+	c.Start()
+
+	return func() {
+		stopped := c.Stop()
+		select {
+		case <-stopped.Done():
+		case <-time.After(schedulerStopGrace):
+			log.Printf("cron: stop grace elapsed with a job still running; leaving it behind")
+		}
+	}
+}
+
+// newScheduler builds the scheduler without starting it, so a test can read
+// back the entries it computed (StartScheduler hands out only a stop func,
+// deliberately: nothing in the program has any business reaching into the
+// running scheduler).
+func newScheduler(d jobs.Deps) *robfig.Cron {
+	c := robfig.New(robfig.WithLocation(time.UTC))
+
+	for _, job := range Jobs {
+		if _, err := c.AddFunc(Schedules[job], func() {
+			// A fresh background context per tick: the scheduler outlives
+			// any single request and a job must not be cancelled by one.
+			runSafely(context.Background(), job, func(ctx context.Context) error {
+				return RunJob(ctx, job, d)
+			})
+		}); err != nil {
+			// Schedules is a compile-time constant map validated by
+			// cron_test.go; a parse failure here means the source was edited
+			// to something invalid, which should be loud at boot rather than
+			// a job that silently never runs.
+			panic(fmt.Sprintf("cron: invalid schedule for %q: %v", job, err))
+		}
+	}
+	return c
+}
+
+// runSafely runs fn, logging (never propagating) both a returned error and a
+// panic: a panicking job must not kill the process.
+func runSafely(ctx context.Context, name string, fn func(context.Context) error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("cron: %s panicked: %v\n%s", name, r, debug.Stack())
+		}
+	}()
+	if err := fn(ctx); err != nil {
+		log.Printf("cron: %s failed: %v", name, err)
+	}
+}

--- a/apps/server/internal/cron/cron_test.go
+++ b/apps/server/internal/cron/cron_test.go
@@ -1,0 +1,164 @@
+// The tests live in `package cron` rather than `package cron_test` (the
+// convention everywhere else in this module) for one reason: runSafely, the
+// recover-and-log wrapper that keeps a panicking job from killing the
+// process, is unexported and has no observable effect through the exported
+// surface — StartScheduler would only exercise it on a real cron tick.
+// Testing it directly is the only way to prove the guarantee the package
+// comment states.
+package cron
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	robfig "github.com/robfig/cron/v3"
+
+	"github.com/andersro93/mi-casa-su-casa/server/internal/jobs"
+	applog "github.com/andersro93/mi-casa-su-casa/server/internal/log"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/testrig"
+)
+
+func depsFor(app *testrig.AppRig) jobs.Deps {
+	return jobs.Deps{
+		Repo:      app.Deps.Repo,
+		Q:         app.Rig.Q,
+		RateLimit: app.Deps.RateLimit,
+		Now:       app.Deps.Now,
+	}
+}
+
+func TestJobsAndSchedulesAgree(t *testing.T) {
+	if len(Jobs) != 1 || Jobs[0] != "retention" {
+		t.Fatalf("Jobs = %v, want [retention]", Jobs)
+	}
+	for _, job := range Jobs {
+		if _, ok := Schedules[job]; !ok {
+			t.Errorf("Schedules has no entry for %q", job)
+		}
+	}
+	if len(Schedules) != len(Jobs) {
+		t.Errorf("Schedules has %d entries, want %d", len(Schedules), len(Jobs))
+	}
+}
+
+// The expression is a contract, not a preference: retention is what keeps
+// the 30-day window a promise, and the window is stated in UTC. Asserting
+// against real UTC instants rather than comparing the string to itself is
+// what makes that check mean something.
+func TestRetentionScheduleParsesAndFiresAtThreeUTC(t *testing.T) {
+	parser := robfig.NewParser(robfig.Minute | robfig.Hour | robfig.Dom | robfig.Month | robfig.Dow)
+
+	schedule, err := parser.Parse(Schedules["retention"])
+	if err != nil {
+		t.Fatalf("parse retention schedule: %v", err)
+	}
+	got := schedule.Next(time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC))
+	if want := time.Date(2026, 3, 1, 3, 0, 0, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("retention next = %s, want %s", got, want)
+	}
+}
+
+// robfig/cron defaults to time.Local and the image sets no TZ, so UTC would
+// otherwise be an accident of the base image rather than a contract. This
+// asserts on the running scheduler's own entries: under Europe/Oslo the same
+// expression would come out as 01:00 or 02:00 UTC.
+func TestSchedulerRunsInUTC(t *testing.T) {
+	// newScheduler rather than StartScheduler: the assertion is on the
+	// entries the scheduler computed, and Entries() only has them once the
+	// scheduler is running.
+	c := newScheduler(jobs.Deps{})
+	c.Start()
+	defer c.Stop()
+
+	entries := c.Entries()
+	if len(entries) != len(Jobs) {
+		t.Fatalf("scheduler has %d entries, want %d", len(entries), len(Jobs))
+	}
+	next := entries[0].Next.UTC()
+	if next.Hour() != 3 || next.Minute() != 0 || next.Second() != 0 {
+		t.Errorf("next retention run is %s (%02d:%02d UTC), want 03:00 UTC",
+			entries[0].Next, next.Hour(), next.Minute())
+	}
+	if next.Before(time.Now().UTC()) {
+		t.Errorf("next retention run %s is in the past", next)
+	}
+}
+
+// An unrecognised job name must be an error, never a silent no-op: it is
+// what a typo'd scheduled-job argument looks like, and a job that exits 0
+// having done nothing is the worst possible outcome. The message names both
+// the bad input and the jobs that do exist, because the operator reading it
+// is looking at a one-line failure and nothing else.
+func TestRunJobUnknownNameErrorsAndListsTheJobs(t *testing.T) {
+	err := RunJob(context.Background(), "retentionn", jobs.Deps{})
+	if err == nil {
+		t.Fatal("RunJob(retentionn) = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "retentionn") {
+		t.Errorf("error %q does not name the bad job", err)
+	}
+	if !strings.Contains(err.Error(), "retention") {
+		t.Errorf("error %q does not list the jobs that exist", err)
+	}
+}
+
+// The dispatch really reaches the job: a run through RunJob records the run
+// the same way calling jobs.Retention directly would.
+func TestRunJobRetentionRunsTheJob(t *testing.T) {
+	app := testrig.App(t)
+	applog.SetOutput(io.Discard)
+	t.Cleanup(func() { applog.SetOutput(nil) })
+
+	if err := RunJob(t.Context(), "retention", depsFor(app)); err != nil {
+		t.Fatalf("RunJob(retention): %v", err)
+	}
+
+	installation, err := app.Rig.Q.GetInstallation(t.Context())
+	if err != nil {
+		t.Fatalf("GetInstallation: %v", err)
+	}
+	if !installation.LastRetentionRunAt.Valid {
+		t.Error("RunJob(retention) did not record the run")
+	}
+}
+
+func TestIsJob(t *testing.T) {
+	for _, name := range Jobs {
+		if !IsJob(name) {
+			t.Errorf("IsJob(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"", "Retention", "nightly", "retention "} {
+		if IsJob(name) {
+			t.Errorf("IsJob(%q) = true, want false", name)
+		}
+	}
+}
+
+// robfig/cron runs each job in its own goroutine, so a panic inside one
+// would take down the whole process rather than the run. runSafely is the
+// wrapper that stops it; a panic escaping here would restart-loop a pod
+// that is otherwise healthy.
+func TestRunSafelySwallowsPanicsAndErrors(t *testing.T) {
+	runSafely(context.Background(), "boom", func(context.Context) error {
+		panic("job exploded")
+	})
+	runSafely(context.Background(), "sad", func(context.Context) error {
+		return errors.New("job failed")
+	})
+	// Reaching here at all is the assertion: neither call unwound the stack.
+}
+
+// StartScheduler must hand back a stop function that actually stops, and it
+// must be safe to call even though no tick has fired.
+func TestStartSchedulerStops(t *testing.T) {
+	stop := StartScheduler(jobs.Deps{})
+	if stop == nil {
+		t.Fatal("StartScheduler returned a nil stop func")
+	}
+	stop()
+}

--- a/apps/server/internal/db/gen/invitations.sql.go
+++ b/apps/server/internal/db/gen/invitations.sql.go
@@ -406,7 +406,7 @@ func (q *Queries) MarkInvitationAccepted(ctx context.Context, arg MarkInvitation
 	return err
 }
 
-const refreshExpiredInvitations = `-- name: RefreshExpiredInvitations :exec
+const refreshExpiredInvitations = `-- name: RefreshExpiredInvitations :execrows
 UPDATE "household_invitations"
 SET "status" = 'expired',
     "updated_at" = now()
@@ -426,7 +426,14 @@ type RefreshExpiredInvitationsParams struct {
 //
 // household_id is optional: the invitations screen refreshes just its own
 // household before listing, while the nightly job sweeps them all.
-func (q *Queries) RefreshExpiredInvitations(ctx context.Context, arg RefreshExpiredInvitationsParams) error {
-	_, err := q.db.Exec(ctx, refreshExpiredInvitations, arg.Now, arg.HouseholdID)
-	return err
+//
+// :execrows rather than :exec because the retention job reports how many
+// invitations it expired (REF §A3's retention_completed sibling counts); the
+// admin screens ignore the number and only care that the sweep ran.
+func (q *Queries) RefreshExpiredInvitations(ctx context.Context, arg RefreshExpiredInvitationsParams) (int64, error) {
+	result, err := q.db.Exec(ctx, refreshExpiredInvitations, arg.Now, arg.HouseholdID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }

--- a/apps/server/internal/db/gen/ratelimit.sql.go
+++ b/apps/server/internal/db/gen/ratelimit.sql.go
@@ -47,6 +47,25 @@ func (q *Queries) HitRateLimit(ctx context.Context, arg HitRateLimitParams) (int
 	return count, err
 }
 
+const sweepAuthRateLimits = `-- name: SweepAuthRateLimits :execrows
+DELETE FROM "rate_limits"
+WHERE "expires_at" < $1
+`
+
+// The same housekeeping for Limen's own "rate_limits" table. Limen creates
+// the rows and never prunes them (Cloudflare KV expired them by itself; a
+// Postgres table does not), so the retention job sweeps both tables in one
+// pass rather than leaving the auth limiter's counters to grow without
+// bound. The two tables stay separate — different owners, different keys —
+// but nobody else is going to clean this one up.
+func (q *Queries) SweepAuthRateLimits(ctx context.Context, expiresAt pgtype.Timestamptz) (int64, error) {
+	result, err := q.db.Exec(ctx, sweepAuthRateLimits, expiresAt)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const sweepRateLimit = `-- name: SweepRateLimit :execrows
 DELETE FROM "rate_limit"
 WHERE "expires_at" < $1

--- a/apps/server/internal/db/queries/invitations.sql
+++ b/apps/server/internal/db/queries/invitations.sql
@@ -144,13 +144,17 @@ INNER JOIN "household_memberships"
 WHERE "household_invitation_provider_access"."invitation_id" = sqlc.arg(invitation_id)
 ON CONFLICT ("household_membership_id", "provider_id") DO NOTHING;
 
--- name: RefreshExpiredInvitations :exec
+-- name: RefreshExpiredInvitations :execrows
 -- Flips pending invitations whose expiry has passed. The comparison is
 -- against a caller-supplied timestamp, not now(), so the retention job and
 -- the admin screens agree on one clock and a test can pin both sides.
 --
 -- household_id is optional: the invitations screen refreshes just its own
 -- household before listing, while the nightly job sweeps them all.
+--
+-- :execrows rather than :exec because the retention job reports how many
+-- invitations it expired (REF §A3's retention_completed sibling counts); the
+-- admin screens ignore the number and only care that the sweep ran.
 UPDATE "household_invitations"
 SET "status" = 'expired',
     "updated_at" = now()

--- a/apps/server/internal/db/queries/ratelimit.sql
+++ b/apps/server/internal/db/queries/ratelimit.sql
@@ -27,3 +27,13 @@ RETURNING "count";
 -- something to prune by. Returns how many rows went.
 DELETE FROM "rate_limit"
 WHERE "expires_at" < $1;
+
+-- name: SweepAuthRateLimits :execrows
+-- The same housekeeping for Limen's own "rate_limits" table. Limen creates
+-- the rows and never prunes them (Cloudflare KV expired them by itself; a
+-- Postgres table does not), so the retention job sweeps both tables in one
+-- pass rather than leaving the auth limiter's counters to grow without
+-- bound. The two tables stay separate — different owners, different keys —
+-- but nobody else is going to clean this one up.
+DELETE FROM "rate_limits"
+WHERE "expires_at" < $1;

--- a/apps/server/internal/jobs/retention.go
+++ b/apps/server/internal/jobs/retention.go
@@ -1,0 +1,145 @@
+// Package jobs holds the work the scheduler runs, one exported function per
+// job, and nothing about WHEN it runs — that belongs to internal/cron, and
+// the exit code a CLI invocation turns it into belongs to cmd/mi-casa. The
+// split is what lets `mi-casa cron retention` and the in-process scheduler
+// share one implementation instead of two that drift.
+//
+// It is the Go port of src/server/jobs/retention.ts.
+package jobs
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/andersro93/mi-casa-su-casa/server/internal/db/gen"
+	applog "github.com/andersro93/mi-casa-su-casa/server/internal/log"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/ratelimit"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/repo"
+)
+
+// Deps is everything the scheduled work needs, handed in by cmd/mi-casa's
+// composition root exactly as it hands api.Deps to the HTTP layer. Nothing
+// here reads the environment or opens a connection.
+//
+// Q sits beside Repo because two of the job's steps have no repository
+// wrapper and want none: recording the run is a single UPDATE of a singleton
+// row, and sweeping Limen's rate-limit table is housekeeping for a table
+// this application does not otherwise own.
+//
+// Now is a function rather than a time so the scheduler's tick and a test's
+// pinned clock reach the job the same way: readiness later compares the
+// recorded run against the same clock the API reads, and a job that called
+// time.Now itself would make that comparison untestable.
+type Deps struct {
+	Repo      *repo.Repo
+	Q         *gen.Queries
+	RateLimit ratelimit.Store
+	Now       func() time.Time
+}
+
+// Result is what one retention pass did. Batches counts statements, not
+// rows: it is how an operator tells a healthy nightly run (two statements,
+// one per table) from a catch-up after days of cron silence.
+type Result struct {
+	MessagesPurged     int
+	QuarantinePurged   int
+	Batches            int
+	InvitationsExpired int
+	DurationMs         int64
+}
+
+// Retention is the nightly job: purge mail past its retention window, expire
+// pending invitations, record the run, and prune both rate limiters'
+// expired counters.
+//
+// The order matters in one place only: recording the run comes LAST, and
+// only on success. `last_retention_run_at` is what /readyz reports as
+// `retention.stale`, so stamping it before the work would turn a job that
+// has been failing every night for a week into a readiness probe that says
+// everything is fine — the exact failure the field exists to catch.
+//
+// The error is logged AND returned, the way retention.ts logged and
+// re-threw: the log line is for whoever greps the runbook's event names, and
+// the return value is what makes `mi-casa cron retention` exit non-zero so a
+// scheduler records a failed run rather than a silent one.
+//
+// The purge is bounded at repo.PurgeBatchSize rows per statement so a
+// catch-up run after a long outage never takes one enormous lock.
+func Retention(ctx context.Context, d Deps) (Result, error) {
+	startedAt := time.Now()
+	now := d.Now().UTC()
+	// The TypeScript logged an ISO string and the runbook's examples show
+	// one, so this stays a string rather than becoming a bare time.Time.
+	scheduledFor := now.Format(time.RFC3339Nano)
+
+	result, err := run(ctx, d, now)
+	result.DurationMs = time.Since(startedAt).Milliseconds()
+
+	if err != nil {
+		applog.Event(applog.LevelError, "retention_failed", map[string]any{
+			"scheduledFor": scheduledFor,
+			"durationMs":   result.DurationMs,
+			"error":        err.Error(),
+		})
+		return result, err
+	}
+
+	applog.Event(applog.LevelInfo, "retention_completed", map[string]any{
+		"scheduledFor":     scheduledFor,
+		"messagesPurged":   result.MessagesPurged,
+		"quarantinePurged": result.QuarantinePurged,
+		"batches":          result.Batches,
+		"durationMs":       result.DurationMs,
+	})
+	return result, nil
+}
+
+// run is Retention's body without the logging, so the success and failure
+// lines are written in exactly one place each.
+func run(ctx context.Context, d Deps, now time.Time) (Result, error) {
+	var result Result
+
+	purged, err := d.Repo.PurgeExpired(ctx, now, repo.PurgeBatchSize)
+	if err != nil {
+		return result, err
+	}
+	result.MessagesPurged = purged.Messages
+	result.QuarantinePurged = purged.Quarantine
+	result.Batches = purged.Batches
+
+	// nil household: every household in one pass. The admin screens sweep
+	// their own household before listing; this is the sweep that catches the
+	// households nobody opened.
+	expired, err := d.Repo.RefreshExpiredInvitations(ctx, now, nil)
+	if err != nil {
+		return result, err
+	}
+	result.InvitationsExpired = expired
+
+	if err := d.Q.RecordRetentionRun(ctx, timestamptz(now)); err != nil {
+		return result, err
+	}
+
+	// Both limiters, because neither prunes itself: ours through the Store
+	// the middleware counts through, Limen's through its own table. The
+	// Workers deployment got this for free from KV's TTLs; Postgres keeps
+	// every row until something deletes it.
+	if _, err := d.RateLimit.Sweep(ctx, now); err != nil {
+		return result, err
+	}
+	if _, err := d.Q.SweepAuthRateLimits(ctx, timestamptz(now)); err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
+// timestamptz adapts a Go time to the driver's parameter type. internal/repo
+// keeps its own unexported copy of this; four lines duplicated here are
+// cheaper than exporting a conversion helper from a package whose job is not
+// conversion.
+func timestamptz(t time.Time) pgtype.Timestamptz {
+	return pgtype.Timestamptz{Time: t.UTC(), Valid: true}
+}

--- a/apps/server/internal/jobs/retention_test.go
+++ b/apps/server/internal/jobs/retention_test.go
@@ -1,0 +1,366 @@
+// Ports test/integration/retention.test.ts and the job-level half of
+// test/integration/invitation-expiry.test.ts against a real Postgres: the
+// batching, the invitation sweep, the recorded run and the readiness field
+// that run feeds are the four things the nightly job exists to do, and every
+// one of them is a database fact rather than a call the job made.
+package jobs_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/andersro93/mi-casa-su-casa/server/internal/jobs"
+	applog "github.com/andersro93/mi-casa-su-casa/server/internal/log"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/ratelimit"
+	"github.com/andersro93/mi-casa-su-casa/server/internal/testrig"
+)
+
+// scheduledAt is the instant every test in this file pins both clocks to:
+// the job's Now and the readiness handler's, so "stale" is decided by the
+// recorded run rather than by how long the suite took to get here.
+var scheduledAt = time.Date(2026, 6, 1, 3, 0, 0, 0, time.UTC)
+
+// depsFor builds jobs.Deps the way cmd/mi-casa's composition root does, from
+// the rig's own collaborators.
+func depsFor(app *testrig.AppRig) jobs.Deps {
+	return jobs.Deps{
+		Repo:      app.Deps.Repo,
+		Q:         app.Rig.Q,
+		RateLimit: app.Deps.RateLimit,
+		Now:       app.Deps.Now,
+	}
+}
+
+// captureLogs redirects internal/log for the duration of one test.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buffer := &bytes.Buffer{}
+	applog.SetOutput(buffer)
+	t.Cleanup(func() { applog.SetOutput(nil) })
+	return buffer
+}
+
+// findEvent returns the first logged line whose "event" is name, decoded.
+func findEvent(t *testing.T, logs *bytes.Buffer, name string) map[string]any {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimSpace(logs.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var fields map[string]any
+		if err := json.Unmarshal([]byte(line), &fields); err != nil {
+			t.Fatalf("log line is not JSON: %q (%v)", line, err)
+		}
+		if fields["event"] == name {
+			return fields
+		}
+	}
+	t.Fatalf("no %q line in the log:\n%s", name, logs.String())
+	return nil
+}
+
+// seedMessages writes n expired-or-not messages for one provider in one
+// statement. generate_series rather than a loop: the batching assertion
+// needs more rows than the batch size, and 600 round trips would dominate
+// the test's runtime for no extra coverage.
+func seedMessages(t *testing.T, app *testrig.AppRig, householdID, providerID string, n int, deleteAfter time.Time) {
+	t.Helper()
+	if _, err := app.Rig.Pool.Exec(t.Context(), `
+		INSERT INTO "messages" (
+			"id", "message_id", "household_id", "provider_id", "envelope_from",
+			"envelope_to", "text_body", "classification_reason", "raw_size",
+			"received_at", "delete_after")
+		SELECT
+			'm-' || $4::text || '-' || i, '<m-' || $4::text || '-' || i || '@test>',
+			$1, $2, 'sender@service.example', 'casa@inbox.example.com',
+			'body', 'seeded', 1, $3::timestamptz - interval '30 days', $3::timestamptz
+		FROM generate_series(1, $5::int) AS i`,
+		householdID, providerID, deleteAfter, deleteAfter.Format(time.RFC3339), n,
+	); err != nil {
+		t.Fatalf("seed %d messages: %v", n, err)
+	}
+}
+
+// seedQuarantine is seedMessages for the needs-review table, which has no
+// provider and its own uniqueness constraint.
+func seedQuarantine(t *testing.T, app *testrig.AppRig, householdID string, n int, deleteAfter time.Time) {
+	t.Helper()
+	if _, err := app.Rig.Pool.Exec(t.Context(), `
+		INSERT INTO "quarantine_messages" (
+			"id", "message_id", "household_id", "envelope_from", "envelope_to",
+			"text_body", "quarantine_reason", "raw_size", "received_at", "delete_after")
+		SELECT
+			'q-' || $3::text || '-' || i, '<q-' || $3::text || '-' || i || '@test>',
+			$1, 'sender@service.example', 'casa@inbox.example.com',
+			'body', 'no rule matched', 1, $2::timestamptz - interval '30 days', $2::timestamptz
+		FROM generate_series(1, $4::int) AS i`,
+		householdID, deleteAfter, deleteAfter.Format(time.RFC3339), n,
+	); err != nil {
+		t.Fatalf("seed %d quarantine rows: %v", n, err)
+	}
+}
+
+// readyz drives GET /readyz through the whole handler and returns the
+// retention half of the payload.
+func readyz(t *testing.T, app *testrig.AppRig) map[string]any {
+	t.Helper()
+	rec := app.Do(t, http.MethodGet, "/readyz", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /readyz = %d, body %s", rec.Code, rec.Body.String())
+	}
+	body := app.JSON(t, rec)
+	retention, ok := body["retention"].(map[string]any)
+	if !ok {
+		t.Fatalf("readyz body has no retention object: %s", rec.Body.String())
+	}
+	return retention
+}
+
+// The whole job in one pass, exactly as retention.test.ts drove it: more
+// expired mail than one batch can hold, some mail that is not expired, an
+// invitation past its expiry beside a fresh one, and a /readyz that goes
+// from stale to fresh because of what the job recorded.
+func TestRetentionPurgesInBatchesExpiresInvitationsAndClearsStaleness(t *testing.T) {
+	app := testrig.App(t)
+	app.CompleteSetup(t)
+	app.SetNow(scheduledAt)
+
+	household, err := app.Deps.Repo.GetHouseholdBySlug(t.Context(), testrig.OwnerHouseholdSlug)
+	if err != nil || household == nil {
+		t.Fatalf("GetHouseholdBySlug: %v", err)
+	}
+	provider, err := app.Deps.Repo.CreateProvider(t.Context(), household.ID, "netflix", "Netflix")
+	if err != nil {
+		t.Fatalf("CreateProvider: %v", err)
+	}
+
+	// 600 > the job's batch of 500, so the message sweep takes two
+	// statements and the batch loop is genuinely exercised (the TypeScript
+	// test shrank the batch instead; the Go job's batch size is a constant
+	// the deployment relies on, so the fixture is what gets bigger).
+	expired := scheduledAt.Add(-24 * time.Hour)
+	fresh := scheduledAt.AddDate(0, 0, 30)
+	seedMessages(t, app, household.ID, provider.ID, 600, expired)
+	seedMessages(t, app, household.ID, provider.ID, 5, fresh)
+	seedQuarantine(t, app, household.ID, 3, expired)
+	seedQuarantine(t, app, household.ID, 1, fresh)
+
+	// One invitation that expired earlier the same day and one that has not
+	// (invitation-expiry.test.ts's first two cases, seen from the job).
+	expiredInvite := scheduledAt.Add(-8 * time.Hour)
+	app.Invite(t, testrig.OwnerHouseholdSlug, "late@example.com", "Late", "member", &expiredInvite)
+	app.Invite(t, testrig.OwnerHouseholdSlug, "soon@example.com", "Soon", "member", nil)
+
+	// Expired counters in BOTH limiters: ours and Limen's. Nothing else
+	// prunes either table.
+	if _, err := app.Rig.Pool.Exec(t.Context(),
+		`INSERT INTO "rate_limit" ("key", "count", "expires_at") VALUES ('app:setup:1:0', 1, $1)`,
+		scheduledAt.Add(-time.Hour),
+	); err != nil {
+		t.Fatalf("seed app rate limit: %v", err)
+	}
+	if _, err := app.Rig.Pool.Exec(t.Context(),
+		`INSERT INTO "rate_limits" ("key", "count", "expires_at") VALUES ('limen:signin:1', 1, $1)`,
+		scheduledAt.Add(-time.Hour),
+	); err != nil {
+		t.Fatalf("seed limen rate limit: %v", err)
+	}
+
+	before := readyz(t, app)
+	if before["lastRunAt"] != nil || before["stale"] != true {
+		t.Fatalf("readyz before the job = %+v, want {lastRunAt:null, stale:true}", before)
+	}
+
+	logs := captureLogs(t)
+	result, err := jobs.Retention(t.Context(), depsFor(app))
+	if err != nil {
+		t.Fatalf("Retention: %v", err)
+	}
+
+	if result.MessagesPurged != 600 {
+		t.Errorf("MessagesPurged = %d, want 600", result.MessagesPurged)
+	}
+	if result.QuarantinePurged != 3 {
+		t.Errorf("QuarantinePurged = %d, want 3", result.QuarantinePurged)
+	}
+	// Two statements for the 600 messages (500 then 100), one for the three
+	// quarantine rows: a short batch is what ends each table's loop.
+	if result.Batches != 3 {
+		t.Errorf("Batches = %d, want 3 (2 for messages, 1 for quarantine)", result.Batches)
+	}
+	if result.InvitationsExpired != 1 {
+		t.Errorf("InvitationsExpired = %d, want 1", result.InvitationsExpired)
+	}
+	if result.DurationMs < 0 {
+		t.Errorf("DurationMs = %d, want a non-negative duration", result.DurationMs)
+	}
+
+	if got := app.Count(t, "messages", ""); got != 5 {
+		t.Errorf("messages left = %d, want the 5 unexpired ones", got)
+	}
+	if got := app.Count(t, "quarantine_messages", ""); got != 1 {
+		t.Errorf("quarantine rows left = %d, want the 1 unexpired one", got)
+	}
+	if got := app.Count(t, "household_invitations", "status = 'expired'"); got != 1 {
+		t.Errorf("expired invitations = %d, want 1", got)
+	}
+	if got := app.Count(t, "household_invitations", "status = 'pending'"); got != 1 {
+		t.Errorf("pending invitations = %d, want the fresh one", got)
+	}
+	// Only the EXPIRED counters go: CompleteSetup left a live one of its
+	// own behind, and a sweep that took that too would reset a limiter
+	// mid-window.
+	if got := app.Count(t, "rate_limit", `"expires_at" < $1`, scheduledAt); got != 0 {
+		t.Errorf("expired app rate-limit counters left = %d, want 0", got)
+	}
+	if got := app.Count(t, "rate_limit", `"key" = 'app:setup:1:0'`); got != 0 {
+		t.Errorf("the seeded expired app counter survived the sweep")
+	}
+	if got := app.Count(t, "rate_limits", ""); got != 0 {
+		t.Errorf("Limen rate-limit counters left = %d, want 0", got)
+	}
+
+	installation, err := app.Rig.Q.GetInstallation(t.Context())
+	if err != nil {
+		t.Fatalf("GetInstallation: %v", err)
+	}
+	if !installation.LastRetentionRunAt.Valid || !installation.LastRetentionRunAt.Time.Equal(scheduledAt) {
+		t.Errorf("last_retention_run_at = %v, want %s", installation.LastRetentionRunAt, scheduledAt)
+	}
+
+	// REF §A7's field list, verbatim: the operations runbook tells people to
+	// grep these names.
+	completed := findEvent(t, logs, "retention_completed")
+	if completed["level"] != "info" {
+		t.Errorf("retention_completed level = %v, want info", completed["level"])
+	}
+	if completed["scheduledFor"] != scheduledAt.Format(time.RFC3339Nano) {
+		t.Errorf("scheduledFor = %v, want %s", completed["scheduledFor"], scheduledAt.Format(time.RFC3339Nano))
+	}
+	if completed["messagesPurged"] != float64(600) || completed["quarantinePurged"] != float64(3) ||
+		completed["batches"] != float64(3) {
+		t.Errorf("retention_completed counts = %+v", completed)
+	}
+	if _, ok := completed["durationMs"]; !ok {
+		t.Errorf("retention_completed has no durationMs: %+v", completed)
+	}
+
+	after := readyz(t, app)
+	if after["stale"] != false {
+		t.Errorf("readyz after the job = %+v, want stale:false", after)
+	}
+	lastRunAt, ok := after["lastRunAt"].(string)
+	if !ok {
+		t.Fatalf("readyz lastRunAt = %v, want the recorded instant", after["lastRunAt"])
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, lastRunAt)
+	if err != nil || !parsed.Equal(scheduledAt) {
+		t.Errorf("readyz lastRunAt = %q, want %s", lastRunAt, scheduledAt)
+	}
+}
+
+// An empty database still costs one statement per table, and must not be an
+// error: the job runs nightly whether or not anything expired.
+func TestRetentionOnAnEmptyDatabaseRecordsTheRun(t *testing.T) {
+	app := testrig.App(t)
+	app.SetNow(scheduledAt)
+	captureLogs(t)
+
+	result, err := jobs.Retention(t.Context(), depsFor(app))
+	if err != nil {
+		t.Fatalf("Retention: %v", err)
+	}
+	if result.MessagesPurged != 0 || result.QuarantinePurged != 0 || result.InvitationsExpired != 0 {
+		t.Errorf("result = %+v, want zero counts", result)
+	}
+	if result.Batches != 2 {
+		t.Errorf("Batches = %d, want 2 (one probe per table)", result.Batches)
+	}
+
+	installation, err := app.Rig.Q.GetInstallation(t.Context())
+	if err != nil {
+		t.Fatalf("GetInstallation: %v", err)
+	}
+	if !installation.LastRetentionRunAt.Valid {
+		t.Error("last_retention_run_at is null after a successful run")
+	}
+}
+
+// A failed run must be visible as a failure: logged with the reason and
+// returned, so `mi-casa cron retention` exits non-zero and the scheduler
+// logs it rather than quietly recording a run that did not happen.
+func TestRetentionFailureLogsAndReturnsTheError(t *testing.T) {
+	app := testrig.App(t)
+	app.SetNow(scheduledAt)
+
+	// A closed pool is the cheapest honest "the database went away": every
+	// statement the job issues fails, starting with the first purge.
+	app.Rig.Pool.Close()
+
+	logs := captureLogs(t)
+	_, err := jobs.Retention(t.Context(), depsFor(app))
+	if err == nil {
+		t.Fatal("Retention against a closed pool returned nil, want an error")
+	}
+
+	failed := findEvent(t, logs, "retention_failed")
+	if failed["level"] != "error" {
+		t.Errorf("retention_failed level = %v, want error", failed["level"])
+	}
+	if failed["scheduledFor"] != scheduledAt.Format(time.RFC3339Nano) {
+		t.Errorf("scheduledFor = %v, want %s", failed["scheduledFor"], scheduledAt.Format(time.RFC3339Nano))
+	}
+	if _, ok := failed["durationMs"]; !ok {
+		t.Errorf("retention_failed has no durationMs: %+v", failed)
+	}
+	message, ok := failed["error"].(string)
+	if !ok || message == "" {
+		t.Errorf("retention_failed error = %v, want the failure's message", failed["error"])
+	}
+	// retention_completed must NOT also be there: a run either finished or
+	// it did not.
+	if strings.Contains(logs.String(), "retention_completed") {
+		t.Errorf("a failed run also logged retention_completed:\n%s", logs.String())
+	}
+}
+
+// Deps.RateLimit is the app's Store, not the repository, so the job sweeps
+// through the same interface the middleware counts through. Asserting the
+// call happened (rather than only the rows going) keeps that wiring honest.
+func TestRetentionSweepsThroughTheRateLimitStore(t *testing.T) {
+	app := testrig.App(t)
+	app.SetNow(scheduledAt)
+	captureLogs(t)
+
+	counting := &countingStore{inner: app.Deps.RateLimit}
+	deps := depsFor(app)
+	deps.RateLimit = counting
+
+	if _, err := jobs.Retention(t.Context(), deps); err != nil {
+		t.Fatalf("Retention: %v", err)
+	}
+	if counting.sweeps != 1 {
+		t.Errorf("Store.Sweep calls = %d, want 1", counting.sweeps)
+	}
+}
+
+type countingStore struct {
+	inner  ratelimit.Store
+	sweeps int
+}
+
+var _ ratelimit.Store = (*countingStore)(nil)
+
+func (c *countingStore) Hit(ctx context.Context, key string, windowSeconds int) (int, error) {
+	return c.inner.Hit(ctx, key, windowSeconds)
+}
+
+func (c *countingStore) Sweep(ctx context.Context, now time.Time) (int, error) {
+	c.sweeps++
+	return c.inner.Sweep(ctx, now)
+}

--- a/apps/server/internal/repo/invitations.go
+++ b/apps/server/internal/repo/invitations.go
@@ -217,17 +217,21 @@ func (r *Repo) AcceptInvitation(ctx context.Context, in AcceptInvitationInput) e
 	})
 }
 
-// RefreshExpiredInvitations flips pending invitations past their expiry.
-// householdID nil sweeps every household (the nightly job); a value scopes it
-// to one (the admin screen, before it lists).
-func (r *Repo) RefreshExpiredInvitations(ctx context.Context, now time.Time, householdID *string) error {
-	if err := r.q.RefreshExpiredInvitations(ctx, gen.RefreshExpiredInvitationsParams{
+// RefreshExpiredInvitations flips pending invitations past their expiry and
+// returns how many it flipped. householdID nil sweeps every household (the
+// nightly job); a value scopes it to one (the admin screen, before it lists).
+//
+// The count exists for the job, which reports what a run did; the admin
+// screens ignore it and only care that the sweep ran before they read.
+func (r *Repo) RefreshExpiredInvitations(ctx context.Context, now time.Time, householdID *string) (int, error) {
+	expired, err := r.q.RefreshExpiredInvitations(ctx, gen.RefreshExpiredInvitationsParams{
 		Now:         ts(now.UTC()),
 		HouseholdID: householdID,
-	}); err != nil {
-		return fmt.Errorf("repo: refresh expired invitations: %w", err)
+	})
+	if err != nil {
+		return 0, fmt.Errorf("repo: refresh expired invitations: %w", err)
 	}
-	return nil
+	return int(expired), nil
 }
 
 // IsInvitationExpired reports whether the invitation's expiry has passed.

--- a/apps/server/internal/repo/invitations_test.go
+++ b/apps/server/internal/repo/invitations_test.go
@@ -288,7 +288,7 @@ func TestRefreshExpiredInvitations(t *testing.T) {
 	}
 
 	// Scoped to one household, only that household's invitations flip.
-	if err := r.RefreshExpiredInvitations(c, now, &casa.ID); err != nil {
+	if _, err := r.RefreshExpiredInvitations(c, now, &casa.ID); err != nil {
 		t.Fatalf("RefreshExpiredInvitations: %v", err)
 	}
 	if got := countRows(t, rig, "household_invitations", "status = 'expired'"); got != 1 {
@@ -307,7 +307,7 @@ func TestRefreshExpiredInvitations(t *testing.T) {
 	}
 
 	// Unscoped, every household's stale invitations flip.
-	if err := r.RefreshExpiredInvitations(c, now, nil); err != nil {
+	if _, err := r.RefreshExpiredInvitations(c, now, nil); err != nil {
 		t.Fatalf("RefreshExpiredInvitations (all households): %v", err)
 	}
 	if got := countRows(t, rig, "household_invitations", "status = 'expired'"); got != 2 {


### PR DESCRIPTION
Phase P7 of the Go backend migration. Closes #220.

- `internal/jobs.Retention`: purge expired inbox and quarantine rows in batches of 500, expire pending invitations, record the run for `/readyz` staleness, sweep both rate-limit tables; `retention_completed`/`retention_failed` log lines with the original fields
- `internal/cron`: `0 3 * * *` pinned to UTC with per-job panic recovery
- `cmd/mi-casa`: `cron retention` (exit 0/1, usage 2), `worker` (scheduler + bare `/healthz`), default mode schedules after serving, `server` never; the scheduler stops before HTTP shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yS5kEFd3AcfSkVidBs4Fj