### PR TITLE
test(e2e): Playwright suite against the real image with Mailpit (P10)

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -205,6 +205,44 @@ jobs:
             http://localhost:3000/api/inbound/mailgun/mime)
           test "$status" = "401" || { echo "webhook probe returned $status, expected 401"; exit 1; }
 
+      # The Playwright suite drives the SAME image through a real browser:
+      # first-run setup, sign-in, two-step verification with a generated TOTP,
+      # invitations delivered to Mailpit, an inbound Mailgun webhook turning
+      # into a code on screen. It needs a stack the smoke test does not have
+      # (Mailpit as the SMTP relay, APP_URL matching the published port), so
+      # the smoke stack comes down and scripts/e2e-stack.sh — the same script
+      # `mise run e2e` uses locally — brings its own up around mi-casa:ci.
+      # No second build: E2E_IMAGE points at the image already sitting here.
+      - name: Start the e2e stack (same image, plus Mailpit)
+        run: |
+          docker rm -f app pg || true
+          docker network rm mi-casa-ci || true
+          E2E_IMAGE=mi-casa:ci bash scripts/e2e-stack.sh up
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('bun.lock') }}
+          restore-keys: ${{ runner.os }}-playwright-
+
+      - name: Install Playwright browser
+        run: bunx playwright install --with-deps chromium
+
+      - name: E2E tests
+        env:
+          E2E_BASE_URL: http://127.0.0.1:3300
+        run: cd e2e && bunx playwright test
+
+      # The trace of a failed run is the only way to see what the browser saw;
+      # the runner is thrown away seconds later.
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-report
+          path: e2e/playwright-report
+          if-no-files-found: ignore
+
       # Only after the smoke test: an image that does not serve must never
       # reach the registry, not even as a preview.
       #
@@ -237,16 +275,20 @@ jobs:
 
       # Whatever failed above, the container's own log is the only place
       # that says why — the image has no shell to go poking around in.
+      # Both stacks are named, because the failure could be in either.
       # Last, so it catches a failure in any step before it, the preview
       # push included.
       - name: Container logs on failure
         if: failure()
-        run: docker logs app || true
+        run: |
+          docker logs app || true
+          docker logs mi-casa-e2e-app || true
 
       # The runner is thrown away either way; this keeps a re-run on a
       # self-hosted runner from tripping over a name that is still taken.
-      - name: Tear down the smoke-test stack
+      - name: Tear down the stacks
         if: always()
         run: |
           docker rm -f app pg || true
           docker network rm mi-casa-ci || true
