### PR TITLE
build: native artifacts, distroless image, PR preview images and GoReleaser releases (P9)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# The image is COPY-only (see Dockerfile): everything is built natively by
+# scripts/build-artifacts.sh first. So the build context is an allowlist —
+# ignore the whole tree, then admit the one thing the Dockerfile COPYs.
+# This also keeps secrets (.dev.vars and friends) structurally out of reach.
+*
+!dist/server

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -1,10 +1,17 @@
 name: CI (Go)
 
+# The PR gate: "is this change good?" — the full suite (test.yml), then the
+# image built once from native artifacts, smoke-tested, and pushed as a
+# semver-prerelease preview. Pushes to main are release.yml's business:
+# merging IS releasing.
+
 on: pull_request
 
 permissions:
   contents: read
 
+# A force-push to a PR obsoletes the running check — cancel it instead of
+# letting it burn minutes to report on a commit nobody can merge.
 concurrency:
   group: ci-go-${{ github.head_ref }}
   cancel-in-progress: true
@@ -14,3 +21,222 @@ jobs:
     uses: ./.github/workflows/test.yml
     permissions:
       contents: read
+
+  # The image has to build and RUN, not merely typecheck — and it is
+  # published as a preview so the publish path is exercised on every change
+  # rather than first tried during a release.
+  #
+  # Preview tags are semver prereleases of the release they precede
+  # (0.2.0-pr.123 sorts below 0.2.0), so they can never be mistaken for a
+  # release. release.yml is what produces bare version tags and `latest`.
+  image:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      # Full history and tags: svu computes the upcoming version from
+      # Conventional Commits since the last v* tag, and a shallow clone has
+      # neither.
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+
+      # Only what this job runs: go and bun to build the artifacts, svu to
+      # name the preview. The codegen tools in .mise.toml are compiled from
+      # source and nothing here runs `go generate` — that drift guard lives
+      # in test.yml, which has already passed by the time this job starts.
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          install_args: "go bun node aqua:caarlos0/svu"
+
+      # mise does not cache Go modules; do it directly, keyed on the module
+      # that actually owns go.sum.
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('apps/server/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
+
+      - name: Install
+        run: bun install --frozen-lockfile
+
+      # What the next release WOULD be (same --v0 rule as release.yml), so
+      # the preview tags sort below it as prereleases of it.
+      - name: Compute version
+        id: version
+        run: |
+          tag=$(svu next --v0)
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      # Everything the image COPYs, compiled natively — the Dockerfile
+      # itself is COPY-only, so the buildx assemble below takes seconds and
+      # nothing ever runs under QEMU. Both architectures land in
+      # dist/server, which the preview push at the end reuses.
+      - name: Build artifacts (SPA + both server binaries)
+        run: bash scripts/build-artifacts.sh
+
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      # A pull request from a fork gets a read-only GITHUB_TOKEN, so pushing
+      # would fail on something unrelated to the change. Build-only there.
+      - name: Can this run push?
+        id: gate
+        run: |
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "push=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "push=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Log in to the container registry
+        if: steps.gate.outputs.push == 'true'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Plain single-arch build for the smoke test: the artifacts are
+      # prebuilt, so this is one COPY. No layer cache needed — there is
+      # nothing worth caching any more.
+      - name: Build image
+        run: docker build -t mi-casa:ci .
+
+      - name: Smoke-test the image
+        run: |
+          docker network create mi-casa-ci
+          docker run -d --name pg --network mi-casa-ci \
+            -e POSTGRES_USER=micasa -e POSTGRES_PASSWORD=micasa -e POSTGRES_DB=micasa \
+            postgres:17-alpine
+          # -h 127.0.0.1 forces the probe over TCP. Without it pg_isready
+          # checks the Unix socket, which already accepts during initdb's
+          # socket-only first start — before the restart that opens TCP —
+          # so the migrate one-off below could race a "ready" Postgres that
+          # refused TCP connections.
+          for _ in $(seq 1 30); do
+            docker exec pg pg_isready -h 127.0.0.1 -U micasa -d micasa && break
+            sleep 1
+          done
+
+          # No volume, no object store, no /data: everything the app keeps
+          # lives in Postgres, so a bare `docker run` is the whole
+          # deployment. config.Load demands every one of these at boot even
+          # when the feature behind it is never used — which is exactly why
+          # a smoke test that only compiled the binary would miss a
+          # regression here.
+          #
+          # ENVIRONMENT=test is what makes the http:// APP_URL legal: outside
+          # development and test the loader refuses anything but https,
+          # because an http origin means session cookies without Secure.
+          #
+          # SMTP_URL points at a port nothing is listening on, deliberately:
+          # the sender dials the relay only when a mail is actually sent, and
+          # this smoke test never sends one. It is here because config.Load
+          # requires the variable, not because mail is exercised — the
+          # Playwright suite (a later phase) is what runs a real Mailpit.
+          env_args=(
+            -e DATABASE_URL=postgres://micasa:micasa@pg:5432/micasa
+            -e ENVIRONMENT=test
+            -e APP_URL=http://localhost:3000
+            -e AUTH_SECRET=ci-smoke-test-secret-at-least-32-bytes-long
+            -e SETUP_SECRET=ci-smoke-test-setup-secret
+            -e OWNER_EMAIL=owner@example.com
+            -e EMAIL_DOMAIN=example.com
+            -e MAILGUN_WEBHOOK_SIGNING_KEY=ci-smoke-test-signing-key
+            -e SMTP_URL=smtp://127.0.0.1:1025
+            -e OUTBOUND_EMAIL_FROM=no-reply@example.com
+          )
+
+          # Migrations must apply from the image itself.
+          docker run --rm --network mi-casa-ci "${env_args[@]}" mi-casa:ci \
+            migrate
+
+          # The default mode: migrate (again, a no-op under the advisory
+          # lock), then serve with the in-process scheduler — what a
+          # single-container deployment actually runs.
+          docker run -d --name app --network mi-casa-ci -p 3000:3000 \
+            "${env_args[@]}" mi-casa:ci
+
+          # It must actually serve, not merely start. /readyz proves it
+          # reached Postgres; "/" proves the embedded SPA wins there — pure
+          # route ordering, and just as easy to break the other way if a
+          # health or API route ever stops taking priority over the
+          # static-file fallback. `id="root"` rather than the title, because
+          # the committed placeholder index.html carries the same title: a
+          # build that skipped scripts/spa-embed-overlay.sh must fail here.
+          for _ in $(seq 1 30); do
+            curl -fsS http://localhost:3000/healthz && break
+            sleep 1
+          done
+          curl -fsS http://localhost:3000/readyz | grep -q '"ok":true'
+          curl -fsS http://localhost:3000/ | grep -q 'id="root"'
+
+          # The server is a compiled Go binary in a shell-less image, and
+          # `go test` runs against source — so this probe is the only thing
+          # standing between a build/link regression and production. It
+          # needs no fixtures.
+          #
+          # An unsigned webhook post must answer 401. Reaching that answer
+          # means the router mounted the inbound subtree outside the spec
+          # validator and the same-site guard, the multipart form parsed,
+          # and HMAC verification ran — a broken build gives 404 or 500 here,
+          # not 401. An empty body-mime is fine: the signature is checked
+          # before the message is ever looked at.
+          status=$(curl -s -o /dev/null -w '%{http_code}' \
+            -X POST -F body-mime=@/dev/null -F timestamp=1 -F token=x -F signature=deadbeef \
+            http://localhost:3000/api/inbound/mailgun/mime)
+          test "$status" = "401" || { echo "webhook probe returned $status, expected 401"; exit 1; }
+
+      # Only after the smoke test: an image that does not serve must never
+      # reach the registry, not even as a preview.
+      #
+      # Two tags per push: <next>-pr.<n> moves with the PR (grab the PR's
+      # current state), <next>-pr.<n>.<sha> never moves. Both are valid
+      # semver prereleases of the release they precede.
+      - name: Push preview image (multi-arch)
+        if: steps.gate.outputs.push == 'true'
+        run: |
+          short=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
+          pr="${{ github.event.pull_request.number }}"
+          moving="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-pr.${pr}"
+          pinned="${moving}.${short}"
+          # The same context the smoke-tested image came from — dist/server
+          # still holds both binaries from the artifact step, so buildx just
+          # re-runs the COPY per platform and pushes the manifest list. No
+          # rebuild, hence no scripts/build-artifacts.sh here.
+          docker buildx build --platform linux/amd64,linux/arm64 \
+            -t "$moving" -t "$pinned" --push .
+          {
+            echo "### Preview image"
+            echo
+            echo '```'
+            echo "docker pull $moving"
+            echo '```'
+            echo
+            echo "Also tagged \`$pinned\` (immutable)."
+            echo "Next release would be **${{ steps.version.outputs.tag }}**."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Whatever failed above, the container's own log is the only place
+      # that says why — the image has no shell to go poking around in.
+      # Last, so it catches a failure in any step before it, the preview
+      # push included.
+      - name: Container logs on failure
+        if: failure()
+        run: docker logs app || true
+
+      # The runner is thrown away either way; this keeps a re-run on a
+      # self-hosted runner from tripping over a name that is still taken.
+      - name: Tear down the smoke-test stack
+        if: always()
+        run: |
+          docker rm -f app pg || true
+          docker network rm mi-casa-ci || true

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -85,12 +85,22 @@ jobs:
 
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
-      # A pull request from a fork gets a read-only GITHUB_TOKEN, so pushing
-      # would fail on something unrelated to the change. Build-only there.
+      # Two kinds of pull request get a read-only GITHUB_TOKEN, and pushing
+      # from either would fail with a 403 that has nothing to do with the
+      # change under test — after the smoke test has already passed, which
+      # is the worst possible place to learn it:
+      #
+      #   - a fork, because a fork's token can never write to this repo;
+      #   - Dependabot, whose runs are always treated as untrusted and given
+      #     the read-only token EVEN on an in-repo branch. The head repo
+      #     check alone does not catch it, so the actor is checked too.
+      #
+      # Build and smoke-test both; just do not publish a preview.
       - name: Can this run push?
         id: gate
         run: |
-          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ] \
+            || [ "${{ github.actor }}" = "dependabot[bot]" ]; then
             echo "push=false" >> "$GITHUB_OUTPUT"
           else
             echo "push=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,6 +226,7 @@ jobs:
           git push origin "${{ needs.version.outputs.tag }}"
 
       - name: GoReleaser (publish)
+        id: goreleaser
         if: needs.version.outputs.publish == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -233,8 +234,20 @@ jobs:
           trap 'bash scripts/restore-embed-overlay.sh' EXIT
           goreleaser release --clean
 
+      # The tag exists from the step above the publish; if the publish did
+      # not finish, it must not survive — "never a tag without a release".
+      #
+      # `failure()` alone is not enough: a run cancelled between the tag push
+      # and the end of GoReleaser (a timeout, someone pressing Cancel, a
+      # superseded queue entry) leaves the tag behind, because a cancelled
+      # job is not a failed one. Keying on the publish step's own outcome
+      # covers failure, cancellation and "never started" alike — and
+      # `always()` is what lets this step run at all in a cancelled job.
+      #
+      # Both deletions are idempotent (`|| true`): there is usually no
+      # GitHub Release to delete, and on a re-run there may be no tag either.
       - name: Delete the tag on failure
-        if: failure() && needs.version.outputs.publish == 'true'
+        if: always() && needs.version.outputs.publish == 'true' && steps.goreleaser.outcome != 'success'
         run: |
           gh release delete "${{ needs.version.outputs.tag }}" --yes || true
           git push --delete origin "${{ needs.version.outputs.tag }}" || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,256 @@
+name: Release
+
+# Merging IS releasing: every push to main with releasable commits
+# (feat/fix/perf/breaking since the last tag) tags and publishes
+# automatically. The PR review that approved the merge is the approval
+# gate. Docs/chore/ci-only merges end green without releasing.
+#
+# The manual dispatch remains for exactly two things:
+#   - dry_run: the full pipeline as a snapshot, nothing pushed/tagged/signed
+#   - allow_major: permit 1.0.0 — reaching a new major stays a deliberate
+#     human act, never a side effect of merging
+#
+# The version is NOT typed in by hand. svu computes it from Conventional
+# Commits since the last v* tag, which is why CLAUDE.md mandates the commit
+# format — the changelog (GoReleaser) and the version number (svu) are both
+# downstream of it.
+#
+# This workflow TAGS, then GoReleaser BUILDS AND PUBLISHES everything from
+# the tag: binaries, archives, checksums, SBOMs, cosign signatures, the
+# multi-arch image, and the GitHub Release with changelog. The tag comes
+# FIRST because GoReleaser releases from a tag; a failed publish deletes it
+# again, so a tag never points at a release that does not exist.
+#
+# It does not roll out: where the container runs is deployment
+# infrastructure this repo does not own. Rolling out means, in order:
+#
+#   1. `/app/mi-casa migrate` as a one-off (Job / initContainer / compose
+#      `migrate` service). Before the new image serves traffic: migrations
+#      are append-only, so old code running briefly against a newer schema
+#      is safe, whereas new code against an older schema is not.
+#   2. Point the deployment at the new tag and let the rollout proceed.
+#      /readyz gates each replica; SIGTERM drains it.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Compute and build, but do not push or tag"
+        type: boolean
+        default: true
+      allow_major:
+        description: "Permit a 1.0.0 release (breaking changes bump minor while the major is 0)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# Rapid merges serialize: the second run computes its version from the tag
+# the first one just created.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      tag: ${{ steps.v.outputs.tag }}
+      releasable: ${{ steps.v.outputs.releasable }}
+      # "true" only for a real publish: a push with releasable commits, or a
+      # non-dry dispatch. Downstream jobs key off these two rather than
+      # re-deriving event logic.
+      publish: ${{ steps.mode.outputs.publish }}
+      dry: ${{ steps.mode.outputs.dry }}
+    steps:
+      # Tags and full history are the inputs to the calculation.
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          install_args: "aqua:caarlos0/svu"
+
+      # svu reads Conventional Commits since the last v* tag. --v0 keeps
+      # breaking changes bumping the minor while the major is 0; the
+      # allow_major input drops it to permit 1.0.0.
+      - name: Compute version
+        id: v
+        run: |
+          current=$(svu current)
+          if [ "${{ inputs.allow_major }}" = "true" ]; then
+            tag=$(svu next)
+          else
+            tag=$(svu next --v0)
+          fi
+          version="${tag#v}"
+          releasable=true
+          if [ "$tag" = "$current" ]; then releasable=false; fi
+          {
+            echo "tag=$tag"; echo "version=$version"; echo "releasable=$releasable"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "### Version"
+            echo "- current: \`$current\`"
+            echo "- next:    \`$tag\` (releasable: $releasable)"
+          } | tee "$GITHUB_STEP_SUMMARY"
+
+      # On a push, an unreleasable merge (docs/chore/ci only) is a normal,
+      # green outcome — the app did not change, so nothing ships and the
+      # later jobs are skipped. On a manual dispatch it is a refusal instead:
+      # a human pressing the button expects a release to exist.
+      - name: Decide what this run does
+        id: mode
+        run: |
+          dry=false
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.dry_run }}" = "true" ]; then
+            dry=true
+          fi
+          publish=false
+          if [ "${{ steps.v.outputs.releasable }}" = "true" ] && [ "$dry" = "false" ]; then
+            publish=true
+          fi
+          echo "dry=$dry" >> "$GITHUB_OUTPUT"
+          echo "publish=$publish" >> "$GITHUB_OUTPUT"
+          if [ "$publish" = "false" ] && [ "$dry" = "false" ]; then
+            echo "Nothing releasable since ${{ steps.v.outputs.tag }} — skipping." | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Refuse an empty manual release
+        if: github.event_name == 'workflow_dispatch' && steps.v.outputs.releasable != 'true' && steps.mode.outputs.dry != 'true'
+        run: |
+          echo "No feat/fix/perf/breaking commits since the last tag — nothing to release."
+          exit 1
+
+  # The merge commit is not the PR head the PR's CI tested, so the suite
+  # runs once more on exactly what ships. Skipped entirely for unreleasable
+  # merges — nothing would ship anyway.
+  verify:
+    needs: version
+    if: needs.version.outputs.publish == 'true' || needs.version.outputs.dry == 'true'
+    uses: ./.github/workflows/test.yml
+    permissions:
+      contents: read
+
+  publish:
+    needs: [version, verify]
+    if: needs.version.outputs.publish == 'true' || needs.version.outputs.dry == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      # The artifact this job publishes is the container image. There is no
+      # hosted deployment this repo owns, so the honest default is the
+      # package page the image lands on; set the PRODUCTION_URL repository
+      # variable to point at a real instance instead.
+      url: ${{ vars.PRODUCTION_URL || format('https://github.com/{0}/pkgs/container/mi-casa-su-casa', github.repository) }}
+    permissions:
+      contents: write   # the git tag + the GitHub Release
+      packages: write   # ghcr.io
+      id-token: write   # keyless cosign signing (GitHub OIDC)
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          install_args: "go bun node aqua:goreleaser/goreleaser aqua:sigstore/cosign aqua:anchore/syft"
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('apps/server/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
+
+      # GoReleaser's before hook builds the SPA; that needs node_modules.
+      - name: Install
+        run: bun install --frozen-lockfile
+
+      # dockers_v2 builds both platforms with an SBOM attestation in one
+      # buildx run — that needs the docker-container driver, which this
+      # action creates and selects (the runner's default "docker" driver
+      # supports neither attestations nor multi-platform pushes).
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Log in to the container registry
+        if: needs.version.outputs.publish == 'true'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Dry run: the full pipeline (binaries, archives, SBOMs, image build)
+      # with nothing pushed, tagged or signed.
+      - name: GoReleaser (snapshot)
+        if: needs.version.outputs.dry == 'true'
+        run: |
+          trap 'bash scripts/restore-embed-overlay.sh' EXIT
+          goreleaser release --snapshot --clean --skip=sign
+
+      # GoReleaser auto-skips signing in snapshot mode, which is exactly how
+      # a cosign flag incompatibility once reached a real release. Exercise
+      # the same sign + verify invocations against a throwaway blob so the
+      # dry run proves them too (OIDC is available here; nothing uploads).
+      - name: Cosign flags smoke
+        if: needs.version.outputs.dry == 'true'
+        run: |
+          echo smoke > /tmp/cosign-smoke.txt
+          cosign sign-blob --yes --bundle=/tmp/cosign-smoke.sigstore.json /tmp/cosign-smoke.txt
+          cosign verify-blob \
+            --bundle /tmp/cosign-smoke.sigstore.json \
+            --certificate-identity-regexp "https://github.com/${{ github.repository }}/\.github/workflows/release\.yml@.*" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            /tmp/cosign-smoke.txt
+
+      # The real thing. GoReleaser releases FROM a tag, so the tag is
+      # created first — and deleted again below if anything after it fails,
+      # preserving the "never a tag without a release" property.
+      - name: Tag the release
+        if: needs.version.outputs.publish == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ needs.version.outputs.tag }}" -m "${{ needs.version.outputs.tag }}"
+          git push origin "${{ needs.version.outputs.tag }}"
+
+      - name: GoReleaser (publish)
+        if: needs.version.outputs.publish == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          trap 'bash scripts/restore-embed-overlay.sh' EXIT
+          goreleaser release --clean
+
+      - name: Delete the tag on failure
+        if: failure() && needs.version.outputs.publish == 'true'
+        run: |
+          gh release delete "${{ needs.version.outputs.tag }}" --yes || true
+          git push --delete origin "${{ needs.version.outputs.tag }}" || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        run: |
+          {
+            if [ "${{ needs.version.outputs.dry }}" = "true" ]; then
+              echo "### Dry run — nothing pushed, nothing tagged"
+            else
+              echo "### Released ${{ needs.version.outputs.tag }}"
+            fi
+            echo
+            echo "- version: \`${{ needs.version.outputs.version }}\`"
+            echo "- image:   \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.version.outputs.version }}\` (amd64+arm64, cosign-signed)"
+            echo "- release: binaries, checksums, SBOMs and signatures on the GitHub Release"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,10 @@
 name: Tests
 
 # The single definition of "the Go suite is green": lint/typecheck, the
-# frontend/unit test suite, and Go vet + tests against a real Postgres.
-# Reusable — called by ci-go.yml on every pull request, so the quality gate
-# is defined once.
+# release config lint, the frontend/unit test suite, and Go vet + tests
+# against a real Postgres. Reusable — called by ci-go.yml (every pull
+# request) and release.yml (every push to main), so the quality gate is
+# defined once and cannot drift between the two.
 
 on:
   workflow_call:
@@ -43,11 +44,13 @@ jobs:
       # apps/server/internal/api/spec_sync_test.go runs oapi-codegen from
       # PATH to guard against generated-code drift and never skips, and
       # sqlc is installed so a future sqlc drift test can do the same.
-      # cache: true lets mise-action cache these Go-built tools instead of
-      # recompiling them on every run.
+      # goreleaser is here for the config lint below — the release
+      # pipeline's own config, checked on every PR rather than at release
+      # time. cache: true lets mise-action cache these Go-built tools
+      # instead of recompiling them on every run.
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
-          install_args: "go bun node go:github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen go:github.com/sqlc-dev/sqlc/cmd/sqlc"
+          install_args: "go bun node go:github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen go:github.com/sqlc-dev/sqlc/cmd/sqlc aqua:goreleaser/goreleaser"
           cache: true
 
       # mise does not cache Go modules; do it directly, keyed on the module
@@ -65,6 +68,12 @@ jobs:
 
       - name: Lint + typecheck
         run: bun run check
+
+      # The release pipeline's config is code too — a broken .goreleaser.yaml
+      # should fail here, not halfway through a release that has already
+      # pushed a tag.
+      - name: GoReleaser config check
+        run: goreleaser check
 
       - name: Frontend tests
         run: bun run test

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,148 @@
+# GoReleaser owns everything downstream of a version tag: binaries,
+# archives, checksums, SBOMs, cosign signatures, the multi-arch image and
+# its manifest, and the GitHub Release with a Conventional-Commits
+# changelog. The version DECISION stays outside (svu, in release.yml) —
+# GoReleaser releases *from* the tag it finds.
+#
+# Local dry run: `mise run snapshot` (wraps
+#   goreleaser release --snapshot --clean --skip=sign
+# and restores the SPA embed overlay afterwards). Signing is skipped
+# locally because keyless cosign needs an OIDC identity (GitHub Actions).
+version: 2
+
+# The binary, the image and the archives are all "mi-casa" — the repository
+# is mi-casa-su-casa, but nobody types the long form at a shell prompt. Only
+# the GitHub release target and the image path below use the repo name.
+project_name: mi-casa
+
+# Not the default ./dist: the repo's own build outputs live there
+# (dist/client from Vite, dist/server from build-artifacts.sh), and the
+# before hook below writes into it — which would trip GoReleaser's
+# dist-must-be-empty check even under --clean.
+dist: dist/goreleaser
+
+before:
+  hooks:
+    # The SPA must sit in its go:embed directory before the builds run.
+    # Callers restore the overlay afterwards
+    # (scripts/restore-embed-overlay.sh) — GoReleaser OSS has no global
+    # after-hooks.
+    - bash scripts/spa-embed-overlay.sh
+
+builds:
+  - id: mi-casa
+    dir: apps/server
+    main: ./cmd/mi-casa
+    binary: mi-casa
+    env:
+      - CGO_ENABLED=0
+    goos: [linux]
+    goarch: [amd64, arm64]
+    flags: [-trimpath]
+    ldflags: ["-s -w"]
+
+archives:
+  - formats: [tar.gz]
+    # mi-casa_0.1.0_linux_amd64.tar.gz — binary only; the SPA, spec,
+    # migrations and tzdata are embedded in it.
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+
+checksum:
+  name_template: checksums.txt
+
+# One SBOM per archive (syft, SPDX JSON) — uploaded to the release.
+sboms:
+  - artifacts: archive
+
+# Keyless cosign signature over the checksum file: verifying it plus the
+# checksums transitively verifies every archive. cosign 3.x signs into a
+# single Sigstore bundle (signature + certificate in one JSON file) — the
+# old --output-signature/--output-certificate flags refuse to run without
+# it. README documents the `cosign verify-blob --bundle` invocation.
+signs:
+  - cmd: cosign
+    artifacts: checksum
+    output: true
+    signature: "${artifact}.sigstore.json"
+    args:
+      - sign-blob
+      - --yes
+      - --bundle=${signature}
+      - ${artifact}
+
+# Multi-platform image from the same COPY-only Dockerfile the rest of the
+# repo uses. GoReleaser's build context holds the binaries at
+# linux/<arch>/mi-casa, hence BINARY_ROOT=. (the Dockerfile's own default,
+# dist/server, serves the scripts/build-artifacts.sh layout instead). There
+# is nothing else to ship into the context: the image has no /data, no
+# skeleton directory and no config file — everything the app needs is inside
+# the binary or in the environment. buildx builds and pushes the manifest in
+# one run at publish time; image SBOMs are on by default here.
+dockers_v2:
+  - images:
+      - ghcr.io/andersro93/mi-casa-su-casa
+    # A pinning ladder: the full version never moves (re-releasing it is
+    # structurally impossible — the git tag already exists), major.minor
+    # moves with patches, major with minors (risky pre-1.0: minors carry
+    # breaking changes under the --v0 rule), latest with every release.
+    # sha-<commit> and @digest stay for byte-exact pinning.
+    tags:
+      - "{{ .Version }}"
+      - "{{ .Major }}.{{ .Minor }}"
+      - "{{ .Major }}"
+      - latest
+      - sha-{{ .FullCommit }}
+    dockerfile: Dockerfile
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    build_args:
+      BINARY_ROOT: "."
+
+# Keyless cosign signatures on the pushed images/manifests.
+docker_signs:
+  - cmd: cosign
+    artifacts: all
+    output: true
+    args:
+      - sign
+      - --yes
+      - "${artifact}@${digest}"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs"
+      - "^test"
+      - "^chore"
+      - "^ci"
+      - "^style"
+      - "merge conflict"
+      - Merge pull request
+      - Merge branch
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: Bug fixes
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: Performance
+      regexp: '^.*?perf(\([[:word:]]+\))??!?:.+$'
+      order: 2
+    - title: Other
+      order: 999
+
+release:
+  github:
+    owner: andersro93
+    name: mi-casa-su-casa
+  footer: |
+    **Container image:** `ghcr.io/andersro93/mi-casa-su-casa:{{ .Version }}` (linux/amd64 + linux/arm64, cosign-signed)
+
+    **Verify a download:** see the "Verifying a release" section of the README.
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-snapshot.{{ .ShortCommit }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -99,6 +99,17 @@ dockers_v2:
       - linux/arm64
     build_args:
       BINARY_ROOT: "."
+    # OCI annotations, and one of them earns its keep beyond documentation:
+    # image.source is what makes GHCR link the package to this repository
+    # (inheriting its visibility and README) instead of leaving an orphan
+    # package under the account. revision and version pin the pulled image
+    # back to a commit and a tag without a registry round trip — `docker
+    # inspect` answers "what am I running?" on a host with no clone.
+    labels:
+      org.opencontainers.image.source: "https://github.com/andersro93/mi-casa-su-casa"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.licenses: "MIT"
 
 # Keyless cosign signatures on the pushed images/manifests.
 docker_signs:

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,10 +1,12 @@
 # Toolchain pin for Mi Casa Su Casa — the single source of truth for dev AND
 # CI. `mise install` in the repo gives everyone the same Go + Bun + Node plus
 # the codegen tools `go generate` expects on PATH (sqlc, oapi-codegen, goose).
-# CI installs from this same file via jdx/mise-action, but only `go bun node`
-# (install_args) — the codegen tools are compiled from source and CI never
-# runs `go generate` (generated code is committed; a drift-guard test
-# enforces it).
+# CI installs from this same file via jdx/mise-action, naming per job only
+# what that job runs (install_args): the test job adds the codegen tools and
+# goreleaser, the image job adds svu, the release job adds goreleaser,
+# cosign and syft. CI never runs `go generate` — generated code is
+# committed and a drift-guard test enforces it — but the codegen binaries
+# are still installed because that test shells out to them.
 [tools]
 go = "1.27.0"
 bun = "1.4"
@@ -29,7 +31,7 @@ run = [
 
 [tasks.check]
 description = "Lint, typecheck, i18n coverage, goreleaser config"
-run = ["bun run check", "[ ! -f .goreleaser.yaml ] || goreleaser check"]
+run = ["bun run check", "goreleaser check"]
 
 [tasks.artifacts]
 description = "SPA + both server binaries → dist/server/linux/<arch>/mi-casa"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+# syntax=docker/dockerfile:1
+
+# Mi Casa Su Casa — one image, one static Go binary, several modes selected
+# by argv[1]: the web server (default: migrate-then-serve-and-schedule),
+# `server` (HTTP only), `worker` (scheduler only, plus a bare /healthz),
+# `migrate` (alias `migrations`) and `cron <job>`, plus `healthcheck` for
+# HEALTHCHECK below. See apps/server/cmd/mi-casa/main.go for the
+# authoritative dispatch table.
+#
+# NOTHING COMPILES IN HERE. The binaries are built natively, outside Docker:
+#
+#   bash scripts/build-artifacts.sh   # → dist/server/linux/{amd64,arm64}/mi-casa
+#
+# and this file only COPYs the one matching TARGETPLATFORM. That keeps a
+# multi-arch `docker buildx build --platform linux/amd64,linux/arm64` down
+# to seconds of file copying — no QEMU emulation, no in-container Go or Bun
+# toolchains, and the native build reuses the developer's (or CI's) module
+# and Vite caches. If the COPY below fails with "not found", run the script
+# first.
+#
+# The SPA is not copied separately: it is embedded inside the binary
+# (go:embed in internal/web), along with the SQL migrations and the IANA
+# zone database (`import _ "time/tzdata"`).
+#
+# The base is distroless "static" rather than scratch: same
+# no-shell/no-libc/no-package-manager attack surface, but it ships the
+# things a from-scratch image has to hand-roll — an up-to-date CA bundle
+# (the SMTP relay is dialled over TLS), tzdata, /tmp, and the `nonroot` user
+# (uid 65532, which the :nonroot tag also sets as USER). Pinned by digest;
+# Dependabot bumps it.
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:afa5c872c891853ca7fcf1f12c3edb23f7eeef36189728842dd51042ff57f7ab
+
+# Automatic buildx arg: "linux/amd64" or "linux/arm64" per platform.
+ARG TARGETPLATFORM
+# Where the per-platform binaries live in the build context. The default
+# serves the scripts/build-artifacts.sh layout (dist/server/linux/<arch>/
+# mi-casa); GoReleaser's dockers_v2 passes BINARY_ROOT=. because its build
+# context holds them at linux/<arch>/mi-casa directly.
+ARG BINARY_ROOT=dist/server
+
+# No volume and no writable directory: the app keeps everything in Postgres
+# — inbound mail, attachments and all — so there is nothing on disk to
+# persist and nothing for a nonroot process to need write access to.
+COPY ${BINARY_ROOT}/${TARGETPLATFORM}/mi-casa /app/mi-casa
+
+ENV PORT=3000
+EXPOSE 3000
+
+# The binary is its own healthcheck client — there is no shell or curl here.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD ["/app/mi-casa", "healthcheck"]
+
+ENTRYPOINT ["/app/mi-casa"]

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -1,0 +1,143 @@
+# Mi Casa Su Casa, self-hosted, from the published image:
+#
+#   APP_URL=https://casa.example.com \
+#   EMAIL_DOMAIN=casa.example.com \
+#   OWNER_EMAIL=you@example.com \
+#   AUTH_SECRET=$(openssl rand -hex 32) \
+#   SETUP_SECRET=$(openssl rand -hex 16) \
+#   MAILGUN_WEBHOOK_SIGNING_KEY=... \
+#   SMTP_URL=smtps://user:pass@smtp.example.com:465 \
+#   OUTBOUND_EMAIL_FROM=no-reply@casa.example.com \
+#     docker compose -f docker-compose.selfhost.yml up -d
+#
+# In practice you want those in a .env file next to this one rather than on
+# the command line — every variable below reads from the environment, and
+# `docker compose` loads .env automatically.
+#
+# Nothing to clone and nothing to build: this pulls
+# ghcr.io/andersro93/mi-casa-su-casa. Contributors want docker-compose.yml
+# instead, which builds from source; the two files are deliberately separate
+# so a self-hoster never needs the repo.
+#
+# What runs: Postgres for the data, and the app in its default mode — it
+# migrates itself under a Postgres advisory lock at startup, then serves with
+# its in-process scheduler running (the nightly retention pass). A single
+# container has no orchestrator to drive migrations or cron separately, so the
+# default mode does both itself.
+#
+# Two containers, no object store and no app volume: everything the app keeps
+# — households, inbound mail, attachments — lives in Postgres.
+#
+# Pin the tag. `latest` moves on every merge to main; `MI_CASA_TAG=1` follows
+# the major, `1.4` the minor, and `1.4.2` nothing at all. See the README's
+# "Self-hosting" section for the pinning ladder and `cosign verify`.
+#
+# BACK UP THE db-data VOLUME. It is the entire application state — there is
+# no second copy anywhere. A backup written to the same host as the database
+# is not a backup.
+#
+#   docker compose -f docker-compose.selfhost.yml exec -T db \
+#     pg_dump -U micasa micasa | gzip > micasa-$(date +%F).sql.gz
+
+name: mi-casa-su-casa
+
+services:
+  db:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: micasa
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-micasa}
+      POSTGRES_DB: micasa
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    healthcheck:
+      # -d as well as -U: without the database name pg_isready reports ready
+      # while the init scripts are still creating it, and the app's startup
+      # migration then fails on a database that does not exist yet.
+      test: ["CMD-SHELL", "pg_isready -U micasa -d micasa"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  app:
+    image: ghcr.io/andersro93/mi-casa-su-casa:${MI_CASA_TAG:-latest}
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      # Bind this to 127.0.0.1 (`127.0.0.1:${PORT:-3000}:3000`) if a reverse
+      # proxy on the same host terminates TLS in front of it — the app speaks
+      # plain HTTP and has no business on a public interface directly.
+      - "${PORT:-3000}:3000"
+    environment:
+      # The database. Only change this if you point at a Postgres of your own
+      # instead of the `db` service above — in which case delete that service
+      # and the volume with it.
+      DATABASE_URL: postgres://micasa:${POSTGRES_PASSWORD:-micasa}@db:5432/micasa
+
+      # The public origin people type. Behind a reverse proxy with TLS this is
+      # your https:// address, not localhost — sessions are signed and links
+      # in outbound mail are built from it, and the config loader REFUSES a
+      # non-https value here unless ENVIRONMENT is development or test. A
+      # wrong value breaks sign-in in ways that look like anything except a
+      # configuration error.
+      APP_URL: "${APP_URL:?the public https:// origin, e.g. https://casa.example.com}"
+
+      # Signs sessions. At least 32 characters; generate one with
+      # `openssl rand -hex 32`. Changing it signs everyone out.
+      AUTH_SECRET: "${AUTH_SECRET:?generate one with: openssl rand -hex 32}"
+
+      # The one-time secret /setup asks for on first run, so a freshly
+      # exposed instance cannot be claimed by whoever finds it first. Any
+      # strong passphrase; it is used once.
+      SETUP_SECRET: "${SETUP_SECRET:?any strong passphrase — /setup asks for it once}"
+
+      # The address of the first account, created by that same /setup run.
+      OWNER_EMAIL: "${OWNER_EMAIL:?the email address of the first owner account}"
+
+      # The domain households receive mail on: each household gets
+      # <slug>@EMAIL_DOMAIN. Point its MX records at Mailgun and add a
+      # Mailgun route matching `match_recipient(".*@EMAIL_DOMAIN")` that
+      # forwards to https://<APP_URL>/api/inbound/mailgun/mime — see the
+      # README's "Self-hosting" section and docs/email-routing.md.
+      EMAIL_DOMAIN: "${EMAIL_DOMAIN:?the domain household inboxes live on, e.g. casa.example.com}"
+
+      # Mailgun's HTTP webhook signing key (Dashboard → Sending → Webhooks →
+      # "HTTP webhook signing key" — NOT the API key). Every inbound POST is
+      # verified against it; without the right key the app answers 401 and
+      # your mail silently goes nowhere.
+      MAILGUN_WEBHOOK_SIGNING_KEY: "${MAILGUN_WEBHOOK_SIGNING_KEY:?Mailgun's HTTP webhook signing key}"
+
+      # The relay outbound mail (invitations, password resets) is sent
+      # through. `smtps://` connects with TLS on 465; `smtp://` upgrades with
+      # STARTTLS, usually on 587. URL-encode the password if it contains
+      # @ : / or #.
+      SMTP_URL: "${SMTP_URL:?e.g. smtps://user:pass@smtp.example.com:465}"
+
+      # The From address on that mail. Must be an address your relay is
+      # allowed to send as, or it will be rejected or spam-filed.
+      OUTBOUND_EMAIL_FROM: "${OUTBOUND_EMAIL_FROM:?e.g. no-reply@casa.example.com}"
+
+      # How many reverse proxies sit in front. 0 means the app trusts the
+      # socket's peer address and IGNORES X-Forwarded-For (by design — it is
+      # caller-supplied), which behind a proxy buckets every client together
+      # for rate limiting. One nginx/Caddy/Traefik in front: 1. Cloudflare in
+      # front of that one: 2. Count wrong and you either rate-limit everyone
+      # as one caller or let a caller spoof their address.
+      TRUSTED_PROXY_HOPS: ${TRUSTED_PROXY_HOPS:-0}
+
+      # Optional. The display name in the UI and in outbound mail.
+      APP_NAME: ${APP_NAME:-Mi Casa Su Casa}
+
+      # Optional. `production` (the default) is what you want; `development`
+      # and `test` relax the https requirement on APP_URL and are for a
+      # laptop, never for a deployment.
+      ENVIRONMENT: ${ENVIRONMENT:-production}
+
+      # Optional. `debug` when you are chasing something, `info` otherwise.
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+
+volumes:
+  db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,133 @@
+# Mi Casa Su Casa, whole stack, one command — builds from source:
+#
+#   bash scripts/build-artifacts.sh   # REQUIRED FIRST — see below
+#   docker compose up
+#
+# The Dockerfile is COPY-only: it compiles nothing, it copies the binary
+# that scripts/build-artifacts.sh produced natively. So run that script
+# before the first `docker compose build` and again after any server or SPA
+# change — otherwise the build fails with "dist/server/... not found", or
+# (worse) quietly ships yesterday's binary.
+#
+# Two containers and nothing else: Postgres holds everything, inbound mail
+# and attachments included, so there is no object store and no data volume
+# for the app.
+#
+# The app runs in its default dispatch mode: it migrates itself under a
+# Postgres advisory lock at startup, then serves with its in-process
+# scheduler running — the right shape for a single container, which has no
+# orchestrator to drive migrations or cron separately. Run migrations
+# explicitly instead (before a rollout, say) with the `migrate` service
+# below.
+#
+# Self-hosting? Use docker-compose.selfhost.yml instead: it pulls the
+# published image and needs no clone at all.
+
+name: mi-casa-su-casa
+
+services:
+  db:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: micasa
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-micasa}
+      POSTGRES_DB: micasa
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    healthcheck:
+      # -d as well as -U: without the database name pg_isready reports ready
+      # while the init scripts are still creating it, and the migration then
+      # fails on a database that does not exist yet.
+      test: ["CMD-SHELL", "pg_isready -U micasa -d micasa"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  app:
+    # The Dockerfile is COPY-only: run `bash scripts/build-artifacts.sh`
+    # before the first `docker compose build` (and after server/SPA changes).
+    build: .
+    # Named so the one-off services below share the built image instead of
+    # each triggering their own build of the same context.
+    image: mi-casa:local
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "${PORT:-3000}:3000"
+    environment: &app-env
+      DATABASE_URL: postgres://micasa:${POSTGRES_PASSWORD:-micasa}@db:5432/micasa
+
+      # `development` is what makes the http:// APP_URL below legal — outside
+      # development and test the config loader refuses anything but https,
+      # because an http origin means session cookies without Secure.
+      ENVIRONMENT: ${ENVIRONMENT:-development}
+      APP_URL: ${APP_URL:-http://localhost:3000}
+
+      # Dev defaults, deliberately weak and deliberately not secrets. The
+      # self-host file demands real ones; this file is a laptop.
+      AUTH_SECRET: ${AUTH_SECRET:-dev-secret-do-not-use-in-production-0123456789}
+      SETUP_SECRET: ${SETUP_SECRET:-dev-setup-secret}
+
+      # The account first-run /setup creates, and the domain households
+      # receive mail on (<slug>@EMAIL_DOMAIN).
+      OWNER_EMAIL: ${OWNER_EMAIL:-owner@example.com}
+      EMAIL_DOMAIN: ${EMAIL_DOMAIN:-example.com}
+
+      # Inbound and outbound mail. Nothing here reaches a real relay by
+      # default: the point is that the process boots, since config.Load
+      # requires all three regardless of whether mail is ever sent.
+      MAILGUN_WEBHOOK_SIGNING_KEY: ${MAILGUN_WEBHOOK_SIGNING_KEY:-dev-signing-key}
+      SMTP_URL: ${SMTP_URL:-smtp://localhost:1025}
+      OUTBOUND_EMAIL_FROM: ${OUTBOUND_EMAIL_FROM:-no-reply@example.com}
+
+      # Behind a reverse proxy, set this to the number of proxies in front —
+      # otherwise the rate limiter ignores X-Forwarded-For (by design, since
+      # it is caller-supplied) and buckets every caller together.
+      TRUSTED_PROXY_HOPS: ${TRUSTED_PROXY_HOPS:-0}
+
+      APP_NAME: ${APP_NAME:-Mi Casa Su Casa}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+
+  # One-off: apply migrations and exit.
+  #
+  #   docker compose run --rm migrate
+  #
+  # The default mode already migrates at startup, so a single-container
+  # deployment never needs this. It exists for the orchestrated case
+  # (Kubernetes, several `server` replicas) where migrations must land before
+  # any replica depending on the new schema starts. Safe to run concurrently
+  # with a booting app container: both take the same Postgres advisory lock.
+  #
+  # Behind a profile so `docker compose up` does not start it.
+  migrate:
+    build: .
+    image: mi-casa:local
+    profiles: ["tools"]
+    depends_on:
+      db:
+        condition: service_healthy
+    command: ["migrate"]
+    environment: *app-env
+
+  # One-off: run a single scheduled job and exit.
+  #
+  #   docker compose run --rm cron retention
+  #
+  # Same image, same configuration, so a Kubernetes CronJob runs exactly what
+  # is already deployed. Not needed alongside the default mode either — its
+  # in-process scheduler drives the job itself.
+  cron:
+    build: .
+    image: mi-casa:local
+    profiles: ["tools"]
+    depends_on:
+      db:
+        condition: service_healthy
+    entrypoint: ["/app/mi-casa", "cron"]
+    environment: *app-env
+
+volumes:
+  db-data:

--- a/scripts/build-artifacts.sh
+++ b/scripts/build-artifacts.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Builds everything the container image COPYs, natively — no compilation
+# happens inside Docker. Output:
+#
+#   dist/server/linux/amd64/mi-casa
+#   dist/server/linux/arm64/mi-casa
+#
+# The SPA is not a separate artifact: it is embedded into both binaries via
+# go:embed (scripts/spa-embed-overlay.sh), and the overlay is restored
+# afterwards — even on failure — so the working tree stays clean.
+#
+# The layout mirrors GoReleaser's dockers_v2 build context
+# (linux/<TARGETARCH>/mi-casa), so ONE Dockerfile COPY line serves both this
+# script (BINARY_ROOT=dist/server, the default) and GoReleaser
+# (BINARY_ROOT=.).
+#
+# Releases do not use this script — GoReleaser drives the same overlay and
+# equivalent go build flags itself (.goreleaser.yaml). This is the dev/CI
+# path for compose and the preview image.
+#
+# Prerequisites: `mise install` (Go + Bun) and `bun install`.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+trap 'bash scripts/restore-embed-overlay.sh' EXIT
+
+bash scripts/spa-embed-overlay.sh
+
+echo "==> server binaries"
+rm -rf dist/server
+mkdir -p dist/server
+for arch in amd64 arm64; do
+  mkdir -p "dist/server/linux/$arch"
+  (cd apps/server && CGO_ENABLED=0 GOOS=linux GOARCH="$arch" \
+    go build -trimpath -ldflags="-s -w" \
+    -o "../../dist/server/linux/$arch/mi-casa" ./cmd/mi-casa)
+  echo "    dist/server/linux/$arch/mi-casa"
+done
+
+ls -lh dist/server/linux/*/

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Build the shipping image for both architectures Mi Casa Su Casa targets:
+# linux/amd64 (most VPS hosts) and linux/arm64 (Apple Silicon, Ampere, a
+# Raspberry Pi 5).
+#
+#   bash scripts/build-image.sh                    # → mi-casa:dev, local only
+#   TAG=ghcr.io/andersro93/mi-casa-su-casa:v1 PUSH=1 bash scripts/build-image.sh
+#
+# The binaries are compiled natively FIRST (scripts/build-artifacts.sh —
+# skipped when SKIP_ARTIFACTS=1 and dist/server is already populated); the
+# Dockerfile is COPY-only, so the multi-platform buildx step below is
+# seconds of file copying with no QEMU emulation.
+#
+# A multi-platform result is a manifest list, and the local `docker images`
+# store cannot hold one: without PUSH=1 the build is verified and discarded
+# (--output=type=cacheonly), which is what you want in CI and before a
+# release. Pushing needs a registry you are logged into (`docker login
+# ghcr.io`); single-arch iteration is plain `docker build -t mi-casa:dev .`
+# after running build-artifacts.sh once.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+TAG="${TAG:-mi-casa:dev}"
+PLATFORMS="${PLATFORMS:-linux/amd64,linux/arm64}"
+
+if [ "${SKIP_ARTIFACTS:-0}" != "1" ] || [ ! -e dist/server/linux/amd64/mi-casa ]; then
+  bash scripts/build-artifacts.sh
+fi
+
+# docker-container is the only driver that can build more than one platform
+# in a single invocation; the default "docker" driver refuses. Created once
+# and reused.
+BUILDER="${BUILDER:-mi-casa}"
+if ! docker buildx inspect "$BUILDER" >/dev/null 2>&1; then
+  echo "==> creating buildx builder '$BUILDER' (docker-container driver)"
+  docker buildx create --name "$BUILDER" --driver docker-container >/dev/null
+fi
+
+if [ "${PUSH:-0}" = "1" ]; then
+  OUTPUT=(--push)
+  echo "==> building $TAG for $PLATFORMS and pushing"
+else
+  OUTPUT=(--output=type=cacheonly)
+  echo "==> building $TAG for $PLATFORMS (verify only; set PUSH=1 to publish)"
+fi
+
+docker buildx build \
+  --builder "$BUILDER" \
+  --platform "$PLATFORMS" \
+  --tag "$TAG" \
+  "${OUTPUT[@]}" \
+  .

--- a/scripts/restore-embed-overlay.sh
+++ b/scripts/restore-embed-overlay.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Drops the SPA build overlaid into the go:embed directory and puts the
+# committed placeholder back, leaving the working tree clean. Idempotent; a
+# no-op outside a git checkout (an exported tarball just keeps the overlay).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+EMBED_DIRS=(
+  apps/server/internal/web/dist
+)
+
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  for dir in "${EMBED_DIRS[@]}"; do
+    # clean first, then checkout: `git clean` removes the Vite output the
+    # overlay dropped here, and `git checkout --` restores the placeholder
+    # index.html it overwrote.
+    #
+    # -x, and this is the one place it is wanted: .gitignore ignores
+    # everything in this directory except the placeholder (so that a stray
+    # SPA build can never be staged by `git add -A`), which also means a
+    # plain `git clean -fd` walks straight past the overlay and leaves it on
+    # disk — invisible to `git status` and still embedded by the next
+    # `go build`. The flag is scoped to this directory alone, where the only
+    # thing git tracks is the placeholder that the next line restores.
+    git clean -qfdx "$dir"
+    git checkout -q -- "$dir"
+  done
+fi

--- a/scripts/spa-embed-overlay.sh
+++ b/scripts/spa-embed-overlay.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Builds the SPA and overlays it into apps/server/internal/web/dist, where
+# go:embed picks it up at compile time (a committed placeholder index.html
+# normally sits there so plain `go build`/`go test` work without a frontend
+# build). Used by scripts/build-artifacts.sh — callers are responsible for
+# restoring the overlay afterwards (scripts/restore-embed-overlay.sh) so the
+# working tree stays clean.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+EMBED_DIR=apps/server/internal/web/dist
+
+echo "==> SPA (vite)"
+# Through the workspace filter rather than `cd apps/frontend && bun run
+# build`: the SPA's dependencies are hoisted to the root node_modules, so
+# the build must run with the workspace root resolved.
+bun run --filter @mi-casa/frontend build   # writes dist/client at the repo root
+
+echo "==> embed overlay"
+rm -rf "$EMBED_DIR"
+mkdir -p "$EMBED_DIR"
+cp -R dist/client/. "$EMBED_DIR/"


### PR DESCRIPTION
Phase P9 of the Go backend migration. Closes #224.

- `scripts/build-artifacts.sh`: Vite build → go:embed overlay → CGO-free linux amd64/arm64 binaries, overlay restored on every exit; `build-image.sh` for multi-arch buildx
- COPY-only `Dockerfile` on distroless `static-debian12:nonroot` (digest-pinned), the binary as its own healthcheck; ~8 MB image content
- `docker-compose.yml` (from source) and `docker-compose.selfhost.yml` (published image, every variable documented)
- `ci-go.yml` image job: build, smoke test (migrate, `/readyz`, SPA at `/`, webhook bad-signature 401), then `<next>-pr.N` preview images to GHCR (skipped for forks and Dependabot)
- `release.yml` + `.goreleaser.yaml`: merging is releasing — svu version, tag, archives, checksums, SBOMs, keyless cosign signatures, multi-arch image with OCI labels, GitHub Release; tag removed if publishing fails or is cancelled
- `test.yml` gains `goreleaser check`

Note: merging this cuts the first release, `v0.1.0`, and pushes `ghcr.io/andersro93/mi-casa-su-casa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yS5kEFd3AcfSkVidBs4Fj