+          bash scripts/e2e-stack.sh down || true

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ apps/server/internal/web/dist/*
 # Playwright
 e2e/playwright-report/
 e2e/test-results/
+
+# Playwright storage state (sessions saved by e2e/global-setup.ts)
+e2e/.auth/

--- a/.mise.toml
+++ b/.mise.toml
@@ -49,9 +49,11 @@ goreleaser release --snapshot --clean --skip=sign
 """
 
 [tasks.e2e]
-description = "Playwright E2E against the real image (builds it if missing)"
+description = "Playwright E2E against the real image, with Mailpit (builds it if missing)"
 run = """
 trap 'bash scripts/e2e-stack.sh down' EXIT
 bash scripts/e2e-stack.sh up
-cd e2e && bunx playwright test
+# In a subshell: the trap above runs in this shell's working directory, and a
+# bare `cd e2e` would leave it looking for scripts/ one level too deep.
+(cd e2e && bunx playwright test)
 """

--- a/biome.json
+++ b/biome.json
@@ -7,6 +7,8 @@
       "!.wrangler",
       "!apps/server",
       "!e2e/playwright-report",
+      "!e2e/test-results",
+      "!e2e/.auth",
       "!apps/frontend/src/lib/api-schema.d.ts"
     ]
   },

--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
         "@cloudflare/vite-plugin": "1.53.1",
         "@cloudflare/vitest-pool-workers": "^0.22.0",
         "@cloudflare/workers-types": "5.20260820.1",
+        "@playwright/test": "1.63.0",
         "@testing-library/jest-dom": "^7.0.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.5",
@@ -40,6 +41,7 @@
         "concurrently": "10.0.5",
         "drizzle-kit": "^0.31.10",
         "jsdom": "^30.0.1",
+        "otpauth": "9.5.2",
         "typescript": "7.0.2",
         "vite": "8.2.2",
         "vitest": "4.1.11",
@@ -364,7 +366,7 @@
 
     "@noble/ciphers": ["@noble/ciphers@2.3.0", "", {}, "sha512-Clu/xdfgVTf9o7ngLOURaxePwR0j8sjclKEtVij10/jGulwFsPWCvvRgG/XjUVf8Nei+jLG6uwyXzUTGY1DQrw=="],
 
-    "@noble/hashes": ["@noble/hashes@2.3.0", "", {}, "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ=="],
+    "@noble/hashes": ["@noble/hashes@2.4.0", "", {}, "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA=="],
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
 
@@ -395,6 +397,8 @@
     "@peculiar/utils": ["@peculiar/utils@2.0.3", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ=="],
 
     "@peculiar/x509": ["@peculiar/x509@1.14.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.0", "@peculiar/asn1-csr": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.0", "@peculiar/asn1-pkcs9": "^2.6.0", "@peculiar/asn1-rsa": "^2.6.0", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.0", "pvtsutils": "^1.3.6", "reflect-metadata": "^0.2.2", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA=="],
+
+    "@playwright/test": ["@playwright/test@1.63.0", "", { "dependencies": { "playwright": "1.63.0" }, "bin": { "playwright": "cli.js" } }, "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ=="],
 
     "@popperjs/core": ["@popperjs/core@2.11.8", "", {}, "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="],
 
@@ -758,6 +762,8 @@
 
     "openapi-typescript-helpers": ["openapi-typescript-helpers@0.1.0", "", {}, "sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw=="],
 
+    "otpauth": ["otpauth@9.5.2", "", { "dependencies": { "@noble/hashes": "2.4.0" } }, "sha512-GQ5emWR/x1tcExT62IBT0UfO95wZzJZyxYOJOGVeQF47SYEN9vmh0vISvDZaNMuFJRG+IaWCKtfm+t9Bfoal6w=="],
+
     "p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
     "p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
@@ -783,6 +789,10 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "playwright": ["playwright@1.63.0", "", { "dependencies": { "playwright-core": "1.63.0" }, "bin": { "playwright": "cli.js" } }, "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg=="],
+
+    "playwright-core": ["playwright-core@1.63.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg=="],
 
     "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
 
@@ -954,6 +964,8 @@
 
     "@babel/generator/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@better-auth/utils/@noble/hashes": ["@noble/hashes@2.3.0", "", {}, "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ=="],
+
     "@cloudflare/vitest-pool-workers/miniflare": ["miniflare@5.20260815.0-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260815.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-YAaGj4Sh5f4fqHKiMQ8zRHDOOM5IGUVtMhnLIeyjuQfU+9P6hcOTrHUVtbfj/ZPay9Kzik4pWELB39pGgefjiQ=="],
 
     "@cloudflare/vitest-pool-workers/wrangler": ["wrangler@4.124.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "5.20260815.0-alpha", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260815.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260815.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-75euoZKjVTJYFy+Xhctt/5JlZL4M6A4xmovZsUlep+6GHcCm14n9VtdGzNIybOW2t8wuNxRj5iMUwjT5E7Ctog=="],
@@ -963,6 +975,8 @@
     "@jridgewell/gen-mapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
+    "better-auth/@noble/hashes": ["@noble/hashes@2.3.0", "", {}, "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ=="],
 
     "better-call/@better-auth/utils": ["@better-auth/utils@0.5.0", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-BL8W4EfIZFwlu0r54m3v1ztjDhu6dDe/amLTm0xybmbZaNgYUqhD3SjpAsnq0q8YD6/ki4iwIgxJNLP/N3TxiA=="],
 
@@ -991,6 +1005,8 @@
     "@cloudflare/vitest-pool-workers/miniflare/workerd": ["workerd@1.20260815.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260815.1", "@cloudflare/workerd-darwin-arm64": "1.20260815.1", "@cloudflare/workerd-linux-64": "1.20260815.1", "@cloudflare/workerd-linux-arm64": "1.20260815.1", "@cloudflare/workerd-windows-64": "1.20260815.1" }, "bin": "bin/workerd" }, "sha512-8bArFkHmlp7qFEKVPyNzDzHzS35gc2fg0PYBcDtaNLF7UCDryCX2BQnpkUkTHYIy824IRrHOTwOEoTj0sUO2Fg=="],
 
     "@cloudflare/vitest-pool-workers/wrangler/workerd": ["workerd@1.20260815.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260815.1", "@cloudflare/workerd-darwin-arm64": "1.20260815.1", "@cloudflare/workerd-linux-64": "1.20260815.1", "@cloudflare/workerd-linux-arm64": "1.20260815.1", "@cloudflare/workerd-windows-64": "1.20260815.1" }, "bin": "bin/workerd" }, "sha512-8bArFkHmlp7qFEKVPyNzDzHzS35gc2fg0PYBcDtaNLF7UCDryCX2BQnpkUkTHYIy824IRrHOTwOEoTj0sUO2Fg=="],
+
+    "better-call/@better-auth/utils/@noble/hashes": ["@noble/hashes@2.3.0", "", {}, "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ=="],
 
     "qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
 

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,130 @@
+import { expect, test } from "./fixtures";
+import {
+  apiSignIn,
+  createMember,
+  newBrowserContext,
+  OWNER_EMAIL,
+  OWNER_SLUG,
+  PASSWORD,
+  SIGNED_OUT,
+  signIn,
+  signOut,
+} from "./helpers";
+
+// The seam no unit test sees: the limen-auth client driving the real login
+// screen against the real server, and the session that comes out of it living
+// in a real cookie jar.
+
+test.describe("the login screen", () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test("signs the owner in and lands in their household inbox", async ({
+    page,
+  }) => {
+    await signIn(page, OWNER_EMAIL, PASSWORD);
+
+    await expect(page).toHaveURL(new RegExp(`/${OWNER_SLUG}/inbox`), {
+      timeout: 15_000,
+    });
+    await expect(
+      page.getByRole("heading", { name: "Latest codes" }),
+    ).toBeVisible();
+  });
+
+  test("rejects a wrong password and stays put", async ({ page }) => {
+    await signIn(page, OWNER_EMAIL, "not-the-right-password");
+
+    await expect(page.getByRole("alert")).toBeVisible();
+    await expect(page).toHaveURL(/\/login/);
+    // Still nobody: the protected route bounces straight back.
+    await page.goto(`/${OWNER_SLUG}/inbox`).catch(() => {});
+    await expect(page).toHaveURL(/\/login/, { timeout: 15_000 });
+  });
+});
+
+test.describe("signing out", () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  // Deliberately NOT the owner: global-setup.ts's owner session is shared by
+  // every owner-only spec, and signing it out here would revoke it for all of
+  // them. A member created for this test alone has nothing else depending on
+  // it.
+  test("signs out from the account menu and the session is really gone", async ({
+    browser,
+  }) => {
+    const member = await createMember(OWNER_SLUG, { tag: "signout" });
+    const context = await newBrowserContext(browser, {
+      storageState: member.state,
+    });
+
+    try {
+      const page = await context.newPage();
+      await page.goto(`/${OWNER_SLUG}/inbox`);
+      await expect(
+        page.getByRole("heading", { name: "Latest codes" }),
+      ).toBeVisible();
+
+      await signOut(page);
+
+      // The SPA's own redirect aborts the navigation — that abort IS the
+      // evidence, so swallow it and assert where the browser ended up.
+      await page.goto(`/${OWNER_SLUG}/inbox`).catch(() => {});
+      await expect(page).toHaveURL(/\/login/, { timeout: 15_000 });
+    } finally {
+      await context.close();
+    }
+  });
+});
+
+test.describe("session revocation", () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test("signing out everywhere else kills the other device's session", async ({
+    browser,
+  }) => {
+    // A member of the owner's household, created through the invitation flow
+    // so nothing here depends on the owner's own session surviving the test.
+    const member = await createMember(OWNER_SLUG, { tag: "revoke" });
+
+    const laptop = await newBrowserContext(browser, {
+      storageState: member.state,
+    });
+    const phone = await newBrowserContext(browser, {
+      storageState: SIGNED_OUT,
+    });
+
+    try {
+      // Two genuine sessions for one account: the one acceptance minted, and
+      // a second from a fresh sign-in on another device.
+      await apiSignIn(phone.request, member.email);
+
+      const phonePage = await phone.newPage();
+      await phonePage.goto(`/${OWNER_SLUG}/inbox`);
+      await expect(
+        phonePage.getByRole("heading", { name: "Latest codes" }),
+      ).toBeVisible();
+
+      const laptopPage = await laptop.newPage();
+      await laptopPage.goto("/settings");
+      const devices = laptopPage.getByRole("list", {
+        name: "Signed-in devices",
+      });
+      await expect(devices.getByRole("listitem")).toHaveCount(2);
+
+      await laptopPage
+        .getByRole("button", { name: "Sign out everywhere else" })
+        .click();
+      await laptopPage.getByRole("button", { name: "Sign out others" }).click();
+      await expect(
+        laptopPage.getByText("Only this device is signed in."),
+      ).toBeVisible();
+
+      // The revoked device is out: its next navigation bounces to sign-in.
+      await phonePage.goto(`/${OWNER_SLUG}/inbox`).catch(() => {});
+      await expect(phonePage).toHaveURL(/\/login/, { timeout: 15_000 });
+    } finally {
+      await phone.close();
+      await laptop.close();
+    }
+  });
+});

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,7 +1,7 @@
 import { test as base, expect } from "@playwright/test";
 import { BASE_URL, clientAddressHeaders } from "./helpers";
 
-// Two things every spec needs and no spec should have to remember.
+// Three things every spec needs and no spec should have to remember.
 //
 // 1. Clipboard access. Copying is not decoration in this app — it is the
 //    action. `CopyButton` only reports success (and the inbox only marks a
@@ -10,10 +10,18 @@ import { BASE_URL, clientAddressHeaders } from "./helpers";
 //    origin has been granted clipboard-write. Without this, copy-then-mark-used
 //    would fail for a reason that has nothing to do with the app.
 //
-// 2. Its own client address. The stack runs behind a one-hop proxy contract
-//    (TRUSTED_PROXY_HOPS=1) and this header is what the app reads as the
-//    caller's address, so each test's browser is one household member as far
-//    as the rate limiters are concerned. See helpers.ts's clientAddress.
+// 2. A client address for the browser. The stack runs behind a one-hop proxy
+//    contract (TRUSTED_PROXY_HOPS=1) and this header is what the app reads as
+//    the caller's address, so each test's browser is one household member as
+//    far as the rate limiters are concerned. See helpers.ts's clientAddress.
+//
+// 3. The same for `request`. Playwright's built-in fixture is a separate
+//    APIRequestContext that knows nothing about the browser context's headers,
+//    so without this override every `request`-based call in the suite — the
+//    setup attempts, the inbound webhook posts, the Mailpit reads — shares one
+//    bucket keyed on the docker gateway's address, which is precisely the
+//    situation (2) exists to avoid. `storageState` is threaded through so the
+//    fixture still honours whatever a file's `test.use` asked for.
 export const test = base.extend({
   context: async ({ context }, use) => {
     await context.grantPermissions(["clipboard-read", "clipboard-write"], {
@@ -21,6 +29,16 @@ export const test = base.extend({
     });
     await context.setExtraHTTPHeaders(clientAddressHeaders());
     await use(context);
+  },
+
+  request: async ({ playwright, storageState }, use) => {
+    const api = await playwright.request.newContext({
+      baseURL: BASE_URL,
+      storageState,
+      extraHTTPHeaders: clientAddressHeaders(),
+    });
+    await use(api);
+    await api.dispose();
   },
 });
 

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,27 @@
+import { test as base, expect } from "@playwright/test";
+import { BASE_URL, clientAddressHeaders } from "./helpers";
+
+// Two things every spec needs and no spec should have to remember.
+//
+// 1. Clipboard access. Copying is not decoration in this app — it is the
+//    action. `CopyButton` only reports success (and the inbox only marks a
+//    code as used) when `navigator.clipboard.writeText` resolves, and in a
+//    headless context that promise rejects with a permission error unless the
+//    origin has been granted clipboard-write. Without this, copy-then-mark-used
+//    would fail for a reason that has nothing to do with the app.
+//
+// 2. Its own client address. The stack runs behind a one-hop proxy contract
+//    (TRUSTED_PROXY_HOPS=1) and this header is what the app reads as the
+//    caller's address, so each test's browser is one household member as far
+//    as the rate limiters are concerned. See helpers.ts's clientAddress.
+export const test = base.extend({
+  context: async ({ context }, use) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"], {
+      origin: BASE_URL,
+    });
+    await context.setExtraHTTPHeaders(clientAddressHeaders());
+    await use(context);
+  },
+});
+
+export { expect };

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,31 +1,142 @@
 import { mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
-import { request as apiRequest } from "@playwright/test";
-import { BASE_URL, completeSetup, OWNER_STATE } from "./helpers";
+import {
+  type APIRequestContext,
+  request as apiRequest,
+  type Browser,
+  chromium,
+  expect,
+} from "@playwright/test";
+import {
+  apiSignIn,
+  BASE_URL,
+  clientAddressHeaders,
+  EMAIL_DOMAIN,
+  OWNER_EMAIL,
+  OWNER_HOUSEHOLD,
+  OWNER_NAME,
+  OWNER_SLUG,
+  OWNER_STATE,
+  PASSWORD,
+  SETUP_SECRET,
+  setupStatus,
+} from "./helpers";
 
 /**
- * Runs once per `playwright test`, before any spec.
+ * Runs once per `playwright test`, before any spec — and it is where the
+ * first-run setup SCREEN is tested.
  *
- * First-run setup can happen exactly once per database, which makes it a poor
- * fit for a test that has to run first: spec file order is not something to
- * rely on, and with two projects the same file runs twice. So setup happens
- * here, through the API, and setup.spec.ts asserts what a CONFIGURED
- * installation does — `/setup` locked, and the same 409 for a wrong secret as
- * for the right one.
+ * Setup can happen exactly once per database, which makes it a poor fit for an
+ * ordinary spec: file order is not something to rely on, and with two projects
+ * the same file would run twice. But it is also the first screen anybody ever
+ * sees, and the only one that creates an account without an invitation, so it
+ * cannot go untested either. So the whole first-run journey is driven here, in
+ * a real browser against the real image — `/` redirecting to `/setup`, a wrong
+ * SETUP_SECRET rejected with the installation left untouched, then the real
+ * secret landing the owner in their inbox — and `setup.spec.ts` picks up
+ * afterwards with what a CONFIGURED installation must do.
  *
- * The owner ends up signed in, and their storage state is saved for every
- * owner-only spec to adopt with `test.use({ storageState: OWNER_STATE })`.
- * That keeps the suite's sign-in count down to the specs whose subject IS
- * signing in — the auth routes are rate limited per client address, and the
- * whole suite shares one.
+ * The session that comes out of it is saved to OWNER_STATE for every
+ * owner-only spec to adopt with `test.use({ storageState: OWNER_STATE })`,
+ * which keeps the suite's sign-in count down to the specs whose subject IS
+ * signing in.
  */
 export default async function globalSetup(): Promise<void> {
-  const context = await apiRequest.newContext({ baseURL: BASE_URL });
+  const api = await apiRequest.newContext({
+    baseURL: BASE_URL,
+    extraHTTPHeaders: clientAddressHeaders(),
+  });
+  const browser = await chromium.launch();
+
   try {
-    await completeSetup(context);
+    const status = await setupStatus(api);
+    if (status.needsSetup) {
+      await runFirstRunSetup(browser, api);
+      return;
+    }
+
+    // Already configured — a re-run against a stack left up from an earlier
+    // `bunx playwright test`. There is no first run left to drive, so the
+    // owner simply signs in. `mise run e2e` always starts a fresh stack, so
+    // this branch is for the iterating-locally case.
+    await apiSignIn(api, OWNER_EMAIL, PASSWORD);
+    await mkdir(dirname(OWNER_STATE), { recursive: true });
+    await api.storageState({ path: OWNER_STATE });
+  } finally {
+    await browser.close();
+    await api.dispose();
+  }
+}
+
+/** The first-run journey, through the screen a real operator uses. */
+async function runFirstRunSetup(browser: Browser, api: APIRequestContext) {
+  const context = await browser.newContext({
+    baseURL: BASE_URL,
+    extraHTTPHeaders: clientAddressHeaders(),
+  });
+  const page = await context.newPage();
+
+  try {
+    // An unconfigured installation sends every visitor to setup, whatever
+    // they asked for.
+    await page.goto("/");
+    await expect(page).toHaveURL(/\/setup/, { timeout: 15_000 });
+    await expect(
+      page.getByRole("heading", { name: "Set up your household inbox" }),
+    ).toBeVisible();
+
+    await page
+      .getByRole("textbox", { name: "Household name" })
+      .fill(OWNER_HOUSEHOLD);
+    // The address is derived from the household name as you type; setting it
+    // by hand is what an operator who wants a particular mailbox does, and the
+    // preview underneath is the promise being made about where mail arrives.
+    await page.getByRole("textbox", { name: "Inbox address" }).fill(OWNER_SLUG);
+    await expect(
+      page.getByText(
+        `Login codes will arrive at ${OWNER_SLUG}@${EMAIL_DOMAIN}.`,
+      ),
+    ).toBeVisible();
+    await page.getByRole("textbox", { name: "Owner email" }).fill(OWNER_EMAIL);
+    await page.getByRole("textbox", { name: "Your name" }).fill(OWNER_NAME);
+    await page
+      .getByRole("textbox", { name: "Choose a password" })
+      .fill(PASSWORD);
+
+    // --- the wrong secret first: this is the guard the whole screen exists
+    // for, and it has to leave the installation exactly as it found it.
+    await page
+      .getByRole("textbox", { name: "Setup secret" })
+      .fill("not-the-setup-secret");
+    await page.getByRole("button", { name: "Complete setup" }).click();
+
+    await expect(page.getByRole("alert")).toHaveText("Invalid setup secret");
+    await expect(page).toHaveURL(/\/setup/);
+    const afterRejection = await setupStatus(api);
+    expect(
+      afterRejection.needsSetup,
+      "a rejected secret must not claim the installation",
+    ).toBe(true);
+
+    // --- and now the real one
+    await page
+      .getByRole("textbox", { name: "Setup secret" })
+      .fill(SETUP_SECRET);
+    await page.getByRole("button", { name: "Complete setup" }).click();
+
+    // The owner is signed in as part of the same response, so they land on
+    // their household's inbox rather than on a sign-in form asking for the
+    // password they have just chosen.
+    await expect(page).toHaveURL(new RegExp(`/${OWNER_SLUG}/inbox`), {
+      timeout: 20_000,
+    });
+    await expect(
+      page.getByRole("heading", { name: "Latest codes" }),
+    ).toBeVisible();
+
     await mkdir(dirname(OWNER_STATE), { recursive: true });
     await context.storageState({ path: OWNER_STATE });
   } finally {
-    await context.dispose();
+    await context.close();
   }
 }

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,31 @@
+import { mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+import { request as apiRequest } from "@playwright/test";
+import { BASE_URL, completeSetup, OWNER_STATE } from "./helpers";
+
+/**
+ * Runs once per `playwright test`, before any spec.
+ *
+ * First-run setup can happen exactly once per database, which makes it a poor
+ * fit for a test that has to run first: spec file order is not something to
+ * rely on, and with two projects the same file runs twice. So setup happens
+ * here, through the API, and setup.spec.ts asserts what a CONFIGURED
+ * installation does — `/setup` locked, and the same 409 for a wrong secret as
+ * for the right one.
+ *
+ * The owner ends up signed in, and their storage state is saved for every
+ * owner-only spec to adopt with `test.use({ storageState: OWNER_STATE })`.
+ * That keeps the suite's sign-in count down to the specs whose subject IS
+ * signing in — the auth routes are rate limited per client address, and the
+ * whole suite shares one.
+ */
+export default async function globalSetup(): Promise<void> {
+  const context = await apiRequest.newContext({ baseURL: BASE_URL });
+  try {
+    await completeSetup(context);
+    await mkdir(dirname(OWNER_STATE), { recursive: true });
+    await context.storageState({ path: OWNER_STATE });
+  } finally {
+    await context.dispose();
+  }
+}

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -106,14 +106,25 @@ async function body(response: APIResponse): Promise<unknown> {
 }
 
 /**
+ * How many times a 429 is retried before it is allowed to fail.
+ *
+ * Every caller in the suite has its own client address (see clientAddress), so
+ * the per-client limits should never be reached at all and these retries
+ * should never fire. The cap is deliberately small: if a caller loses its
+ * address — the mistake this whole mechanism exists to prevent — the run
+ * should fail quickly, with "429" in the message, rather than sit through
+ * minutes of backoff and then time out saying something else.
+ */
+const RATE_LIMIT_ATTEMPTS = 3;
+const RATE_LIMIT_BACKOFF_MS = 6_000;
+
+/**
  * POSTs with a bounded retry on 429.
  *
  * The auth routes are rate limited per client address — sign-in 5/minute,
  * reset requests 3 per 5 minutes, two-factor verification 5/minute (see
- * apps/server/internal/auth/auth.go) — and every request in the suite comes
- * from one address. Real users never hit those; a suite that signs a handful
- * of accounts in seconds does. The limits stay as they are and the harness
- * backs off, rather than the app being weakened for the tests.
+ * apps/server/internal/auth/auth.go). The limits stay exactly as they are; the
+ * harness gives itself a distinct address per caller and keeps this as a belt.
  */
 async function postWithBackoff(
   request: APIRequestContext,
@@ -121,8 +132,12 @@ async function postWithBackoff(
   options: Parameters<APIRequestContext["post"]>[1],
 ): Promise<APIResponse> {
   let response = await request.post(url, options);
-  for (let attempt = 0; response.status() === 429 && attempt < 12; attempt++) {
-    await sleep(6_000);
+  for (
+    let attempt = 1;
+    response.status() === 429 && attempt < RATE_LIMIT_ATTEMPTS;
+    attempt++
+  ) {
+    await sleep(RATE_LIMIT_BACKOFF_MS);
     response = await request.post(url, options);
   }
   return response;
@@ -148,48 +163,6 @@ export async function setupStatus(
   const response = await request.get(`${BASE_URL}/api/setup/status`);
   expect(response.ok(), `setup status: ${response.status()}`).toBeTruthy();
   return (await response.json()) as SetupStatus;
-}
-
-/**
- * Completes first-run setup, once per stack.
- *
- * `/setup` can only ever succeed once against a given database, so this is
- * idempotent by design: a stack that is already configured answers 409 and the
- * owner is signed in with their password instead. That is what lets
- * global-setup.ts run against a fresh stack and against one left up from an
- * earlier `bunx playwright test` alike.
- */
-export async function completeSetup(request: APIRequestContext): Promise<void> {
-  const status = await setupStatus(request);
-
-  if (status.needsSetup) {
-    const response = await postWithBackoff(
-      request,
-      `${BASE_URL}/api/setup/complete`,
-      {
-        headers: originHeader,
-        data: {
-          email: OWNER_EMAIL,
-          name: OWNER_NAME,
-          password: PASSWORD,
-          householdName: OWNER_HOUSEHOLD,
-          householdSlug: OWNER_SLUG,
-          setupSecret: SETUP_SECRET,
-        },
-      },
-    );
-    // 409 means somebody (a previous run) got there first — fall through to
-    // the sign-in below rather than failing a perfectly usable stack.
-    if (response.status() !== 409) {
-      expect(
-        response.status(),
-        `setup: ${response.status()} ${JSON.stringify(await body(response))}`,
-      ).toBe(201);
-      return;
-    }
-  }
-
-  await apiSignIn(request, OWNER_EMAIL, PASSWORD);
 }
 
 // ------------------------------------------------------------------- auth
@@ -253,8 +226,8 @@ export async function signIn(
       ),
       page.getByRole("button", { name: "Sign in", exact: true }).click(),
     ]);
-    if (response.status() !== 429 || attempt >= 12) return;
-    await sleep(6_000);
+    if (response.status() !== 429 || attempt >= RATE_LIMIT_ATTEMPTS - 1) return;
+    await sleep(RATE_LIMIT_BACKOFF_MS);
   }
 }
 
@@ -282,8 +255,8 @@ export async function submitChallengeCode(
       ),
       page.getByRole("button", { name: "Verify" }).click(),
     ]);
-    if (response.status() !== 429 || attempt >= 12) return;
-    await sleep(6_000);
+    if (response.status() !== 429 || attempt >= RATE_LIMIT_ATTEMPTS - 1) return;
+    await sleep(RATE_LIMIT_BACKOFF_MS);
   }
 }
 
@@ -339,13 +312,6 @@ const appLinkPattern = new RegExp(
 );
 
 export const mailpit = {
-  /** Everything Mailpit is holding, deleted. Specs that read "the latest mail
-   * to X" call this first when the same address is written to twice. */
-  async deleteAll(request: APIRequestContext): Promise<void> {
-    const response = await request.delete(`${MAILPIT_URL}/api/v1/messages`);
-    expect(response.ok(), `mailpit delete: ${response.status()}`).toBeTruthy();
-  },
-
   /**
    * The newest message delivered to `email`, with the app link from its plain
    * text body already extracted.

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,712 @@
+import { createHmac } from "node:crypto";
+import { mkdir } from "node:fs/promises";
+import {
+  type APIRequestContext,
+  type APIResponse,
+  request as apiRequest,
+  type Browser,
+  type BrowserContext,
+  type BrowserContextOptions,
+  expect,
+  type Page,
+} from "@playwright/test";
+import { TOTP, URI } from "otpauth";
+
+// Everything the specs share: the constants the e2e stack is started with
+// (scripts/e2e-stack.sh), the API shortcuts fixtures use instead of driving a
+// screen that is not under test, and the three seams no unit test can reach —
+// Mailpit, the signed Mailgun webhook, and a real TOTP.
+
+/** Where the app is. Must match the stack's APP_URL: it is the origin the
+ * same-site guard compares against and the base of every mailed link. */
+export const BASE_URL = process.env.E2E_BASE_URL ?? "http://127.0.0.1:3300";
+
+/** Mailpit's HTTP API (the container publishes 8025 here). */
+export const MAILPIT_URL =
+  process.env.E2E_MAILPIT_URL ?? "http://127.0.0.1:8325";
+
+/** scripts/e2e-stack.sh's SETUP_SECRET / OWNER_EMAIL / EMAIL_DOMAIN. */
+export const SETUP_SECRET = "e2e-setup-secret";
+export const OWNER_EMAIL = "owner@e2e.test";
+export const EMAIL_DOMAIN = "e2e.test";
+/** scripts/e2e-stack.sh's MAILGUN_WEBHOOK_SIGNING_KEY. */
+export const MAILGUN_SIGNING_KEY = "e2e-signing-key";
+
+/** The household global-setup.ts creates. Its slug is also its mailbox. */
+export const OWNER_SLUG = "e2e-home";
+export const OWNER_HOUSEHOLD = "E2E Household";
+export const OWNER_NAME = "Ola Owner";
+
+/**
+ * One password for every synthetic account. The server's floor is 12
+ * characters (setup, invitation acceptance and reset all say so), and the SPA
+ * refuses to submit anything shorter, so this is deliberately over it.
+ */
+export const PASSWORD = "e2e-password-12345";
+
+/**
+ * Where saved sessions live. Relative on purpose: the suite is always run from
+ * `e2e/` (the mise task and the CI job both cd here, and Playwright resolves a
+ * config's own relative paths the same way), so one spelling serves
+ * `context.storageState({ path })` and `test.use({ storageState })` alike.
+ */
+const STATE_DIR = ".auth";
+
+/** Where global-setup.ts leaves the owner's signed-in state. */
+export const OWNER_STATE = `${STATE_DIR}/owner.json`;
+
+let counter = 0;
+
+/** A unique address per call so specs never collide on accounts or mailboxes. */
+export function freshEmail(tag: string): string {
+  counter += 1;
+  return `${tag}-${Date.now().toString(36)}-${counter}@${EMAIL_DOMAIN}`;
+}
+
+/** A unique service key per call: two projects run inbox.spec.ts against one
+ * database, and a provider key is unique per household. */
+export function freshKey(tag: string): string {
+  counter += 1;
+  return `${tag}-${Date.now().toString(36)}-${counter}`;
+}
+
+/**
+ * A distinct client address for one browser context or API client.
+ *
+ * The stack runs with TRUSTED_PROXY_HOPS=1 and the suite plays the reverse
+ * proxy, so this header is what the app takes as the caller's address. Every
+ * per-client rate limit — sign-in 5/min, the session endpoint 60/min,
+ * invitations 20 per 10 minutes — is then scoped to one simulated household
+ * member, which is what those limits are for. Lumped into a single address, a
+ * suite that navigates a few dozen times in ninety seconds is indistinguishable
+ * from an attack, and the 429 on /api/auth/me reads to the SPA as "signed out".
+ */
+export function clientAddress(): string {
+  counter += 1;
+  return `10.77.${Math.floor(counter / 250) % 250}.${(counter % 250) + 1}`;
+}
+
+/** The header pair the app reads that address from. */
+export function clientAddressHeaders(): Record<string, string> {
+  return { "X-Forwarded-For": clientAddress() };
+}
+
+/** Playwright's own wait, used only where a fixed window genuinely has to
+ * elapse (see signIn). Never as a substitute for waiting on state. */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function body(response: APIResponse): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return await response.text();
+  }
+}
+
+/**
+ * POSTs with a bounded retry on 429.
+ *
+ * The auth routes are rate limited per client address — sign-in 5/minute,
+ * reset requests 3 per 5 minutes, two-factor verification 5/minute (see
+ * apps/server/internal/auth/auth.go) — and every request in the suite comes
+ * from one address. Real users never hit those; a suite that signs a handful
+ * of accounts in seconds does. The limits stay as they are and the harness
+ * backs off, rather than the app being weakened for the tests.
+ */
+async function postWithBackoff(
+  request: APIRequestContext,
+  url: string,
+  options: Parameters<APIRequestContext["post"]>[1],
+): Promise<APIResponse> {
+  let response = await request.post(url, options);
+  for (let attempt = 0; response.status() === 429 && attempt < 12; attempt++) {
+    await sleep(6_000);
+    response = await request.post(url, options);
+  }
+  return response;
+}
+
+/** The Origin every state-changing API call carries: both the app's same-site
+ * guard and Limen's own origin check compare it against APP_URL. A browser
+ * sets it automatically; an APIRequestContext does not. */
+const originHeader = { Origin: BASE_URL };
+
+// ------------------------------------------------------------------ setup
+
+export interface SetupStatus {
+  status: string;
+  needsSetup: boolean;
+  setupLocked: boolean;
+  emailDomain?: string;
+}
+
+export async function setupStatus(
+  request: APIRequestContext,
+): Promise<SetupStatus> {
+  const response = await request.get(`${BASE_URL}/api/setup/status`);
+  expect(response.ok(), `setup status: ${response.status()}`).toBeTruthy();
+  return (await response.json()) as SetupStatus;
+}
+
+/**
+ * Completes first-run setup, once per stack.
+ *
+ * `/setup` can only ever succeed once against a given database, so this is
+ * idempotent by design: a stack that is already configured answers 409 and the
+ * owner is signed in with their password instead. That is what lets
+ * global-setup.ts run against a fresh stack and against one left up from an
+ * earlier `bunx playwright test` alike.
+ */
+export async function completeSetup(request: APIRequestContext): Promise<void> {
+  const status = await setupStatus(request);
+
+  if (status.needsSetup) {
+    const response = await postWithBackoff(
+      request,
+      `${BASE_URL}/api/setup/complete`,
+      {
+        headers: originHeader,
+        data: {
+          email: OWNER_EMAIL,
+          name: OWNER_NAME,
+          password: PASSWORD,
+          householdName: OWNER_HOUSEHOLD,
+          householdSlug: OWNER_SLUG,
+          setupSecret: SETUP_SECRET,
+        },
+      },
+    );
+    // 409 means somebody (a previous run) got there first — fall through to
+    // the sign-in below rather than failing a perfectly usable stack.
+    if (response.status() !== 409) {
+      expect(
+        response.status(),
+        `setup: ${response.status()} ${JSON.stringify(await body(response))}`,
+      ).toBe(201);
+      return;
+    }
+  }
+
+  await apiSignIn(request, OWNER_EMAIL, PASSWORD);
+}
+
+// ------------------------------------------------------------------- auth
+
+/**
+ * Signs in over the API. The session cookie lands in the caller's cookie jar,
+ * so a page built on the same context is signed in too. The login SCREEN is
+ * driven by signIn() below, which auth.spec.ts and two-factor.spec.ts use —
+ * every other spec takes this door, because their subject is elsewhere and
+ * each extra sign-in eats the 5-per-minute allowance.
+ */
+export async function apiSignIn(
+  request: APIRequestContext,
+  email: string,
+  password: string = PASSWORD,
+): Promise<void> {
+  const response = await postWithBackoff(
+    request,
+    `${BASE_URL}/api/auth/signin/credential`,
+    { headers: originHeader, data: { credential: email, password } },
+  );
+  expect(
+    response.ok(),
+    `sign-in for ${email}: ${response.status()} ${JSON.stringify(await body(response))}`,
+  ).toBeTruthy();
+}
+
+/**
+ * Signs in through the real login screen.
+ *
+ * The submit is watched at the network level rather than by reading the error
+ * alert: a 429 from the shared limiter and a genuinely wrong password both
+ * render an alert, and only one of them is worth retrying. The fixed window is
+ * a minute long, so nothing shorter than a wait gets back in — this is the one
+ * place in the suite where time itself has to pass.
+ *
+ * Resolves once the response is in; the caller asserts where the app landed
+ * (an account with two-step verification on goes to /two-factor, not home).
+ */
+export async function signIn(
+  page: Page,
+  email: string,
+  password: string = PASSWORD,
+): Promise<void> {
+  await page.goto("/login");
+  // Accessible names, not label text: MUI appends an aria-hidden "*" to the
+  // <label> of a required field, so the label's own text is "Password *".
+  await page
+    .getByRole("textbox", { name: "Email address", exact: true })
+    .fill(email);
+  await page
+    .getByRole("textbox", { name: "Password", exact: true })
+    .fill(password);
+
+  for (let attempt = 0; ; attempt++) {
+    const [response] = await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/auth/signin/credential") &&
+          r.request().method() === "POST",
+      ),
+      page.getByRole("button", { name: "Sign in", exact: true }).click(),
+    ]);
+    if (response.status() !== 429 || attempt >= 12) return;
+    await sleep(6_000);
+  }
+}
+
+/** Signs out through the account menu in the app bar. */
+export async function signOut(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "Open account menu" }).click();
+  await page.getByRole("menuitem", { name: "Sign out" }).click();
+  await expect(page).toHaveURL(/\/login/, { timeout: 15_000 });
+}
+
+/** Answers the two-step challenge on /two-factor with the code given. */
+export async function submitChallengeCode(
+  page: Page,
+  code: string,
+): Promise<void> {
+  const field = page.getByLabel(/Authenticator code|Backup code/);
+  await field.fill(code);
+
+  for (let attempt = 0; ; attempt++) {
+    const [response] = await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/auth/two-factor/verify") &&
+          r.request().method() === "POST",
+      ),
+      page.getByRole("button", { name: "Verify" }).click(),
+    ]);
+    if (response.status() !== 429 || attempt >= 12) return;
+    await sleep(6_000);
+  }
+}
+
+/** The current 6-digit code for an otpauth:// URI, as an authenticator app
+ * would show it. */
+export function totpFrom(uri: string): string {
+  const totp = URI.parse(uri);
+  if (!(totp instanceof TOTP)) {
+    throw new Error(`not a TOTP URI: ${uri}`);
+  }
+  return totp.generate();
+}
+
+/**
+ * A code the account has not answered with before.
+ *
+ * A TOTP is only valid once: finishing enrolment and then signing in a couple
+ * of seconds later would otherwise present the same six digits inside the same
+ * 30-second window, and the server is right to refuse them. Waiting for the
+ * period to roll over is what a person with a phone does too — and it is a
+ * wait on the code CHANGING, not a fixed sleep.
+ */
+export async function nextTotp(uri: string, previous: string): Promise<string> {
+  const deadline = Date.now() + 40_000;
+  let code = totpFrom(uri);
+  while (code === previous) {
+    if (Date.now() > deadline) {
+      throw new Error("the TOTP period never rolled over");
+    }
+    await sleep(500);
+    code = totpFrom(uri);
+  }
+  return code;
+}
+
+// ---------------------------------------------------------------- mailpit
+
+interface MailpitSummary {
+  ID: string;
+  Subject: string;
+}
+
+export interface CapturedMail {
+  id: string;
+  subject: string;
+  text: string;
+  /** The first link back into the app — the invitation or reset link. */
+  link: string;
+}
+
+const appLinkPattern = new RegExp(
+  `${BASE_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/[^\\s<>"']+`,
+);
+
+export const mailpit = {
+  /** Everything Mailpit is holding, deleted. Specs that read "the latest mail
+   * to X" call this first when the same address is written to twice. */
+  async deleteAll(request: APIRequestContext): Promise<void> {
+    const response = await request.delete(`${MAILPIT_URL}/api/v1/messages`);
+    expect(response.ok(), `mailpit delete: ${response.status()}`).toBeTruthy();
+  },
+
+  /**
+   * The newest message delivered to `email`, with the app link from its plain
+   * text body already extracted.
+   *
+   * Mail leaves the app on the request that triggered it, but Mailpit indexes
+   * it a moment later, so this polls the search endpoint rather than assuming
+   * it is there — a wait on state, not a sleep.
+   */
+  async lastMessageTo(
+    request: APIRequestContext,
+    email: string,
+    options: { timeout?: number; after?: string } = {},
+  ): Promise<CapturedMail> {
+    const deadline = Date.now() + (options.timeout ?? 15_000);
+    let summary: MailpitSummary | undefined;
+
+    while (!summary) {
+      const response = await request.get(
+        `${MAILPIT_URL}/api/v1/search?query=${encodeURIComponent(`to:${email}`)}`,
+      );
+      if (response.ok()) {
+        const found = (await response.json()) as {
+          messages?: MailpitSummary[];
+        };
+        // Newest first. `after` is the id of the message this caller has
+        // already read, so "the reset link" and "the resent invitation" wait
+        // for the NEW mail instead of racing the old one still sitting there.
+        const newest = found.messages?.[0];
+        summary = newest && newest.ID !== options.after ? newest : undefined;
+      }
+      if (!summary) {
+        if (Date.now() > deadline) {
+          throw new Error(
+            `no new mail delivered to ${email} within the timeout`,
+          );
+        }
+        await sleep(250);
+      }
+    }
+
+    const detail = await request.get(
+      `${MAILPIT_URL}/api/v1/message/${summary.ID}`,
+    );
+    expect(
+      detail.ok(),
+      `mailpit message ${summary.ID}: ${detail.status()}`,
+    ).toBeTruthy();
+    const message = (await detail.json()) as { Subject: string; Text: string };
+    const link = appLinkPattern.exec(message.Text ?? "")?.[0] ?? "";
+
+    return {
+      id: summary.ID,
+      subject: message.Subject,
+      text: message.Text ?? "",
+      link,
+    };
+  },
+};
+
+// --------------------------------------------------------- inbound mail
+
+export interface InboundMail {
+  /** Envelope recipient: `<slug>@e2e.test`. */
+  to: string;
+  /** Envelope sender, also used as the From header unless headerFrom is set. */
+  from: string;
+  headerFrom?: string;
+  subject: string;
+  text: string;
+  /** X-Mailgun-Spf. Omit for a message with no authentication annotation at
+   * all, which the verdict treats as "nothing to check". */
+  spf?: string;
+  /** X-Mailgun-Dkim-Check-Result. */
+  dkim?: string;
+}
+
+/** One RFC 5322 message, the shape Mailgun puts in `body-mime`. */
+function rawMessage(mail: InboundMail): string {
+  const lines = [`From: Service <${mail.headerFrom ?? mail.from}>`];
+  if (mail.spf) lines.push(`X-Mailgun-Spf: ${mail.spf}`);
+  if (mail.dkim) lines.push(`X-Mailgun-Dkim-Check-Result: ${mail.dkim}`);
+  lines.push(
+    `To: ${mail.to}`,
+    `Subject: ${mail.subject}`,
+    `Message-ID: <${Math.random().toString(36).slice(2)}@${EMAIL_DOMAIN}>`,
+    `Date: ${new Date().toUTCString()}`,
+    "Content-Type: text/plain; charset=utf-8",
+    "",
+    mail.text,
+  );
+  return lines.join("\r\n");
+}
+
+let tokenCounter = 0;
+
+/**
+ * Delivers one message the way Mailgun would: a multipart form carrying the
+ * raw message in `body-mime`, signed with the stack's webhook key
+ * (hex HMAC-SHA256 over timestamp+token). This is the only way into the
+ * pipeline — there is no test-only ingest route — so the suite exercises the
+ * signature check, the MIME parse, the classifier and the extractor together.
+ */
+export async function postInbound(
+  request: APIRequestContext,
+  mail: InboundMail,
+): Promise<APIResponse> {
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  tokenCounter += 1;
+  const token = `e2e-token-${Date.now().toString(36)}-${tokenCounter}`;
+  const signature = createHmac("sha256", MAILGUN_SIGNING_KEY)
+    .update(timestamp + token)
+    .digest("hex");
+
+  const response = await request.post(`${BASE_URL}/api/inbound/mailgun/mime`, {
+    multipart: {
+      recipient: mail.to,
+      sender: mail.from,
+      timestamp,
+      token,
+      signature,
+      "body-mime": rawMessage(mail),
+    },
+  });
+  expect(
+    response.status(),
+    `inbound delivery: ${response.status()} ${JSON.stringify(await body(response))}`,
+  ).toBe(200);
+  return response;
+}
+
+// ------------------------------------------------------- app API shortcuts
+
+/** An API context signed in as the owner, for the seeding a spec's subject is
+ * not. Dispose it when done. */
+export function ownerApi(): Promise<APIRequestContext> {
+  return apiRequest.newContext({
+    baseURL: BASE_URL,
+    storageState: OWNER_STATE,
+    extraHTTPHeaders: clientAddressHeaders(),
+  });
+}
+
+/**
+ * An API context with no session at all — spelled out, because inside a test
+ * `request.newContext()` inherits the storage state the file put in `use`, and
+ * an "anonymous" caller that turns out to be the owner silently changes what
+ * an endpoint does (invitation acceptance answers 403 to the wrong account).
+ */
+export function anonymousApi(): Promise<APIRequestContext> {
+  return apiRequest.newContext({
+    baseURL: BASE_URL,
+    storageState: { cookies: [], origins: [] },
+    extraHTTPHeaders: clientAddressHeaders(),
+  });
+}
+
+export interface Service {
+  id: string;
+  providerKey: string;
+  displayName: string;
+}
+
+/** Creates a service (and optionally its first domain sender) for a household.
+ * The caller's context must be an owner of `slug`. */
+export async function createService(
+  request: APIRequestContext,
+  slug: string,
+  options: { key: string; name: string; senderDomain?: string },
+): Promise<Service> {
+  const created = await request.post(
+    `${BASE_URL}/api/admin/${slug}/providers`,
+    {
+      headers: originHeader,
+      data: { providerKey: options.key, displayName: options.name },
+    },
+  );
+  expect(
+    created.status(),
+    `create service: ${created.status()} ${JSON.stringify(await body(created))}`,
+  ).toBe(201);
+  const provider = ((await created.json()) as { provider: { id: string } })
+    .provider;
+
+  if (options.senderDomain) {
+    const rule = await request.post(
+      `${BASE_URL}/api/admin/${slug}/provider-rules`,
+      {
+        headers: originHeader,
+        data: {
+          providerId: provider.id,
+          matchType: "domain",
+          matchValue: options.senderDomain,
+        },
+      },
+    );
+    expect(
+      rule.status(),
+      `create sender rule: ${rule.status()} ${JSON.stringify(await body(rule))}`,
+    ).toBe(201);
+  }
+
+  return {
+    id: provider.id,
+    providerKey: options.key,
+    displayName: options.name,
+  };
+}
+
+export interface Invitation {
+  token: string;
+  url: string;
+  emailSent: boolean;
+  email: string;
+  id: string;
+}
+
+/** Issues an invitation as the owner. Returns the link the invitee would get
+ * (which is also what the "share this link" dialog shows). */
+export async function invite(
+  request: APIRequestContext,
+  slug: string,
+  options: {
+    email: string;
+    name: string;
+    role?: "member" | "owner";
+    providerIds?: string[];
+  },
+): Promise<Invitation> {
+  const response = await request.post(
+    `${BASE_URL}/api/admin/${slug}/invitations`,
+    {
+      headers: originHeader,
+      data: {
+        email: options.email,
+        name: options.name,
+        role: options.role ?? "member",
+        providerIds: options.providerIds ?? [],
+      },
+    },
+  );
+  expect(
+    response.status(),
+    `invite: ${response.status()} ${JSON.stringify(await body(response))}`,
+  ).toBe(201);
+
+  const result = (await response.json()) as {
+    invitation: { id: string; email: string };
+    inviteUrl: string;
+    emailSent: boolean;
+  };
+  return {
+    id: result.invitation.id,
+    email: result.invitation.email,
+    url: result.inviteUrl,
+    token: result.inviteUrl.split("/invite/")[1] ?? "",
+    emailSent: result.emailSent,
+  };
+}
+
+/**
+ * Accepts an invitation as a brand-new account. The caller's context must be
+ * signed OUT; the response sets that context's session cookie, so the new
+ * member is signed in afterwards and their storage state can be saved.
+ */
+export async function acceptInvitation(
+  request: APIRequestContext,
+  token: string,
+  options: { name: string; password?: string },
+): Promise<{ slug: string }> {
+  const response = await postWithBackoff(
+    request,
+    `${BASE_URL}/api/invitations/accept`,
+    {
+      headers: { ...originHeader, "X-Invitation-Token": token },
+      data: { name: options.name, password: options.password ?? PASSWORD },
+    },
+  );
+  expect(
+    response.ok(),
+    `accept invitation: ${response.status()} ${JSON.stringify(await body(response))}`,
+  ).toBeTruthy();
+  const accepted = (await response.json()) as {
+    household?: { slug: string } | null;
+  };
+  return { slug: accepted.household?.slug ?? "" };
+}
+
+/** Nobody signed in. Spelled out because Playwright's default is "whatever
+ * the file's `test.use` said". */
+export const SIGNED_OUT: BrowserContextOptions["storageState"] = {
+  cookies: [],
+  origins: [],
+};
+
+/**
+ * A second (or third) device: its own client address, and a session it has to
+ * name. `browser.newContext()` inherits the calling file's
+ * `test.use({ storageState })`, which is almost never what a spec spinning up
+ * another device means — an "anonymous" invitee that turns out to be the owner
+ * takes a completely different branch of the invitation screen.
+ */
+export function newBrowserContext(
+  browser: Browser,
+  options: { storageState: BrowserContextOptions["storageState"] },
+): Promise<BrowserContext> {
+  return browser.newContext({
+    baseURL: BASE_URL,
+    storageState: options.storageState,
+    extraHTTPHeaders: clientAddressHeaders(),
+  });
+}
+
+export interface MemberAccount {
+  email: string;
+  name: string;
+  /** Storage state for a browser context signed in as this member. */
+  state: string;
+}
+
+/**
+ * A brand-new household member, created the way a real one is: the owner
+ * issues an invitation, and the invitee accepts it with a name and a password.
+ *
+ * Acceptance signs the new account in on the spot, so their session is saved
+ * to a storage-state file instead of being re-established with a sign-in later
+ * — the sign-in route allows five requests a minute across the whole suite,
+ * and the specs that spend them are the ones whose subject IS signing in.
+ */
+export async function createMember(
+  slug: string,
+  options: {
+    tag: string;
+    role?: "member" | "owner";
+    providerIds?: string[];
+  },
+): Promise<MemberAccount> {
+  const email = freshEmail(options.tag);
+  const name = `${options.tag} member`;
+
+  const owner = await ownerApi();
+  let invitation: Invitation;
+  try {
+    invitation = await invite(owner, slug, {
+      email,
+      name,
+      role: options.role,
+      providerIds: options.providerIds,
+    });
+  } finally {
+    await owner.dispose();
+  }
+
+  const state = `${STATE_DIR}/${email.replace(/[^a-z0-9]+/gi, "-")}.json`;
+  const invitee = await anonymousApi();
+  try {
+    await acceptInvitation(invitee, invitation.token, { name });
+    await mkdir(STATE_DIR, { recursive: true });
+    await invitee.storageState({ path: state });
+  } finally {
+    await invitee.dispose();
+  }
+
+  return { email, name, state };
+}

--- a/e2e/household.spec.ts
+++ b/e2e/household.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "./fixtures";
+import { EMAIL_DOMAIN, freshKey, OWNER_SLUG, OWNER_STATE } from "./helpers";
+
+// A household IS an email address: the slug the owner picks becomes
+// <slug>@EMAIL_DOMAIN, which is what gets typed into Netflix. So the address
+// on screen has to be the real one, and copyable — and a second household has
+// to get its own without disturbing the first.
+
+test.use({ storageState: OWNER_STATE });
+
+test("the household settings show the real inbox address, ready to copy", async ({
+  page,
+}) => {
+  await page.goto(`/${OWNER_SLUG}/settings`);
+  await expect(
+    page.getByRole("heading", { name: "Inbox address" }),
+  ).toBeVisible();
+
+  const address = `${OWNER_SLUG}@${EMAIL_DOMAIN}`;
+  await expect(page.getByText(address)).toBeVisible();
+
+  await page.getByRole("button", { name: "Copy address" }).click();
+  expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(
+    address,
+  );
+});
+
+test("an owner creates a second household and renames it", async ({ page }) => {
+  const suffix = freshKey("hh").replace(/^hh-/, "");
+  // Named to sort AFTER the owner's first household: the switcher orders by
+  // lower(display_name), and "the first household" is where every other spec
+  // expects `/` to land.
+  const name = `Zzz Holiday ${suffix}`;
+  const renamed = `Zzz Renamed ${suffix}`;
+  const slug = `zzz-${suffix}`;
+
+  await page.goto("/new-household");
+  await page.getByRole("textbox", { name: "Household name" }).fill(name);
+  await page.getByRole("textbox", { name: "Inbox address" }).fill(slug);
+  await page.getByRole("button", { name: "Create household" }).click();
+
+  await expect(page).toHaveURL(new RegExp(`/${slug}/inbox`), {
+    timeout: 15_000,
+  });
+
+  // Its own mailbox, on the same domain.
+  await page.goto(`/${slug}/settings`);
+  await expect(page.getByText(`${slug}@${EMAIL_DOMAIN}`)).toBeVisible();
+
+  // --- rename
+  await page.getByRole("textbox", { name: "Household name" }).fill(renamed);
+  await page.getByRole("button", { name: "Save name" }).click();
+  await expect(page.getByText("Household renamed.")).toBeVisible();
+
+  // Persisted, not just repainted — and the address is untouched, which is the
+  // promise the screen makes ("The inbox address stays the same").
+  await page.reload();
+  await expect(
+    page.getByRole("textbox", { name: "Household name" }),
+  ).toHaveValue(renamed);
+  await expect(page.getByText(`${slug}@${EMAIL_DOMAIN}`)).toBeVisible();
+});

--- a/e2e/inbox.spec.ts
+++ b/e2e/inbox.spec.ts
@@ -1,0 +1,132 @@
+import { expect, test } from "./fixtures";
+import {
+  createService,
+  EMAIL_DOMAIN,
+  freshKey,
+  OWNER_SLUG,
+  OWNER_STATE,
+  ownerApi,
+  postInbound,
+} from "./helpers";
+
+// The whole point of the product, driven end to end: a service, a signed
+// Mailgun webhook carrying a real RFC 5322 message, and the code coming out
+// the other side on screen — through the parser, the classifier and the
+// extractor, none of which the SPA can fake.
+//
+// This is the one spec both projects run (playwright.config.ts): the inbox is
+// a card stack on a phone and a list-plus-detail on a desktop, and the service
+// view below is reached the same way in both.
+
+test.use({ storageState: OWNER_STATE });
+
+/** Mailbox for the owner's household — the address a service would be given. */
+const MAILBOX = `${OWNER_SLUG}@${EMAIL_DOMAIN}`;
+
+test("an inbound code reaches the inbox, copies, and marks itself used", async ({
+  page,
+  request,
+}) => {
+  const suffix = freshKey("inbox").replace(/^inbox-/, "");
+  const key = `inbox-${suffix}`;
+  const name = `Inbox ${suffix}`;
+  const senderDomain = `inbox-${suffix}.test`;
+  const code = "314159";
+  const subject = `Your ${name} sign-in code`;
+
+  const owner = await ownerApi();
+  try {
+    await createService(owner, OWNER_SLUG, { key, name, senderDomain });
+  } finally {
+    await owner.dispose();
+  }
+
+  await postInbound(request, {
+    to: MAILBOX,
+    from: `codes@${senderDomain}`,
+    subject,
+    text: `Hi there,\n\nYour verification code is ${code}.\n\nThanks.`,
+    // Both annotations pass, so the verdict trusts the sender whichever of the
+    // envelope or the From header the rule matched on.
+    spf: "Pass",
+    dkim: "Pass",
+  });
+
+  // The service list: the household sees the new service with its message.
+  await page.goto(`/${OWNER_SLUG}/inbox`);
+  await expect(
+    page.getByRole("heading", { name: "Latest codes" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("list", { name: "Services" }).getByText(name).first(),
+  ).toBeVisible();
+
+  // The service itself: same route on both layouts.
+  await page.goto(`/${OWNER_SLUG}/inbox/${key}`);
+  // `exact` because the message accordions below carry the service name in
+  // their subjects too.
+  await expect(
+    page.getByRole("heading", { name, exact: true }).first(),
+  ).toBeVisible();
+  await expect(page.getByText(subject).first()).toBeVisible();
+  // Rendered grouped for readability; the value copied is the raw code.
+  await expect(
+    page.getByLabel(`Code ${code.split("").join(" ")}`).first(),
+  ).toBeVisible();
+  await expect(page.getByText("Latest code", { exact: true })).toBeVisible();
+
+  await page.getByRole("button", { name: "Copy code" }).first().click();
+  expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(code);
+
+  // Copying IS using it: the message flips to "used" without a second action.
+  await expect(page.getByText("Latest code · used")).toBeVisible();
+});
+
+test("a message that fails the sender checks goes to Needs review, not the inbox", async ({
+  page,
+  request,
+}) => {
+  const suffix = freshKey("spf").replace(/^spf-/, "");
+  const key = `spf-${suffix}`;
+  const name = `Spoofed ${suffix}`;
+  const senderDomain = `spf-${suffix}.test`;
+  const good = `Genuine ${suffix} code`;
+  const forged = `Forged ${suffix} code`;
+
+  const owner = await ownerApi();
+  try {
+    await createService(owner, OWNER_SLUG, { key, name, senderDomain });
+  } finally {
+    await owner.dispose();
+  }
+
+  // Same service, same sender domain — only the authentication differs.
+  await postInbound(request, {
+    to: MAILBOX,
+    from: `codes@${senderDomain}`,
+    subject: good,
+    text: "Your verification code is 246800.",
+    spf: "Pass",
+    dkim: "Pass",
+  });
+  await postInbound(request, {
+    to: MAILBOX,
+    from: `codes@${senderDomain}`,
+    subject: forged,
+    text: "Your verification code is 999111.",
+    spf: "Fail",
+    dkim: "Fail",
+  });
+
+  // The inbox keeps the genuine one and never shows the forged one.
+  await page.goto(`/${OWNER_SLUG}/inbox/${key}`);
+  await expect(page.getByText(good).first()).toBeVisible();
+  await expect(page.getByText(forged)).toHaveCount(0);
+
+  // The forged one is waiting for the owner, labelled for what it is.
+  await page.goto(`/${OWNER_SLUG}/quarantine`);
+  const queue = page.getByRole("list", { name: "Emails needing review" });
+  const item = queue.getByRole("listitem").filter({ hasText: forged });
+  await expect(item).toHaveCount(1);
+  await expect(item.getByText("Sender check failed").first()).toBeVisible();
+});

--- a/e2e/invite.spec.ts
+++ b/e2e/invite.spec.ts
@@ -1,0 +1,236 @@
+import { expect, test } from "./fixtures";
+import {
+  BASE_URL,
+  createService,
+  EMAIL_DOMAIN,
+  freshEmail,
+  freshKey,
+  invite,
+  mailpit,
+  newBrowserContext,
+  OWNER_SLUG,
+  OWNER_STATE,
+  ownerApi,
+  PASSWORD,
+  postInbound,
+  SIGNED_OUT,
+} from "./helpers";
+
+// How anybody but the owner gets in. The invitation itself is only half of it:
+// what matters is that the link actually arrives (Mailpit), that the account
+// created from it lands inside the household, and that it can see exactly the
+// services it was given and no others.
+
+test.use({ storageState: OWNER_STATE });
+
+const MAILBOX = `${OWNER_SLUG}@${EMAIL_DOMAIN}`;
+
+/** Two services with a message each, so both are visible in an inbox that is
+ * allowed to see them — and the absence of one is evidence, not emptiness. */
+async function seedTwoServices(
+  request: Parameters<typeof postInbound>[0],
+  suffix: string,
+) {
+  const owner = await ownerApi();
+  let granted: Awaited<ReturnType<typeof createService>>;
+  let denied: Awaited<ReturnType<typeof createService>>;
+  try {
+    granted = await createService(owner, OWNER_SLUG, {
+      key: `shared-${suffix}`,
+      name: `Shared ${suffix}`,
+      senderDomain: `shared-${suffix}.test`,
+    });
+    denied = await createService(owner, OWNER_SLUG, {
+      key: `private-${suffix}`,
+      name: `Private ${suffix}`,
+      senderDomain: `private-${suffix}.test`,
+    });
+  } finally {
+    await owner.dispose();
+  }
+
+  for (const service of [granted, denied]) {
+    await postInbound(request, {
+      to: MAILBOX,
+      from: `codes@${service.providerKey}.test`,
+      subject: `${service.displayName} code`,
+      text: "Your verification code is 111222.",
+      spf: "Pass",
+      dkim: "Pass",
+    });
+  }
+  return { granted, denied };
+}
+
+test("an invitation by email creates an account scoped to the services it named", async ({
+  page,
+  request,
+  browser,
+}) => {
+  const suffix = freshKey("inv").replace(/^inv-/, "");
+  const { granted, denied } = await seedTwoServices(request, suffix);
+  const email = freshEmail("invitee");
+
+  await page.goto(`/${OWNER_SLUG}/members`);
+  await page.getByRole("button", { name: "Invite someone" }).first().click();
+
+  const dialog = page.getByRole("dialog", { name: "Invite someone" });
+  await dialog.getByRole("textbox", { name: "Email address" }).fill(email);
+  await dialog.getByRole("textbox", { name: "Name" }).fill("Kari Invitee");
+  // Everything is ticked by default; taking one away is what makes the
+  // assertion below mean something.
+  await dialog
+    .getByRole("checkbox", { name: denied.displayName, exact: true })
+    .uncheck();
+  await expect(
+    dialog.getByRole("checkbox", { name: granted.displayName, exact: true }),
+  ).toBeChecked();
+  await dialog.getByRole("button", { name: "Send invitation" }).click();
+
+  const sent = page.getByRole("dialog", { name: "Invitation sent" });
+  await expect(sent.getByText(email)).toBeVisible();
+  await sent.getByRole("button", { name: "Done" }).click();
+  await expect(page.getByText(email)).toBeVisible();
+
+  // The link really left the building.
+  const mail = await mailpit.lastMessageTo(request, email);
+  expect(mail.subject).toContain("invited you to Mi Casa Su Casa");
+  expect(mail.link).toContain("/invite/");
+
+  // A brand-new visitor opens it and makes their account.
+  // Explicitly signed out: `browser.newContext()` inherits this file's
+  // `test.use({ storageState: OWNER_STATE })`, and an invitee who arrives as
+  // the owner is shown "this invitation is for a different account" instead.
+  const invitee = await newBrowserContext(browser, {
+    storageState: SIGNED_OUT,
+  });
+  try {
+    const page2 = await invitee.newPage();
+    await page2.goto(mail.link);
+    await expect(
+      page2.getByRole("heading", { name: /invited you to/ }),
+    ).toBeVisible();
+    await page2
+      .getByRole("textbox", { name: "Your name" })
+      .fill("Kari Invitee");
+    await page2
+      .getByRole("textbox", { name: "Choose a password" })
+      .fill(PASSWORD);
+    await page2
+      .getByRole("button", { name: "Create account and join" })
+      .click();
+
+    await expect(page2).toHaveURL(new RegExp(`/${OWNER_SLUG}/inbox`), {
+      timeout: 15_000,
+    });
+
+    // Scoped, not blanket: one service is theirs, the other does not exist as
+    // far as they are concerned.
+    const services = page2.getByRole("list", { name: "Services" });
+    await expect(services.getByText(granted.displayName).first()).toBeVisible();
+    await expect(services.getByText(denied.displayName)).toHaveCount(0);
+  } finally {
+    await invitee.close();
+  }
+});
+
+test("an invitation the email could not carry is handed over as a link", async ({
+  page,
+}) => {
+  // Mailpit is started with --smtp-allowed-recipients=@e2e\.test$, so this
+  // address is refused at RCPT TO — the same failure a real relay produces for
+  // an unroutable domain, and the reason the "share it yourself" path exists.
+  const unreachable = `${freshKey("blocked")}@unreachable.test`;
+
+  await page.goto(`/${OWNER_SLUG}/members`);
+  await page.getByRole("button", { name: "Invite someone" }).first().click();
+  const dialog = page.getByRole("dialog", { name: "Invite someone" });
+  await dialog
+    .getByRole("textbox", { name: "Email address" })
+    .fill(unreachable);
+  await dialog.getByRole("textbox", { name: "Name" }).fill("Unreachable");
+  await dialog.getByRole("button", { name: "Send invitation" }).click();
+
+  const shared = page.getByRole("dialog", {
+    name: "Share this invitation link",
+  });
+  const link = shared.getByRole("textbox", { name: "Invitation link" });
+  await expect(link).toHaveValue(new RegExp(`^${BASE_URL}/invite/.+`));
+
+  // The invitation itself stands — only the delivery failed.
+  await shared.getByRole("button", { name: "Copy link" }).click();
+  expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(
+    await link.inputValue(),
+  );
+  await shared.getByRole("button", { name: "Done" }).click();
+  await expect(page.getByText(unreachable)).toBeVisible();
+});
+
+test("resending an invitation mails a new link and kills the old one", async ({
+  page,
+  request,
+}) => {
+  const email = freshEmail("resend");
+  const owner = await ownerApi();
+  let first: Awaited<ReturnType<typeof invite>>;
+  try {
+    first = await invite(owner, OWNER_SLUG, { email, name: "Resend Target" });
+  } finally {
+    await owner.dispose();
+  }
+  const firstMail = await mailpit.lastMessageTo(request, email);
+
+  await page.goto(`/${OWNER_SLUG}/members`);
+  const pending = page
+    .getByRole("list", { name: "Pending invitations" })
+    .getByRole("listitem")
+    .filter({ hasText: email });
+  await pending.getByRole("button", { name: "Resend" }).click();
+  await expect(page.getByText(`Invitation resent to ${email}.`)).toBeVisible();
+
+  const secondMail = await mailpit.lastMessageTo(request, email, {
+    after: firstMail.id,
+  });
+  expect(secondMail.link).not.toBe(first.url);
+  expect(secondMail.link).toContain("/invite/");
+
+  // The first link is dead: a resend is a replacement, which is what makes it
+  // safe to offer after a link has gone to the wrong inbox.
+  await page.goto(first.url);
+  await expect(
+    page.getByRole("heading", { name: /isn't available any more/ }),
+  ).toBeVisible();
+});
+
+test("cancelling an invitation stops its link working", async ({ page }) => {
+  const email = freshEmail("cancel");
+  const owner = await ownerApi();
+  let invitation: Awaited<ReturnType<typeof invite>>;
+  try {
+    invitation = await invite(owner, OWNER_SLUG, {
+      email,
+      name: "Cancel Target",
+    });
+  } finally {
+    await owner.dispose();
+  }
+
+  await page.goto(`/${OWNER_SLUG}/members`);
+  const pending = page
+    .getByRole("list", { name: "Pending invitations" })
+    .getByRole("listitem")
+    .filter({ hasText: email });
+  await pending.getByRole("button", { name: "Cancel invitation" }).click();
+  await page
+    .getByRole("dialog", { name: /Cancel the invitation for/ })
+    .getByRole("button", { name: "Cancel invitation" })
+    .click();
+
+  await expect(page.getByText("Invitation cancelled.")).toBeVisible();
+  await expect(pending).toHaveCount(0);
+
+  await page.goto(invitation.url);
+  await expect(
+    page.getByRole("heading", { name: /isn't available any more/ }),
+  ).toBeVisible();
+});

--- a/e2e/members.spec.ts
+++ b/e2e/members.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from "./fixtures";
+import {
+  createMember,
+  createService,
+  freshKey,
+  OWNER_HOUSEHOLD,
+  OWNER_SLUG,
+  OWNER_STATE,
+  ownerApi,
+} from "./helpers";
+
+// Who is in the household and what each of them can see. Access is the whole
+// security model on the member side, so every change here is asserted on the
+// row's own summary line — the thing an owner actually reads — rather than on
+// a toast.
+
+test.use({ storageState: OWNER_STATE });
+
+test("an owner grants access, promotes a member and removes them", async ({
+  page,
+}) => {
+  const suffix = freshKey("acc").replace(/^acc-/, "");
+  const serviceName = `Access ${suffix}`;
+
+  const owner = await ownerApi();
+  try {
+    await createService(owner, OWNER_SLUG, {
+      key: `access-${suffix}`,
+      name: serviceName,
+      senderDomain: `access-${suffix}.test`,
+    });
+  } finally {
+    await owner.dispose();
+  }
+
+  // Invited with no services at all, which the screen calls out in warning
+  // colour — the state this test then walks out of.
+  const member = await createMember(OWNER_SLUG, { tag: `grant${suffix}` });
+
+  await page.goto(`/${OWNER_SLUG}/members`);
+  const row = page
+    .getByRole("list", { name: "Members" })
+    .getByRole("listitem")
+    .filter({ hasText: member.email });
+  await expect(row.getByText("Can't see any services yet")).toBeVisible();
+
+  // --- grant one service
+  await row.getByRole("button", { name: `Options for ${member.name}` }).click();
+  await page
+    .getByRole("menuitem", { name: "Change what they can see" })
+    .click();
+  const access = page.getByRole("dialog", {
+    name: `What can ${member.name} see?`,
+  });
+  await access
+    .getByRole("checkbox", { name: serviceName, exact: true })
+    .check();
+  await access.getByRole("button", { name: "Save" }).click();
+
+  await expect(
+    page.getByText(`Updated what ${member.name} can see.`),
+  ).toBeVisible();
+  await expect(row.getByText(`Can see: ${serviceName}`)).toBeVisible();
+
+  // --- and take it away again: the same dialog, unticked
+  await row.getByRole("button", { name: `Options for ${member.name}` }).click();
+  await page
+    .getByRole("menuitem", { name: "Change what they can see" })
+    .click();
+  await access
+    .getByRole("checkbox", { name: serviceName, exact: true })
+    .uncheck();
+  await access.getByRole("button", { name: "Save" }).click();
+  await expect(row.getByText("Can't see any services yet")).toBeVisible();
+
+  // Grant it back, so the promotion below is a change of role and not a
+  // change of scope.
+  await row.getByRole("button", { name: `Options for ${member.name}` }).click();
+  await page
+    .getByRole("menuitem", { name: "Change what they can see" })
+    .click();
+  await access
+    .getByRole("checkbox", { name: serviceName, exact: true })
+    .check();
+  await access.getByRole("button", { name: "Save" }).click();
+  await expect(row.getByText(`Can see: ${serviceName}`)).toBeVisible();
+
+  // --- promote to owner: scoping stops applying at all
+  await row.getByRole("button", { name: `Options for ${member.name}` }).click();
+  await page.getByRole("menuitem", { name: "Make owner" }).click();
+  await page
+    .getByRole("dialog", { name: `Make ${member.name} an owner?` })
+    .getByRole("button", { name: "Make owner" })
+    .click();
+
+  await expect(page.getByText(`${member.name} is now an owner.`)).toBeVisible();
+  await expect(row.getByText("Owner")).toBeVisible();
+  await expect(row.getByText("Can see everything")).toBeVisible();
+
+  // --- and out again
+  await row.getByRole("button", { name: `Options for ${member.name}` }).click();
+  await page.getByRole("menuitem", { name: "Remove from household" }).click();
+  await page
+    .getByRole("dialog", { name: `Remove ${member.name}?` })
+    .getByRole("button", { name: "Remove", exact: true })
+    .click();
+
+  await expect(page.getByText(`${member.name} removed.`)).toBeVisible();
+  await expect(row).toHaveCount(0);
+});
+
+test("the only owner cannot leave the household", async ({ page }) => {
+  await page.goto("/settings");
+
+  const households = page.getByRole("list", { name: "Households" });
+  const row = households
+    .getByRole("listitem")
+    .filter({ hasText: OWNER_HOUSEHOLD });
+  await row.getByRole("button", { name: "Leave" }).click();
+
+  const dialog = page.getByRole("dialog", {
+    name: `Leave ${OWNER_HOUSEHOLD}?`,
+  });
+  await dialog.getByRole("button", { name: "Leave household" }).click();
+
+  // Refused, and said so in the dialog rather than silently doing nothing.
+  await expect(dialog.getByText(/only owner of this household/)).toBeVisible();
+
+  // Still theirs after a reload: the refusal was the server's, not the SPA's.
+  await page.reload();
+  await expect(
+    households.getByRole("listitem").filter({ hasText: OWNER_HOUSEHOLD }),
+  ).toHaveCount(1);
+});

--- a/e2e/password-reset.spec.ts
+++ b/e2e/password-reset.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "./fixtures";
+import {
+  createMember,
+  mailpit,
+  newBrowserContext,
+  OWNER_SLUG,
+  signIn,
+} from "./helpers";
+
+// Forgotten password, all the way through the real mail: request, link out of
+// Mailpit, new password, and — the part that matters for security rather than
+// convenience — every other session dropped on the way.
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+const NEW_PASSWORD = "e2e-newpass-98765";
+
+test("a reset link sets a new password and drops the old session", async ({
+  page,
+  request,
+  browser,
+}) => {
+  // Never the owner: global-setup.ts's owner session and password are shared
+  // by every owner-only spec in the suite.
+  const member = await createMember(OWNER_SLUG, { tag: "reset" });
+  // The invitation mail is already sitting in this mailbox; remember it so the
+  // wait below is for the RESET mail and not for that one.
+  const invitationMail = await mailpit.lastMessageTo(request, member.email);
+
+  await page.goto("/forgot-password");
+  await page.getByRole("textbox", { name: "Email Address" }).fill(member.email);
+  await page.getByRole("button", { name: "Send reset link" }).click();
+  await expect(page.getByText(/a reset link is on its way/)).toBeVisible();
+
+  const mail = await mailpit.lastMessageTo(request, member.email, {
+    after: invitationMail.id,
+  });
+  expect(mail.subject).toBe("Reset your Mi Casa Su Casa password");
+  expect(mail.link).toContain("/reset-password?token=");
+
+  await page.goto(mail.link);
+  await page
+    .getByRole("textbox", { name: "New password", exact: true })
+    .fill(NEW_PASSWORD);
+  await page
+    .getByRole("textbox", { name: "Confirm new password" })
+    .fill(NEW_PASSWORD);
+  await page.getByRole("button", { name: "Update password" }).click();
+  await expect(
+    page.getByText(
+      "Your password has been updated. You can sign in with it now.",
+    ),
+  ).toBeVisible();
+
+  // The session the account already had is gone — that is what makes a reset
+  // a recovery rather than a second key for whoever had the first.
+  const stale = await newBrowserContext(browser, {
+    storageState: member.state,
+  });
+  try {
+    const stalePage = await stale.newPage();
+    await stalePage.goto(`/${OWNER_SLUG}/inbox`).catch(() => {});
+    await expect(stalePage).toHaveURL(/\/login/, { timeout: 15_000 });
+  } finally {
+    await stale.close();
+  }
+
+  // And the new password is the one that works now.
+  await signIn(page, member.email, NEW_PASSWORD);
+  await expect(page).toHaveURL(new RegExp(`/${OWNER_SLUG}/inbox`), {
+    timeout: 15_000,
+  });
+});

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,52 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// The E2E suite drives the REAL production artifact: the Go binary inside the
+// container image, serving the embedded SPA against a real Postgres and a real
+// SMTP relay (Mailpit) — never the Vite dev server, so what passes here is
+// what ships. Start the stack with `bash scripts/e2e-stack.sh up` (or let
+// `mise run e2e` do everything).
+//
+// Workers = 1 on purpose: every spec shares one database and one installation.
+// First-run setup can happen exactly once per stack, the auth routes are rate
+// limited per client address, and the owner's household is common ground —
+// none of that survives parallel workers, and at this size parallelism buys
+// nothing worth the flakiness.
+//
+// Two projects, one browser engine:
+//   mobile   — Pixel 7, the profile the app is designed for. Runs everything.
+//   desktop  — Desktop Chrome, which renders the inbox as list + detail rather
+//              than a card stack. Runs inbox.spec.ts only (testMatch), because
+//              that is the one screen whose LAYOUT differs; re-running the
+//              rest would only re-test the same DOM against a wider viewport.
+export default defineConfig({
+  testDir: ".",
+  workers: 1,
+  timeout: 30_000,
+  retries: process.env.CI ? 1 : 0,
+  // Both artefacts stay inside e2e/ (where .gitignore expects them): the
+  // defaults are resolved against the working directory, and a run started
+  // from the repo root would otherwise scatter them there.
+  outputDir: "./test-results",
+  reporter: [
+    ["list"],
+    ["html", { open: "never", outputFolder: "./playwright-report" }],
+  ],
+  // Completes first-run setup once per stack and saves the owner's signed-in
+  // storage state, so no spec has to depend on running first.
+  globalSetup: "./global-setup.ts",
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? "http://127.0.0.1:3300",
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "mobile",
+      use: { ...devices["Pixel 7"] },
+    },
+    {
+      name: "desktop",
+      use: { ...devices["Desktop Chrome"] },
+      testMatch: /inbox\.spec\.ts/,
+    },
+  ],
+});

--- a/e2e/quarantine.spec.ts
+++ b/e2e/quarantine.spec.ts
@@ -92,6 +92,12 @@ test("an owner files an unknown sender under a service and the rule sticks", asy
   await page.goto(`/${OWNER_SLUG}/inbox/${key}`);
   await expect(page.getByText(second).first()).toBeVisible();
   await page.goto(`/${OWNER_SLUG}/quarantine`);
+  // Anchor the absence on the screen having actually rendered: without a
+  // positive locator first, "not in the review queue" is also what a blank
+  // page, a redirect to /login or a failed load look like.
+  await expect(
+    page.getByRole("heading", { name: "Needs review" }),
+  ).toBeVisible();
   await expect(page.getByText(second)).toHaveCount(0);
 });
 
@@ -132,6 +138,11 @@ test("an owner hides an email and it leaves the queue for good", async ({
   await expect(item).toHaveCount(0);
 
   // Still gone after a reload: the decision is in the database, not in a cache.
+  // The heading is the anchor — the queue is not empty (other specs leave
+  // their own entries in it), so its absence is the only thing being asserted.
   await page.reload();
+  await expect(
+    page.getByRole("heading", { name: "Needs review" }),
+  ).toBeVisible();
   await expect(page.getByText(subject)).toHaveCount(0);
 });

--- a/e2e/quarantine.spec.ts
+++ b/e2e/quarantine.spec.ts
@@ -1,0 +1,137 @@
+import { expect, test } from "./fixtures";
+import {
+  createService,
+  EMAIL_DOMAIN,
+  freshKey,
+  OWNER_SLUG,
+  OWNER_STATE,
+  ownerApi,
+  postInbound,
+} from "./helpers";
+
+// Needs review is the household's safety net: everything the classifier would
+// not file on its own waits here until an owner decides. Both decisions are
+// driven through the screen, and both are checked by their consequence — where
+// the message ends up next — rather than by the toast alone.
+
+test.use({ storageState: OWNER_STATE });
+
+const MAILBOX = `${OWNER_SLUG}@${EMAIL_DOMAIN}`;
+
+test("an owner files an unknown sender under a service and the rule sticks", async ({
+  page,
+  request,
+}) => {
+  const suffix = freshKey("rel").replace(/^rel-/, "");
+  const key = `rel-${suffix}`;
+  const name = `Release ${suffix}`;
+  const unknown = `unknown-${suffix}.test`;
+  const first = `First ${suffix} code`;
+  const second = `Second ${suffix} code`;
+
+  const owner = await ownerApi();
+  try {
+    // No sender rule: the service exists, but nothing points at it yet.
+    await createService(owner, OWNER_SLUG, { key, name });
+  } finally {
+    await owner.dispose();
+  }
+
+  await postInbound(request, {
+    to: MAILBOX,
+    from: `codes@${unknown}`,
+    subject: first,
+    text: "Your verification code is 135791.",
+    spf: "Pass",
+    dkim: "Pass",
+  });
+
+  await page.goto(`/${OWNER_SLUG}/quarantine`);
+  const item = page
+    .getByRole("list", { name: "Emails needing review" })
+    .getByRole("listitem")
+    .filter({ hasText: first });
+  await expect(item.getByText("Unknown sender").first()).toBeVisible();
+
+  await item
+    .getByRole("button", { name: new RegExp(first) })
+    .first()
+    .click();
+  await expect(
+    item.getByText("Your verification code is 135791."),
+  ).toBeVisible();
+  await item.getByRole("button", { name: "File under a service…" }).click();
+
+  const dialog = page.getByRole("dialog", { name: "File under a service" });
+  await dialog.getByRole("combobox", { name: "Service" }).click();
+  await page.getByRole("option", { name: new RegExp(name) }).click();
+  // Left checked on purpose: filing is also how a household teaches the app a
+  // sender, and the second delivery below is what proves it was learnt.
+  await expect(
+    dialog.getByRole("checkbox", { name: new RegExp(unknown) }),
+  ).toBeChecked();
+  await dialog.getByRole("button", { name: "File email" }).click();
+
+  await expect(page.getByText(`Filed under ${name}.`)).toBeVisible();
+  await expect(item).toHaveCount(0);
+
+  // Released: it is in the service's inbox now, code and all.
+  await page.goto(`/${OWNER_SLUG}/inbox/${key}`);
+  await expect(page.getByText(first).first()).toBeVisible();
+  await expect(page.getByLabel("Code 1 3 5 7 9 1").first()).toBeVisible();
+
+  // And the sender was remembered: the next one is filed without an owner.
+  await postInbound(request, {
+    to: MAILBOX,
+    from: `codes@${unknown}`,
+    subject: second,
+    text: "Your verification code is 246802.",
+    spf: "Pass",
+    dkim: "Pass",
+  });
+  await page.goto(`/${OWNER_SLUG}/inbox/${key}`);
+  await expect(page.getByText(second).first()).toBeVisible();
+  await page.goto(`/${OWNER_SLUG}/quarantine`);
+  await expect(page.getByText(second)).toHaveCount(0);
+});
+
+test("an owner hides an email and it leaves the queue for good", async ({
+  page,
+  request,
+}) => {
+  const suffix = freshKey("hide").replace(/^hide-/, "");
+  const subject = `Junk ${suffix}`;
+
+  await postInbound(request, {
+    to: MAILBOX,
+    from: `noise@junk-${suffix}.test`,
+    subject,
+    text: "Your verification code is 864209.",
+    spf: "Pass",
+    dkim: "Pass",
+  });
+
+  await page.goto(`/${OWNER_SLUG}/quarantine`);
+  const item = page
+    .getByRole("list", { name: "Emails needing review" })
+    .getByRole("listitem")
+    .filter({ hasText: subject });
+  await expect(item).toHaveCount(1);
+
+  await item
+    .getByRole("button", { name: new RegExp(subject) })
+    .first()
+    .click();
+  await item.getByRole("button", { name: "Hide this email" }).click();
+  await page
+    .getByRole("dialog", { name: "Hide this email?" })
+    .getByRole("button", { name: "Hide email" })
+    .click();
+
+  await expect(page.getByText("Email hidden.")).toBeVisible();
+  await expect(item).toHaveCount(0);
+
+  // Still gone after a reload: the decision is in the database, not in a cache.
+  await page.reload();
+  await expect(page.getByText(subject)).toHaveCount(0);
+});

--- a/e2e/services.spec.ts
+++ b/e2e/services.spec.ts
@@ -81,6 +81,9 @@ test("an owner adds a service with senders, renames it and deletes it", async ({
     .getByRole("button", { name: "Delete service" })
     .click();
 
+  // The toast is the anchor: the list has re-rendered after the delete, so the
+  // absence below is a real absence and not an unrendered page.
+  await expect(page.getByText(`${renamed} deleted.`)).toBeVisible();
   await expect(page.getByRole("heading", { name: renamed })).toHaveCount(0);
 });
 
@@ -104,7 +107,9 @@ test("a sender has to look like a sender", async ({ page }) => {
       "That doesn't look like a domain. Try something like netflix.com.",
     ),
   ).toBeVisible();
-  // Nothing was created behind the rejection.
+  // Nothing was created behind the rejection. The page heading is the anchor:
+  // the dialog is closed and the list is on screen, so the absence is real.
   await dialog.getByRole("button", { name: "Cancel" }).click();
+  await expect(page.getByRole("heading", { name: "Services" })).toBeVisible();
   await expect(page.getByRole("heading", { name })).toHaveCount(0);
 });

--- a/e2e/services.spec.ts
+++ b/e2e/services.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "./fixtures";
+import { freshKey, OWNER_SLUG, OWNER_STATE } from "./helpers";
+
+// The owner's Services screen end to end: a service and its senders are what
+// decide whether an inbound email reaches the inbox at all, so every step here
+// is driven through the real dialogs rather than the API.
+
+test.use({ storageState: OWNER_STATE });
+
+test("an owner adds a service with senders, renames it and deletes it", async ({
+  page,
+}) => {
+  // Unique per run: a provider key is unique within a household, and this
+  // database outlives a single `playwright test`.
+  const suffix = freshKey("svc").replace(/^svc-/, "");
+  const name = `Streamy ${suffix}`;
+  const renamed = `Streamy renamed ${suffix}`;
+  const domain = `streamy-${suffix}.test`;
+  const exact = `codes@only-${suffix}.test`;
+
+  await page.goto(`/${OWNER_SLUG}/providers`);
+  await expect(page.getByRole("heading", { name: "Services" })).toBeVisible();
+
+  // --- create, with its first sender in the same dialog
+  await page.getByRole("button", { name: "Add service" }).first().click();
+  const createDialog = page.getByRole("dialog", { name: "Add a service" });
+  await createDialog.getByRole("textbox", { name: "Service name" }).fill(name);
+  await createDialog
+    .getByRole("textbox", { name: "Emails come from (domain)" })
+    .fill(domain);
+  await createDialog
+    .getByRole("button", { name: "Add service", exact: true })
+    .click();
+
+  const card = page.getByRole("listitem").filter({ hasText: name });
+  await expect(card.getByRole("heading", { name })).toBeVisible();
+  await expect(card.getByText(`${domain} · any address`)).toBeVisible();
+  await expect(card.getByText("1 sender", { exact: true })).toBeVisible();
+
+  // --- add a second sender, this time an exact address
+  await card.getByRole("button", { name: "Add sender" }).click();
+  const senderDialog = page.getByRole("dialog", {
+    name: `Add a sender for ${name}`,
+  });
+  await senderDialog
+    .getByRole("radio", { name: /Only one exact address/ })
+    .check();
+  await senderDialog
+    .getByRole("textbox", { name: "Email address" })
+    .fill(exact);
+  await senderDialog
+    .getByRole("button", { name: "Add sender", exact: true })
+    .click();
+
+  await expect(card.getByText(exact)).toBeVisible();
+  await expect(card.getByText("2 senders")).toBeVisible();
+
+  // --- rename
+  await card.getByRole("button", { name: `Options for ${name}` }).click();
+  await page.getByRole("menuitem", { name: "Rename" }).click();
+  const renameDialog = page.getByRole("dialog", { name: `Rename ${name}` });
+  await renameDialog
+    .getByRole("textbox", { name: "Service name" })
+    .fill(renamed);
+  await renameDialog.getByRole("button", { name: "Save name" }).click();
+
+  const renamedCard = page.getByRole("listitem").filter({ hasText: renamed });
+  await expect(
+    renamedCard.getByRole("heading", { name: renamed }),
+  ).toBeVisible();
+  // The senders travelled with it — a rename is not a re-create.
+  await expect(renamedCard.getByText(`${domain} · any address`)).toBeVisible();
+
+  // --- delete
+  await renamedCard
+    .getByRole("button", { name: `Options for ${renamed}` })
+    .click();
+  await page.getByRole("menuitem", { name: "Delete service" }).click();
+  await page
+    .getByRole("dialog", { name: `Delete ${renamed}?` })
+    .getByRole("button", { name: "Delete service" })
+    .click();
+
+  await expect(page.getByRole("heading", { name: renamed })).toHaveCount(0);
+});
+
+test("a sender has to look like a sender", async ({ page }) => {
+  const suffix = freshKey("bad").replace(/^bad-/, "");
+  const name = `Badsender ${suffix}`;
+
+  await page.goto(`/${OWNER_SLUG}/providers`);
+  await page.getByRole("button", { name: "Add service" }).first().click();
+  const dialog = page.getByRole("dialog", { name: "Add a service" });
+  await dialog.getByRole("textbox", { name: "Service name" }).fill(name);
+  await dialog
+    .getByRole("textbox", { name: "Emails come from (domain)" })
+    .fill("not a domain");
+  await dialog
+    .getByRole("button", { name: "Add service", exact: true })
+    .click();
+
+  await expect(
+    dialog.getByText(
+      "That doesn't look like a domain. Try something like netflix.com.",
+    ),
+  ).toBeVisible();
+  // Nothing was created behind the rejection.
+  await dialog.getByRole("button", { name: "Cancel" }).click();
+  await expect(page.getByRole("heading", { name })).toHaveCount(0);
+});

--- a/e2e/setup.spec.ts
+++ b/e2e/setup.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "./fixtures";
+import {
+  BASE_URL,
+  OWNER_EMAIL,
+  OWNER_HOUSEHOLD,
+  OWNER_SLUG,
+  PASSWORD,
+  SETUP_SECRET,
+  setupStatus,
+} from "./helpers";
+
+// First-run setup, from the other side.
+//
+// global-setup.ts has already claimed this installation (it has to: a database
+// can only be set up once, and two projects run the suite over one stack), so
+// what is left to prove is everything a CONFIGURED installation must do —
+// which is the half that can regress silently. The success path itself is
+// covered by global-setup running at all: nothing else in the suite would have
+// an owner, a household or a session without it.
+
+// Signed out on purpose: these are the answers a stranger gets.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test("setup is locked once the installation has an owner", async ({
+  request,
+}) => {
+  const status = await setupStatus(request);
+
+  expect(status.status).toBe("complete");
+  expect(status.needsSetup).toBe(false);
+  expect(status.setupLocked).toBe(true);
+  // Not secret — every household address ends with it, and the setup screen
+  // previews "name@domain" with it.
+  expect(status.emailDomain).toBe("e2e.test");
+});
+
+test("/setup is no longer reachable and / sends a stranger to sign in", async ({
+  page,
+}) => {
+  await page.goto("/setup");
+  await expect(page).toHaveURL(/\/login/);
+  await expect(
+    page.getByRole("heading", { name: /Your family's login codes/ }),
+  ).toBeVisible();
+
+  await page.goto("/");
+  await expect(page).toHaveURL(/\/login/);
+});
+
+test("a completed installation answers the same to a wrong secret as to the right one", async ({
+  request,
+}) => {
+  const attempt = (setupSecret: string) =>
+    request.post(`${BASE_URL}/api/setup/complete`, {
+      headers: { Origin: BASE_URL },
+      data: {
+        email: OWNER_EMAIL,
+        name: "Someone Else",
+        password: PASSWORD,
+        householdName: OWNER_HOUSEHOLD,
+        householdSlug: OWNER_SLUG,
+        setupSecret,
+      },
+    });
+
+  // "Already complete" is answered before the secret is even looked at, so a
+  // finished installation cannot be used as an oracle for SETUP_SECRET. Both
+  // of these must be the same 409, byte for byte.
+  const wrong = await attempt("not-the-setup-secret");
+  const right = await attempt(SETUP_SECRET);
+
+  expect(wrong.status()).toBe(409);
+  expect(right.status()).toBe(409);
+  expect(await wrong.json()).toEqual(await right.json());
+  expect(JSON.stringify(await wrong.json())).toContain(
+    "Setup has already been completed",
+  );
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2023", "DOM"],
+    "strict": true,
+    "noEmit": true,
+    "types": ["@playwright/test", "node"],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/e2e/two-factor.spec.ts
+++ b/e2e/two-factor.spec.ts
@@ -1,0 +1,175 @@
+import { expect, test } from "./fixtures";
+import {
+  createMember,
+  newBrowserContext,
+  nextTotp,
+  OWNER_SLUG,
+  PASSWORD,
+  SIGNED_OUT,
+  signIn,
+  submitChallengeCode,
+  totpFrom,
+} from "./helpers";
+
+// Two-step verification with a real authenticator on the other side: the
+// otpauth URI the server mints is parsed by `otpauth` and turned into the same
+// six digits a phone would show. Nothing is stubbed, so a change to the
+// algorithm, the period or the secret encoding fails this test.
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test("enrolment, a TOTP sign-in, single-use backup codes, and turning it off", async ({
+  browser,
+}) => {
+  // Three sign-ins and four challenge answers, each rate limited to five a
+  // minute across the whole suite; the helpers back off rather than the limits
+  // being loosened, so give this room. Plus one TOTP period to roll over.
+  test.slow();
+
+  // A member of its own, never the owner: enrolling two-step verification on
+  // the shared owner account would put every other spec behind a challenge.
+  const member = await createMember(OWNER_SLUG, { tag: "twofa" });
+
+  let uri = "";
+  let enrolmentCode = "";
+  let backupCodes: string[] = [];
+
+  // ---------------------------------------------------------- enrolment
+  const enrolled = await newBrowserContext(browser, {
+    storageState: member.state,
+  });
+  try {
+    const page = await enrolled.newPage();
+    await page.goto("/settings");
+    await expect(
+      page.getByRole("heading", { name: "Two-step verification" }),
+    ).toBeVisible();
+    await expect(page.getByText("Not set up yet.")).toBeVisible();
+
+    // Step 1: confirm with the password, and the server answers with the URI.
+    await page.getByRole("button", { name: "Turn on" }).click();
+    const dialog = page.getByRole("dialog", {
+      name: "Turn on two-step verification",
+    });
+    await dialog.getByRole("textbox", { name: "Your password" }).fill(PASSWORD);
+
+    const [setup] = await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/auth/two-factor/initiate-setup") &&
+          r.request().method() === "POST",
+      ),
+      dialog.getByRole("button", { name: "Continue" }).click(),
+    ]);
+    uri = ((await setup.json()) as { uri: string }).uri;
+    expect(uri).toContain("otpauth://totp/");
+
+    // Step 2: the QR is there, and the key offered for hand entry is the same
+    // secret the URI carries — otherwise "can't scan?" hands out a dead key.
+    await expect(
+      dialog.getByRole("img", { name: /QR code to scan/ }),
+    ).toBeVisible();
+    const secret = new URL(
+      uri.replace("otpauth://", "https://"),
+    ).searchParams.get("secret");
+    expect(secret).toBeTruthy();
+    await expect(dialog.getByText(secret as string)).toBeVisible();
+
+    enrolmentCode = totpFrom(uri);
+    await dialog
+      .getByRole("textbox", { name: "6-digit code" })
+      .fill(enrolmentCode);
+    await dialog.getByRole("button", { name: "Verify code" }).click();
+
+    // Step 3: the one-shot codes, shown exactly once.
+    const list = dialog.getByRole("list", { name: "Backup codes" });
+    await expect(list).toBeVisible();
+    backupCodes = (await list.getByRole("listitem").allTextContents()).map(
+      (c) => c.trim(),
+    );
+    expect(backupCodes.length).toBeGreaterThanOrEqual(2);
+    for (const code of backupCodes) expect(code).toContain("-");
+
+    await dialog.getByRole("checkbox", { name: /saved these codes/ }).check();
+    await dialog.getByRole("button", { name: "Done" }).click();
+
+    await page.reload();
+    await expect(
+      page.getByText(
+        "You'll be asked for a code when signing in with your password.",
+      ),
+    ).toBeVisible();
+  } finally {
+    await enrolled.close();
+  }
+
+  // ------------------------------------------------- signing in with TOTP
+  const withTotp = await newBrowserContext(browser, {
+    storageState: SIGNED_OUT,
+  });
+  try {
+    const page = await withTotp.newPage();
+    await signIn(page, member.email);
+    // The password alone is no longer enough: it buys a challenge, not a
+    // session.
+    await expect(page).toHaveURL(/\/two-factor/, { timeout: 15_000 });
+
+    await submitChallengeCode(page, await nextTotp(uri, enrolmentCode));
+    await expect(page).toHaveURL(new RegExp(`/${OWNER_SLUG}/inbox`), {
+      timeout: 15_000,
+    });
+  } finally {
+    await withTotp.close();
+  }
+
+  // ------------------------------------- backup codes: good once, then not
+  const withBackup = await newBrowserContext(browser, {
+    storageState: SIGNED_OUT,
+  });
+  try {
+    const page = await withBackup.newPage();
+    await signIn(page, member.email);
+    await expect(page).toHaveURL(/\/two-factor/, { timeout: 15_000 });
+    await submitChallengeCode(page, backupCodes[0]);
+    await expect(page).toHaveURL(new RegExp(`/${OWNER_SLUG}/inbox`), {
+      timeout: 15_000,
+    });
+  } finally {
+    await withBackup.close();
+  }
+
+  const lastContext = await newBrowserContext(browser, {
+    storageState: SIGNED_OUT,
+  });
+  try {
+    const page = await lastContext.newPage();
+    await signIn(page, member.email);
+    await expect(page).toHaveURL(/\/two-factor/, { timeout: 15_000 });
+
+    // The code that already let somebody in is spent.
+    await submitChallengeCode(page, backupCodes[0]);
+    await expect(page.getByRole("alert")).toBeVisible();
+    await expect(page).toHaveURL(/\/two-factor/);
+
+    // The next one still works.
+    await submitChallengeCode(page, backupCodes[1]);
+    await expect(page).toHaveURL(new RegExp(`/${OWNER_SLUG}/inbox`), {
+      timeout: 15_000,
+    });
+
+    // ------------------------------------------------------ and turned off
+    await page.goto("/settings");
+    await page.getByRole("button", { name: "Turn off" }).click();
+    const off = page.getByRole("dialog", {
+      name: "Turn off two-step verification?",
+    });
+    await off.getByRole("textbox", { name: "Your password" }).fill(PASSWORD);
+    await off.getByRole("button", { name: "Turn off" }).click();
+
+    await expect(page.getByText("Two-step verification is off.")).toBeVisible();
+    await page.reload();
+    await expect(page.getByText("Not set up yet.")).toBeVisible();
+  } finally {
+    await lastContext.close();
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@cloudflare/vite-plugin": "1.53.1",
         "@cloudflare/vitest-pool-workers": "^0.22.0",
         "@cloudflare/workers-types": "5.20260820.1",
+        "@playwright/test": "1.63.0",
         "@testing-library/jest-dom": "^7.0.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.5",
@@ -46,6 +47,7 @@
         "concurrently": "10.0.5",
         "drizzle-kit": "^0.31.10",
         "jsdom": "^30.0.1",
+        "otpauth": "9.5.2",
         "typescript": "7.0.2",
         "vite": "8.2.2",
         "vitest": "4.1.11",
@@ -2568,9 +2570,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
-      "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -2797,6 +2799,22 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@popperjs/core": {
@@ -5542,6 +5560,19 @@
       "integrity": "sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==",
       "license": "MIT"
     },
+    "node_modules/otpauth": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/otpauth/-/otpauth-9.5.2.tgz",
+      "integrity": "sha512-GQ5emWR/x1tcExT62IBT0UfO95wZzJZyxYOJOGVeQF47SYEN9vmh0vISvDZaNMuFJRG+IaWCKtfm+t9Bfoal6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/hectorm/otpauth?sponsor=1"
+      }
+    },
     "node_modules/p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -5676,6 +5707,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/pngjs": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "test:unit": "vitest run --project unit",
     "test:integration": "vitest run --project integration",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p e2e",
     "ci": "npm run check && npm run typecheck && npm run test && npm run build"
   },
   "dependencies": {
@@ -84,6 +84,7 @@
     "@cloudflare/vite-plugin": "1.53.1",
     "@cloudflare/vitest-pool-workers": "^0.22.0",
     "@cloudflare/workers-types": "5.20260820.1",
+    "@playwright/test": "1.63.0",
     "@testing-library/jest-dom": "^7.0.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.5",
@@ -94,6 +95,7 @@
     "concurrently": "10.0.5",
     "drizzle-kit": "^0.31.10",
     "jsdom": "^30.0.1",
+    "otpauth": "9.5.2",
     "typescript": "7.0.2",
     "vite": "8.2.2",
     "vitest": "4.1.11",

--- a/scripts/e2e-stack.sh
+++ b/scripts/e2e-stack.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Starts (or tears down) the stack the Playwright suite runs against: the REAL
+# container image, a throwaway Postgres of its own, and a Mailpit that catches
+# every outbound mail so a spec can read an invitation or reset link back.
+#
+#   bash scripts/e2e-stack.sh up      # builds mi-casa:e2e if missing
+#   bash scripts/e2e-stack.sh down
+#
+# `mise run e2e` wraps up → test → down. The image is the same COPY-only
+# Dockerfile as production; `up` runs scripts/build-artifacts.sh for you when
+# dist/server is missing (E2E_REBUILD=1 forces both the artifacts and the
+# image, which is what you want after touching Go or the SPA).
+#
+# The Postgres here is deliberately NOT the compose test database
+# (docker-compose.test.yml, port 55433): that one is shared with `go test` and
+# is truncated between tests, while this one is created and destroyed with the
+# stack and must survive a whole suite run — first-run setup can only happen
+# once per database, so a stray truncation would break every later spec.
+#
+# Environment knobs (all optional):
+#   E2E_PORT           host port for the app          (default 3300)
+#   E2E_MAILPIT_PORT   host port for Mailpit's API    (default 8325)
+#   E2E_IMAGE          image to run                   (default mi-casa:e2e)
+#   E2E_REBUILD=1      rebuild artifacts and image
+#
+# CI passes E2E_IMAGE=mi-casa:ci so the suite drives the exact image the smoke
+# test just proved, with no second build.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+NET=mi-casa-e2e
+PG=mi-casa-e2e-pg
+MAILPIT=mi-casa-e2e-mailpit
+APP=mi-casa-e2e-app
+PORT="${E2E_PORT:-3300}"
+MAILPIT_PORT="${E2E_MAILPIT_PORT:-8325}"
+IMAGE="${E2E_IMAGE:-mi-casa:e2e}"
+# Pinned rather than :latest so a Mailpit release cannot change what the suite
+# sees between two runs of the same commit.
+MAILPIT_IMAGE="${E2E_MAILPIT_IMAGE:-axllent/mailpit:v1.31.0}"
+
+down() {
+  docker rm -f "$APP" "$MAILPIT" "$PG" >/dev/null 2>&1 || true
+  docker network rm "$NET" >/dev/null 2>&1 || true
+  echo "e2e stack down"
+}
+
+case "${1:-up}" in
+  down) down; exit 0 ;;
+  up) ;;
+  *) echo "usage: e2e-stack.sh [up|down]"; exit 2 ;;
+esac
+
+if [ -z "$(docker images -q "$IMAGE")" ] || [ "${E2E_REBUILD:-0}" = "1" ]; then
+  # E2E_REBUILD=1 rebuilds the ARTIFACTS too: the Dockerfile only COPYs, so
+  # reusing stale binaries would ship an image without the change under test.
+  if [ "${E2E_REBUILD:-0}" = "1" ] || [ ! -e dist/server/linux/amd64/mi-casa ]; then
+    bash scripts/build-artifacts.sh
+  fi
+  docker build -t "$IMAGE" .
+fi
+
+down >/dev/null
+docker network create "$NET" >/dev/null
+
+docker run -d --name "$PG" --network "$NET" \
+  -e POSTGRES_USER=micasa -e POSTGRES_PASSWORD=micasa -e POSTGRES_DB=micasa \
+  postgres:17-alpine >/dev/null
+
+# Mailpit is the SMTP relay AND the assertion surface: the suite reads the
+# invitation and password-reset links back over its HTTP API.
+#
+# The app insists on STARTTLS for any relay that is not on loopback, and this
+# one is another container on the compose network, so SMTP_URL below carries
+# ?starttls=off — the escape hatch internal/mail/smtp.go documents for exactly
+# this case. Without it every send fails before the mailbox is even reached,
+# and a suite that only ever asserts "the link came back" would not notice.
+#
+# --smtp-allowed-recipients is what makes a *failed* delivery reproducible:
+# anything not @e2e.test is refused at RCPT TO, so invite.spec.ts can drive
+# the "we couldn't send the email — here is a link to share" path without
+# stopping a container mid-suite.
+docker run -d --name "$MAILPIT" --network "$NET" -p "$MAILPIT_PORT":8025 \
+  -e MP_SMTP_ALLOWED_RECIPIENTS='@e2e\.test$' \
+  "$MAILPIT_IMAGE" >/dev/null
+
+# -h 127.0.0.1 forces the probe over TCP. Without it pg_isready checks the
+# Unix socket, which already accepts during initdb's socket-only first start —
+# before the restart that opens TCP — so the app could race a "ready" Postgres
+# that refused TCP connections.
+for _ in $(seq 1 30); do
+  docker exec "$PG" pg_isready -h 127.0.0.1 -U micasa -d micasa >/dev/null 2>&1 && break
+  sleep 1
+done
+
+# ENVIRONMENT=test is what makes the http:// APP_URL legal (outside
+# development and test the loader insists on https). APP_URL must match the
+# host port, not the container port: it is the origin the same-site guard
+# compares against and the base of every link mailed out.
+#
+# TRUSTED_PROXY_HOPS=1 is the reverse-proxy deployment (the one the compose
+# files and the self-hosting guide describe), and the suite plays the proxy:
+# every browser context and API client sends its own X-Forwarded-For, so the
+# per-client rate limits — sign-in 5/min, the session endpoint 60/min — apply
+# per simulated household member instead of lumping the whole suite into one
+# bucket. Without it a suite that navigates a few dozen times in ninety
+# seconds gets 429s on /api/auth/me, which the SPA reads as "signed out". The
+# limits themselves are proven in apps/server/internal/api's rate-limit tests,
+# where a fixed clock can assert them properly.
+docker run -d --name "$APP" --network "$NET" -p "$PORT":3000 \
+  -e DATABASE_URL=postgres://micasa:micasa@"$PG":5432/micasa \
+  -e APP_URL=http://127.0.0.1:"$PORT" \
+  -e ENVIRONMENT=test \
+  -e TRUSTED_PROXY_HOPS=1 \
+  -e AUTH_SECRET=e2e-stack-secret-at-least-32-bytes-ok \
+  -e SETUP_SECRET=e2e-setup-secret \
+  -e OWNER_EMAIL=owner@e2e.test \
+  -e EMAIL_DOMAIN=e2e.test \
+  -e MAILGUN_WEBHOOK_SIGNING_KEY=e2e-signing-key \
+  -e SMTP_URL='smtp://'"$MAILPIT"':1025?starttls=off' \
+  -e OUTBOUND_EMAIL_FROM=noreply@e2e.test \
+  "$IMAGE" >/dev/null
+
+for _ in $(seq 1 60); do
+  curl -fsS "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1 && break
+  sleep 1
+done
+curl -fsS "http://127.0.0.1:$PORT/readyz" | grep -q '"ok":true'
+echo "e2e stack up on http://127.0.0.1:$PORT (mailpit http://127.0.0.1:$MAILPIT_PORT)"


### PR DESCRIPTION
Phase P10 of the Go backend migration. Closes #227.

- `scripts/e2e-stack.sh up|down`: builds `mi-casa:e2e` (or reuses `E2E_IMAGE`), throwaway Postgres 17 + Mailpit + the app on :3300; `mise run e2e` wraps up/test/down
- Playwright suite (`e2e/`), one worker, Pixel 7 profile plus a desktop project for the inbox; 25 tests: first-run setup driven through the real `/setup` page (wrong secret refused, success lands in the inbox, locked afterwards), sign-in and session revocation, two-factor enrolment with a TOTP generated from the QR URI, backup-code sign-in, password reset via the Mailpit link, invitations by email and by shared link, services and sender rules, an inbound message through the signed Mailgun form landing with its code (and an SPF-failing one landing in Needs review), quarantine release and dismiss, member access/roles/removal, household settings
- CI: the suite runs after the image smoke test against the same `mi-casa:ci` image; the Playwright report is uploaded on failure

Found three real bugs on the way: `smtp://` needs `?starttls=off` for a plain relay reached by container name (documented in P11), a 429 on `/api/auth/me` was treated as sign-out (fixed in #229's PR), and a doubled `/api/auth/me` on cold load (same fix). Note: adding `otpauth` bumps the hoisted `@noble/hashes` 2.3.0 → 2.4.0 in both lockfiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yS5kEFd3AcfSkVidBs4Fj