### PR TITLE
fix(client): a rate-limited or failing session lookup is not a sign-out

### DIFF
--- a/apps/frontend/src/lib/auth-client.ts
+++ b/apps/frontend/src/lib/auth-client.ts
@@ -75,16 +75,51 @@ export class SessionUnavailableError extends Error {
   }
 }
 
-/** `Retry-After`, in either of the two forms RFC 9110 allows. */
+/**
+ * How long the session check waits before deciding the connection is not
+ * going to answer.
+ *
+ * There has to be a deadline. `fetch` on its own never gives up, so a
+ * half-open connection — a dropped Wi-Fi handover, a proxy that accepted the
+ * socket and died — leaves the guard's promise pending forever and the app
+ * stuck behind its loading screen, with no error, no retry and no way out.
+ * Limen's own SDK defaulted to 30s; half that is still far longer than a
+ * healthy `/me` and half as long to sit staring at a spinner.
+ */
+export const SESSION_TIMEOUT_MS = 15_000;
+
+/**
+ * `Retry-After`, in either of the two forms RFC 9110 allows.
+ *
+ * A value that has already elapsed — `0`, a negative delta, a date in the
+ * past — is reported as *absent* rather than as "retry now": honouring it
+ * literally is how one 429 becomes three in the space of a millisecond.
+ */
 function retryAfterMs(headers: Headers): number | null {
   const raw = headers.get("Retry-After")?.trim();
   if (!raw) return null;
 
   const seconds = Number(raw);
-  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1_000);
+  if (Number.isFinite(seconds)) return seconds > 0 ? seconds * 1_000 : null;
 
   const at = Date.parse(raw);
-  return Number.isNaN(at) ? null : Math.max(0, at - Date.now());
+  if (Number.isNaN(at)) return null;
+
+  const delay = at - Date.now();
+  return delay > 0 ? delay : null;
+}
+
+/**
+ * An abort — ours on the deadline, or the browser tearing the page down.
+ *
+ * Read off `name` rather than `instanceof Error`: an abort surfaces as a
+ * `DOMException`, and jsdom's does not inherit from `Error`, so the obvious
+ * check quietly misclassifies every timeout in the tests as a plain network
+ * failure.
+ */
+function isAbort(error: unknown): boolean {
+  const name = (error as { name?: unknown } | null | undefined)?.name;
+  return name === "TimeoutError" || name === "AbortError";
 }
 
 /**
@@ -115,47 +150,69 @@ function retryAfterMs(headers: Headers): number | null {
  * envelope `mode: "off"`, so the parsed body is the payload.
  */
 export async function getSession(): Promise<SessionData | null> {
-  let response: Response;
-  try {
-    // `globalThis.fetch` per call rather than a captured reference, for the
-    // same reason lib/api.ts dispatches through a closure: a later
-    // replacement (a test's stub, a polyfill) must still be honoured.
-    response = await globalThis.fetch(`${API_BASE}${AUTH_BASE_PATH}/me`, {
-      method: "GET",
-      credentials: "include",
-      headers: { Accept: "application/json" },
-    });
-  } catch (cause) {
-    throw new SessionUnavailableError(
-      "The session check could not reach the server",
-      0,
-      null,
-      { cause },
+  // A hand-rolled controller rather than `AbortSignal.timeout`: it lets the
+  // deadline cover reading the body as well as opening the connection, it
+  // clears itself the moment the answer lands, and — unlike the platform's
+  // internal timer — it is a `setTimeout`, so a test can drive it.
+  const deadline = new AbortController();
+  const timer = setTimeout(() => {
+    deadline.abort(
+      new DOMException("The session check timed out", "TimeoutError"),
     );
-  }
-
-  // The one definitive answer: no session, or one the server will not honour.
-  if (response.status === 401) return null;
-
-  if (!response.ok) {
-    throw new SessionUnavailableError(
-      `The session check answered ${response.status}`,
-      response.status,
-      retryAfterMs(response.headers),
-    );
-  }
+  }, SESSION_TIMEOUT_MS);
 
   try {
-    return defaultSessionParse(await response.json()) as SessionData;
-  } catch (cause) {
-    // A 200 whose body is not a session is a failure of the check, not proof
-    // that nobody is signed in.
-    throw new SessionUnavailableError(
-      "The session check answered with something unreadable",
-      response.status,
-      null,
-      { cause },
-    );
+    let response: Response;
+    try {
+      // `globalThis.fetch` per call rather than a captured reference, for the
+      // same reason lib/api.ts dispatches through a closure: a later
+      // replacement (a test's stub, a polyfill) must still be honoured.
+      response = await globalThis.fetch(`${API_BASE}${AUTH_BASE_PATH}/me`, {
+        method: "GET",
+        credentials: "include",
+        headers: { Accept: "application/json" },
+        signal: deadline.signal,
+      });
+    } catch (cause) {
+      throw new SessionUnavailableError(
+        isAbort(cause)
+          ? "The session check timed out"
+          : "The session check could not reach the server",
+        0,
+        null,
+        { cause },
+      );
+    }
+
+    // The one definitive answer: no session, or one the server will not
+    // honour.
+    if (response.status === 401) return null;
+
+    if (!response.ok) {
+      throw new SessionUnavailableError(
+        `The session check answered ${response.status}`,
+        response.status,
+        retryAfterMs(response.headers),
+      );
+    }
+
+    try {
+      return defaultSessionParse(await response.json()) as SessionData;
+    } catch (cause) {
+      // A 200 whose body is not a session — or one whose stream stalled past
+      // the deadline — is a failure of the check, not proof that nobody is
+      // signed in.
+      throw new SessionUnavailableError(
+        isAbort(cause)
+          ? "The session check timed out"
+          : "The session check answered with something unreadable",
+        isAbort(cause) ? 0 : response.status,
+        null,
+        { cause },
+      );
+    }
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/apps/frontend/src/lib/auth-client.ts
+++ b/apps/frontend/src/lib/auth-client.ts
@@ -17,8 +17,13 @@
  * below are what both this file and the server expect. Every call *throws* a
  * `LimenError` on a non-2xx rather than resolving to `{data, error}` the way
  * Better Auth did — hence the try/catch shape at each call site.
+ *
+ * The one route this file does *not* dispatch through the SDK is `GET /me`:
+ * `getSession` below explains why, and it is the difference between a
+ * rate-limited session check and a sign-out.
  */
 
+import { defaultSessionParse } from "limen-auth";
 import { credentialPasswordPlugin, twoFactorPlugin } from "limen-auth/plugins";
 import { createAuthClient } from "limen-auth/react";
 import type { SessionData } from "../types";
@@ -46,14 +51,112 @@ export const authClient = createAuthClient({
 });
 
 /**
+ * The session check could not be *made*, so nothing is known about whether
+ * anyone is signed in. That is a different fact from "nobody is", and the
+ * guards must not confuse the two (`lib/session.ts`, `lib/guards.ts`).
+ *
+ * `status` is the HTTP status, or `0` when the request never reached a server
+ * at all; `retryAfterMs` is the server's own `Retry-After`, when it sent one.
+ */
+export class SessionUnavailableError extends Error {
+  readonly name = "SessionUnavailableError";
+  readonly status: number;
+  readonly retryAfterMs: number | null;
+
+  constructor(
+    message: string,
+    status: number,
+    retryAfterMs: number | null,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options);
+    this.status = status;
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+/** `Retry-After`, in either of the two forms RFC 9110 allows. */
+function retryAfterMs(headers: Headers): number | null {
+  const raw = headers.get("Retry-After")?.trim();
+  if (!raw) return null;
+
+  const seconds = Number(raw);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1_000);
+
+  const at = Date.parse(raw);
+  return Number.isNaN(at) ? null : Math.max(0, at - Date.now());
+}
+
+/**
  * The awaited "who is signed in?" check the router's guards run through
- * TanStack Query (`lib/session.ts`). Resolves to `null` when nobody is —
- * Limen answers 401 for an absent or expired session, which the SDK surfaces
- * as `data: null` rather than an error.
+ * TanStack Query (`lib/session.ts`). Resolves to the session, or to `null`
+ * when the server *states* that nobody is signed in — a 401, and only a 401.
+ * Every other outcome — the 429 Limen's 60/min limiter answers with, a 5xx, a
+ * connection that never lands — throws `SessionUnavailableError`.
+ *
+ * This calls `GET /api/auth/me` directly rather than through
+ * `authClient.getSession()`, for two reasons, both of which were bugs:
+ *
+ *  1. The SDK's `getSession` awaits a store refetch and then reads the result
+ *     with `$state.get()`. Reading a nanostore atom that has no listeners
+ *     *mounts* it, and the session store is created with `fetchOnMount: true`
+ *     — so the read fires a **second** `GET /me`. Every cold load therefore
+ *     spent two of the sixty requests a client gets each minute, on the very
+ *     route whose 429 this file now has to survive.
+ *  2. That second load synchronously clears `error` on the store before
+ *     `.get()` returns, so `if (state.error) throw` never fires on a cold
+ *     load: a 429 or a 5xx resolved as `null`, indistinguishable from "signed
+ *     out". Which is exactly how a rate-limited visitor got signed out.
+ *
+ * Nothing else in the app reads Limen's session store — the guards and the
+ * chrome both read the TanStack Query cache — so going straight to the route
+ * costs nothing. `defaultSessionParse` is the SDK's own normaliser (the
+ * snake_case → camelCase pass), and the client is configured with the default
+ * envelope `mode: "off"`, so the parsed body is the payload.
  */
 export async function getSession(): Promise<SessionData | null> {
-  const session = await authClient.getSession();
-  return (session as SessionData | null) ?? null;
+  let response: Response;
+  try {
+    // `globalThis.fetch` per call rather than a captured reference, for the
+    // same reason lib/api.ts dispatches through a closure: a later
+    // replacement (a test's stub, a polyfill) must still be honoured.
+    response = await globalThis.fetch(`${API_BASE}${AUTH_BASE_PATH}/me`, {
+      method: "GET",
+      credentials: "include",
+      headers: { Accept: "application/json" },
+    });
+  } catch (cause) {
+    throw new SessionUnavailableError(
+      "The session check could not reach the server",
+      0,
+      null,
+      { cause },
+    );
+  }
+
+  // The one definitive answer: no session, or one the server will not honour.
+  if (response.status === 401) return null;
+
+  if (!response.ok) {
+    throw new SessionUnavailableError(
+      `The session check answered ${response.status}`,
+      response.status,
+      retryAfterMs(response.headers),
+    );
+  }
+
+  try {
+    return defaultSessionParse(await response.json()) as SessionData;
+  } catch (cause) {
+    // A 200 whose body is not a session is a failure of the check, not proof
+    // that nobody is signed in.
+    throw new SessionUnavailableError(
+      "The session check answered with something unreadable",
+      response.status,
+      null,
+      { cause },
+    );
+  }
 }
 
 export type SignInResult = {

--- a/apps/frontend/src/lib/guards.ts
+++ b/apps/frontend/src/lib/guards.ts
@@ -18,6 +18,7 @@ import type {
 } from "@tanstack/react-query";
 import { type ParsedLocation, redirect } from "@tanstack/react-router";
 import type { HouseholdSummary, SessionData } from "../types";
+import { SessionUnavailableError } from "./auth-client";
 import {
   ANONYMOUS_SESSION,
   householdsQueryOptions,
@@ -73,10 +74,9 @@ function then<T, R>(value: Maybe<T>, next: (value: T) => Maybe<R>): Maybe<R> {
  *
  * `sessionQueryOptions` rejects with `SessionUnavailableError` when the check
  * could not be made at all — a 429 from Limen's 60/min limiter, a 5xx, a
- * dropped connection — after retrying it (`lib/session.ts`). When that
- * happens the query keeps whatever answer it last got, so:
+ * dropped connection, a deadline (`lib/session.ts`). When that happens:
  *
- *  - a previously cached session is used, and the navigation carries on. The
+ *  - a previously cached answer is used and the navigation carries on. The
  *    visitor is still signed in; the server just could not say so this
  *    second, and bouncing them to `/login` over that is the bug this exists
  *    to prevent.
@@ -84,19 +84,63 @@ function then<T, R>(value: Maybe<T>, next: (value: T) => Maybe<R>): Maybe<R> {
  *    decides: the public routes settle for "anonymous" so sign-in stays
  *    reachable during an outage, while the authed ones pass `null` and let
  *    the error escape to the router's error screen, which offers a retry.
+ *
+ * Retries are for *finding out*, so they are switched off whenever the cache
+ * already holds an answer. Otherwise a 429 incident would make every single
+ * navigation sit through the backoff and spend three requests out of the
+ * sixty per minute that caused the 429 — paying, on the critical path, for
+ * information the guard is about to discard in favour of the cache. With
+ * nothing cached the retries are the whole point and stay on.
+ *
+ * A cached answer is never a licence to ignore the server: the fetch is still
+ * awaited, so a session revoked elsewhere still answers 401 and still lands
+ * the visitor on `/login`. This is only about what to do when the server does
+ * not answer at all.
  */
 function readSession(
   queryClient: QueryClient,
   whenUnavailable: SessionResult | null,
 ): Maybe<SessionResult> {
-  const value = read(queryClient, sessionQueryOptions);
+  const cached = queryClient.getQueryData<SessionResult>(
+    sessionQueryOptions.queryKey,
+  );
+
+  const value = read(
+    queryClient,
+    cached === undefined
+      ? sessionQueryOptions
+      : { ...sessionQueryOptions, retry: false },
+  );
   if (!(value instanceof Promise)) return value;
 
   return value.catch((error: unknown) => {
-    const cached = queryClient.getQueryData<SessionResult>(
+    // Only a check that could not be made is recoverable here. Anything else
+    // is a bug in the query function and must not be papered over with a
+    // stale session.
+    if (!(error instanceof SessionUnavailableError)) throw error;
+
+    // Re-read: the fetch may have been in flight long enough for the answer
+    // to have changed underneath the value read above.
+    const previous = queryClient.getQueryData<SessionResult>(
       sessionQueryOptions.queryKey,
     );
-    if (cached) return cached;
+
+    if (previous) {
+      // Write it back, unchanged, to re-date it. That is not bookkeeping: a
+      // single navigation runs this guard once per matched route, and a
+      // failed fetch leaves the entry invalidated, so without this every
+      // route in the chain re-asks a server that has just refused — turning
+      // one 429 into several. Re-dating says "this is the answer we are
+      // going with", and it holds for the same `staleTime` a successful
+      // check would have earned. An explicit `invalidateQueries` (sign-in,
+      // sign-out, an accepted invitation) still forces a fresh check.
+      queryClient.setQueryData(sessionQueryOptions.queryKey, previous);
+      return previous;
+    }
+
+    // Nothing cached: do not seed `whenUnavailable`. It is this guard's
+    // decision about one navigation, not an answer about the account, and
+    // caching it would keep a signed-in visitor on `/login` for 30 seconds.
     if (whenUnavailable) return whenUnavailable;
     throw error;
   });

--- a/apps/frontend/src/lib/guards.ts
+++ b/apps/frontend/src/lib/guards.ts
@@ -19,9 +19,11 @@ import type {
 import { type ParsedLocation, redirect } from "@tanstack/react-router";
 import type { HouseholdSummary, SessionData } from "../types";
 import {
+  ANONYMOUS_SESSION,
   householdsQueryOptions,
   isAuthenticated,
   PENDING_INVITE_KEY,
+  type SessionResult,
   type SetupStatusResult,
   sessionQueryOptions,
   setupStatusQueryOptions,
@@ -63,6 +65,41 @@ function read<T, TKey extends QueryKey>(
 /** `.then` that stays synchronous for values that are not promises. */
 function then<T, R>(value: Maybe<T>, next: (value: T) => Maybe<R>): Maybe<R> {
   return value instanceof Promise ? value.then(next) : next(value);
+}
+
+/**
+ * The session, read with the one rule that separates it from every other
+ * query here: **only a definitive 401 means signed out.**
+ *
+ * `sessionQueryOptions` rejects with `SessionUnavailableError` when the check
+ * could not be made at all — a 429 from Limen's 60/min limiter, a 5xx, a
+ * dropped connection — after retrying it (`lib/session.ts`). When that
+ * happens the query keeps whatever answer it last got, so:
+ *
+ *  - a previously cached session is used, and the navigation carries on. The
+ *    visitor is still signed in; the server just could not say so this
+ *    second, and bouncing them to `/login` over that is the bug this exists
+ *    to prevent.
+ *  - with nothing cached there is nothing honest to say. `whenUnavailable`
+ *    decides: the public routes settle for "anonymous" so sign-in stays
+ *    reachable during an outage, while the authed ones pass `null` and let
+ *    the error escape to the router's error screen, which offers a retry.
+ */
+function readSession(
+  queryClient: QueryClient,
+  whenUnavailable: SessionResult | null,
+): Maybe<SessionResult> {
+  const value = read(queryClient, sessionQueryOptions);
+  if (!(value instanceof Promise)) return value;
+
+  return value.catch((error: unknown) => {
+    const cached = queryClient.getQueryData<SessionResult>(
+      sessionQueryOptions.queryKey,
+    );
+    if (cached) return cached;
+    if (whenUnavailable) return whenUnavailable;
+    throw error;
+  });
 }
 
 function pendingInviteToken(): string | null {
@@ -153,7 +190,9 @@ export interface SessionGuardResult {
  */
 export function requireSession(args: GuardArgs): Maybe<SessionGuardResult> {
   return then(requireSetupDone(args), (setup) =>
-    then(read(args.context.queryClient, sessionQueryOptions), (session) => {
+    // No fallback: with nothing cached, a session check that could not be
+    // made must reach the error screen and its retry, never `/login`.
+    then(readSession(args.context.queryClient, null), (session) => {
       if (!isAuthenticated(session)) {
         throw redirect({
           to: "/login",
@@ -161,7 +200,7 @@ export function requireSession(args: GuardArgs): Maybe<SessionGuardResult> {
           replace: true,
         });
       }
-      return { setup, session: session as SessionData };
+      return { setup, session: { user: session.user } };
     }),
   );
 }
@@ -169,12 +208,19 @@ export function requireSession(args: GuardArgs): Maybe<SessionGuardResult> {
 /** `/login` and friends: a signed-in visitor has no business here. */
 export function requireAnonymous(args: GuardArgs): Maybe<SetupStatusResult> {
   return then(requireSetupDone(args), (setup) =>
-    then(read(args.context.queryClient, sessionQueryOptions), (session) => {
-      if (isAuthenticated(session)) {
-        throw redirect({ to: "/", replace: true });
-      }
-      return setup;
-    }),
+    // Falls back to "anonymous": if we cannot find out who this is, the way
+    // *in* has to stay open. Showing the sign-in page to someone who turns
+    // out to be signed in costs them a click; an error screen in front of
+    // sign-in during an outage costs them the app.
+    then(
+      readSession(args.context.queryClient, ANONYMOUS_SESSION),
+      (session) => {
+        if (isAuthenticated(session)) {
+          throw redirect({ to: "/", replace: true });
+        }
+        return setup;
+      },
+    ),
   );
 }
 

--- a/apps/frontend/src/lib/session.ts
+++ b/apps/frontend/src/lib/session.ts
@@ -15,7 +15,7 @@ import {
 } from "@tanstack/react-query";
 import type { HouseholdSummary, SessionData, SetupStatus } from "../types";
 import { ApiError, client, unwrap } from "./api";
-import { getSession, signOut } from "./auth-client";
+import { getSession, SessionUnavailableError, signOut } from "./auth-client";
 
 /** Set by the invite page before it sends a signed-out visitor to sign in. */
 export const PENDING_INVITE_KEY = "pendingInviteToken";
@@ -57,21 +57,74 @@ export const setupStatusQueryOptions = queryOptions({
   staleTime: 30_000,
 });
 
+/**
+ * Who is signed in — or, just as importantly, the admission that we could not
+ * find out.
+ *
+ * The third state is the point. `GET /api/auth/me` sits behind Limen's
+ * 60/min-per-client limiter, so an ordinary busy tab (or a household behind
+ * one NAT) can meet a 429; a restart or a proxy hiccup can meet a 5xx or
+ * nothing at all. Collapsing any of those into "anonymous" is what used to
+ * throw a visitor with a perfectly good session out to `/login`.
+ *
+ * `unavailable` is not a value in this union because it is never cached: the
+ * query *rejects* with `SessionUnavailableError`, which is what lets
+ * TanStack Query retry it and what leaves the last known answer in the cache
+ * for the guards to keep using (`lib/guards.ts`).
+ */
+export type SessionResult =
+  | { status: "anonymous"; user: null }
+  | { status: "signed-in"; user: NonNullable<SessionData["user"]> };
+
+/** The server said nobody is signed in — or we just signed them out. */
+export const ANONYMOUS_SESSION: SessionResult = {
+  status: "anonymous",
+  user: null,
+};
+
+/**
+ * How many times a session lookup that never got an answer is retried before
+ * the guards fall back to the cache (or the error screen). Two is enough to
+ * ride out a limiter window boundary or a single dropped request without
+ * making an outage worse.
+ */
+export const SESSION_RETRY_COUNT = 2;
+const SESSION_RETRY_BASE_MS = 300;
+const SESSION_RETRY_MAX_MS = 5_000;
+
 export const sessionQueryOptions = queryOptions({
   queryKey: ["session"] as const,
-  queryFn: async (): Promise<SessionData | null> => {
-    try {
-      return await getSession();
-    } catch {
-      // A failed session lookup means "not signed in" here, the same as it
-      // did when the app read Better Auth's session hook. Limen answers 401
-      // with `null` rather than throwing, so this only catches a network or
-      // 5xx failure — in which case the guards send the visitor to /login,
-      // which is the safe direction.
-      return null;
-    }
+  queryFn: async (): Promise<SessionResult> => {
+    // Throws `SessionUnavailableError` for anything that is not a definitive
+    // 401; see `lib/auth-client.ts`.
+    const session = await getSession();
+    const user = session?.user;
+
+    // A 200 that names nobody is the same answer as a 401. The old
+    // `isAuthenticated` drew the line at the email address and screens rely
+    // on it being there, so the line stays where it was.
+    return user?.email ? { status: "signed-in", user } : ANONYMOUS_SESSION;
   },
   staleTime: 30_000,
+  // Only a lookup that failed to happen is worth repeating. Anything else
+  // thrown here is a bug in the query function and should surface at once.
+  retry: (failureCount, error) =>
+    error instanceof SessionUnavailableError &&
+    failureCount < SESSION_RETRY_COUNT,
+  retryDelay: (attempt, error) => {
+    // The limiter tells us exactly how long it wants; retrying sooner just
+    // spends another request on another 429.
+    if (
+      error instanceof SessionUnavailableError &&
+      error.retryAfterMs !== null
+    ) {
+      // Capped, though: a limiter window can be a full minute away, and
+      // freezing a route guard for that long is worse than giving up and
+      // letting the cache (or the error screen's own retry) take over.
+      return Math.min(error.retryAfterMs, SESSION_RETRY_MAX_MS);
+    }
+    return Math.min(SESSION_RETRY_BASE_MS * 3 ** attempt, SESSION_RETRY_MAX_MS);
+  },
 });
 
 export const householdsQueryOptions = queryOptions({
@@ -99,8 +152,10 @@ export const householdsQueryOptions = queryOptions({
   },
 });
 
-export function isAuthenticated(session: SessionData | null): boolean {
-  return Boolean(session?.user?.email);
+export function isAuthenticated(
+  session: SessionResult | undefined,
+): session is Extract<SessionResult, { status: "signed-in" }> {
+  return session?.status === "signed-in";
 }
 
 /**
@@ -153,7 +208,7 @@ export async function signOutAndReset(queryClient: QueryClient): Promise<void> {
   } catch {
     // Deliberately swallowed; see above.
   }
-  queryClient.setQueryData(sessionQueryOptions.queryKey, null);
+  queryClient.setQueryData(sessionQueryOptions.queryKey, ANONYMOUS_SESSION);
   queryClient.setQueryData(
     householdsQueryOptions.queryKey,
     SIGNED_OUT_HOUSEHOLDS,
@@ -177,7 +232,10 @@ export function useSetupStatus(): SetupStatusResult {
 
 export function useSessionData(): SessionData | null {
   const { data } = useQuery(sessionQueryOptions);
-  return data ?? null;
+  // A lookup that failed leaves `data` at the last answer it did get, so the
+  // chrome keeps showing the account it was showing a moment ago rather than
+  // blanking out over a 429.
+  return data?.status === "signed-in" ? { user: data.user } : null;
 }
 
 export function useHouseholds(): HouseholdsResult {

--- a/apps/frontend/src/lib/session.ts
+++ b/apps/frontend/src/lib/session.ts
@@ -76,11 +76,15 @@ export type SessionResult =
   | { status: "anonymous"; user: null }
   | { status: "signed-in"; user: NonNullable<SessionData["user"]> };
 
-/** The server said nobody is signed in — or we just signed them out. */
-export const ANONYMOUS_SESSION: SessionResult = {
+/**
+ * The server said nobody is signed in — or we just signed them out. Frozen
+ * because it is seeded straight into the query cache and shared by every
+ * guard that falls back to it; nothing may edit the answer in place.
+ */
+export const ANONYMOUS_SESSION: SessionResult = Object.freeze({
   status: "anonymous",
   user: null,
-};
+});
 
 /**
  * How many times a session lookup that never got an answer is retried before

--- a/apps/frontend/src/router.tsx
+++ b/apps/frontend/src/router.tsx
@@ -18,10 +18,12 @@ import {
   createRootRouteWithContext,
   createRoute,
   createRouter,
+  type ErrorComponentProps,
   Outlet,
   type RouterHistory,
   useNavigate,
   useParams,
+  useRouter,
 } from "@tanstack/react-router";
 import { useState } from "react";
 import { AppChrome } from "./components/AppChrome";
@@ -38,8 +40,10 @@ import { SetupPage } from "./components/SetupPage";
 import { ServicesPage } from "./components/services/ServicesPage";
 import { AccountSettingsPage } from "./components/settings/AccountSettingsPage";
 import { TwoFactorPage } from "./components/TwoFactorPage";
+import { ErrorState } from "./components/ui";
 import { InstallProvider, useInstallState } from "./hooks/useInstallPrompt";
 import { AppearanceProvider } from "./lib/appearance";
+import { SessionUnavailableError } from "./lib/auth-client";
 import {
   type RouterContext,
   redirectToStart,
@@ -106,6 +110,53 @@ function LoadingScreen() {
       <Typography color="text.secondary">
         Checking the current session and preparing the latest messages.
       </Typography>
+    </Box>
+  );
+}
+
+/**
+ * The app's one full-screen failure, and the reason it exists: a guard that
+ * could not find out whether anyone is signed in must land *here*, not on
+ * `/login`. A 429 from Limen's 60/min limiter, a 5xx, a dropped connection —
+ * none of those are a sign-out, so the screen keeps the visitor where they
+ * are and offers the only useful action, which is to ask again.
+ */
+function ErrorScreen({ error, reset }: ErrorComponentProps) {
+  const router = useRouter();
+
+  const unavailable = error instanceof SessionUnavailableError;
+  const message = unavailable
+    ? error.status === 429
+      ? "The server is busy and turned the check away. You have not been signed out."
+      : "We could not reach the server to confirm you are signed in."
+    : error.message || "This page could not be loaded.";
+
+  const retry = async () => {
+    reset();
+    await router.invalidate();
+  };
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        minHeight: "100vh",
+        alignItems: "center",
+        justifyContent: "center",
+        p: 3,
+      }}
+    >
+      <Box sx={{ width: "100%", maxWidth: 520 }}>
+        <ErrorState
+          title={
+            unavailable
+              ? "We couldn't check your session"
+              : "Something went wrong"
+          }
+          message={message}
+          onRetry={() => void retry()}
+        />
+      </Box>
     </Box>
   );
 }
@@ -530,6 +581,9 @@ export function createAppRouter({
     // only shows on a genuine wait — the old app's behaviour, where the
     // full-screen loader appeared the moment a session check started.
     defaultPendingComponent: LoadingScreen,
+    // A guard can now fail without deciding anything — the session check that
+    // never got an answer (lib/guards.ts). This is where that lands.
+    defaultErrorComponent: ErrorScreen,
     defaultPendingMs: 0,
     defaultPendingMinMs: 0,
     scrollRestoration: true,

--- a/apps/frontend/test/router.test.tsx
+++ b/apps/frontend/test/router.test.tsx
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { safeRedirect } from "../src/lib/guards";
 import {
+  ANONYMOUS_SESSION,
   clearAuthQueries,
   householdsQueryOptions,
   sessionQueryOptions,
@@ -284,7 +285,9 @@ describe("signing out", () => {
 
     await signOutAndReset(queryClient);
 
-    expect(queryClient.getQueryData(sessionQueryOptions.queryKey)).toBeNull();
+    expect(queryClient.getQueryData(sessionQueryOptions.queryKey)).toEqual(
+      ANONYMOUS_SESSION,
+    );
     expect(queryClient.getQueryData(householdsQueryOptions.queryKey)).toEqual({
       households: [],
       error: null,
@@ -333,7 +336,9 @@ describe("signing out", () => {
 
     await expect(signOutAndReset(queryClient)).resolves.toBeUndefined();
 
-    expect(queryClient.getQueryData(sessionQueryOptions.queryKey)).toBeNull();
+    expect(queryClient.getQueryData(sessionQueryOptions.queryKey)).toEqual(
+      ANONYMOUS_SESSION,
+    );
     expect(queryClient.getQueryData(householdsQueryOptions.queryKey)).toEqual({
       households: [],
       error: null,

--- a/apps/frontend/test/session.test.tsx
+++ b/apps/frontend/test/session.test.tsx
@@ -13,9 +13,14 @@ import "@testing-library/jest-dom/vitest";
 import { QueryClient } from "@tanstack/react-query";
 import { createMemoryHistory, RouterProvider } from "@tanstack/react-router";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { SESSION_RETRY_COUNT, sessionQueryOptions } from "../src/lib/session";
+import {
+  ANONYMOUS_SESSION,
+  SESSION_RETRY_COUNT,
+  sessionQueryOptions,
+} from "../src/lib/session";
 import type { HouseholdSummary, SessionData } from "../src/types";
 import { readRequest } from "./fetch-mock";
 
@@ -188,6 +193,58 @@ describe("a failing session lookup is not a sign-out", () => {
     expect(guardError(router)).toBeNull();
   });
 
+  it("spends one request, not three, when it already knows who this is", async () => {
+    // Backoff is for finding out. With an answer already in hand there is
+    // nothing to find out, and sitting through ~1.2s of it on every
+    // navigation — while spending three of the sixty requests a minute that
+    // caused the 429 in the first place — makes the incident worse.
+    authState.session = signedIn;
+    mockApi();
+
+    const queryClient = testQueryClient();
+    const warmUp = routerAt("/casa/inbox", queryClient);
+    await warmUp.load();
+
+    authState.failure = rateLimited();
+    authState.calls = 0;
+    await queryClient.invalidateQueries({
+      queryKey: sessionQueryOptions.queryKey,
+    });
+
+    const router = routerAt("/casa/inbox", queryClient);
+    await router.load();
+
+    expect(router.state.location.pathname).toBe("/casa/inbox");
+    expect(guardError(router)).toBeNull();
+    expect(authState.calls).toBe(1);
+  });
+
+  it("does send the visitor to /login when the session is genuinely revoked", async () => {
+    // The other side of the coin: a cached session must not become a licence
+    // to ignore the server. Signed out on another device, or an expiry — the
+    // server answers 401 and that answer wins over anything cached.
+    authState.session = signedIn;
+    mockApi();
+
+    const queryClient = testQueryClient();
+    const warmUp = routerAt("/casa/inbox", queryClient);
+    await warmUp.load();
+    expect(warmUp.state.location.pathname).toBe("/casa/inbox");
+
+    authState.session = null;
+    await queryClient.invalidateQueries({
+      queryKey: sessionQueryOptions.queryKey,
+    });
+
+    const router = routerAt("/casa/inbox", queryClient);
+    await router.load();
+
+    expect(router.state.location.pathname).toBe("/login");
+    expect(queryClient.getQueryData(sessionQueryOptions.queryKey)).toEqual(
+      ANONYMOUS_SESSION,
+    );
+  });
+
   it("does not sign anyone out over a 5xx or a dead network", async () => {
     authState.session = signedIn;
     mockApi();
@@ -231,9 +288,11 @@ describe("a failing session lookup is not a sign-out", () => {
     render(<RouterProvider router={router} />);
     const alert = await screen.findByRole("alert");
     expect(alert).toHaveTextContent(/couldn.t check|sign|session/i);
-    expect(
-      screen.getByRole("button", { name: /try again/i }),
-    ).toBeInTheDocument();
+
+    // The button is the whole point of the screen: it must actually ask again.
+    const spent = authState.calls;
+    await userEvent.click(screen.getByRole("button", { name: /try again/i }));
+    await waitFor(() => expect(authState.calls).toBeGreaterThan(spent));
   });
 
   it("still sends a genuinely signed-out visitor to /login", async () => {
@@ -360,6 +419,79 @@ describe("the session request itself", () => {
     await new Promise((resolve) => setTimeout(resolve, 50));
 
     expect(calls.filter((url) => url.endsWith("/api/auth/me"))).toHaveLength(1);
+  });
+
+  it("gives up on a half-open connection instead of hanging the guard", async () => {
+    // Without a deadline, a connection that opens and never answers leaves
+    // `beforeLoad` pending forever — the app stuck behind its loading screen
+    // with no error, no retry and no way out.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        (_input: RequestInfo | URL, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            const { signal } = init ?? {};
+            signal?.addEventListener("abort", () => reject(signal.reason));
+          }),
+      ),
+    );
+
+    vi.resetModules();
+    const actual = await vi.importActual<
+      typeof import("../src/lib/auth-client")
+    >("../src/lib/auth-client");
+
+    vi.useFakeTimers();
+    try {
+      const settled = actual.getSession().then(
+        () => null,
+        (caught: unknown) => caught,
+      );
+      await vi.advanceTimersByTimeAsync(actual.SESSION_TIMEOUT_MS + 1_000);
+
+      const error = await settled;
+      expect(error).toBeInstanceOf(actual.SessionUnavailableError);
+      const unavailable = error as InstanceType<
+        typeof actual.SessionUnavailableError
+      >;
+      // Nothing was learned about the session, so: not signed out.
+      expect(unavailable.status).toBe(0);
+      expect(unavailable.message).toMatch(/timed out/i);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("treats a Retry-After of zero or less as no Retry-After at all", async () => {
+    let header = "0";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ message: "slow down" }), {
+            status: 429,
+            headers: {
+              "content-type": "application/json",
+              "retry-after": header,
+            },
+          }),
+      ),
+    );
+
+    vi.resetModules();
+    const actual = await vi.importActual<
+      typeof import("../src/lib/auth-client")
+    >("../src/lib/auth-client");
+
+    for (const value of ["0", "-5", "not-a-date"]) {
+      header = value;
+      const error = (await actual.getSession().catch((e: unknown) => e)) as {
+        retryAfterMs: number | null;
+      };
+      // A zero would otherwise mean "retry immediately", which is how a
+      // client turns one 429 into three.
+      expect(error.retryAfterMs).toBeNull();
+    }
   });
 
   it("reports 401 as anonymous and everything else as unavailable", async () => {

--- a/apps/frontend/test/session.test.tsx
+++ b/apps/frontend/test/session.test.tsx
@@ -1,0 +1,411 @@
+// @vitest-environment jsdom
+/**
+ * What the router does when the session lookup *fails* rather than answering.
+ *
+ * `GET /api/auth/me` sits behind Limen's 60/min-per-client limiter, so a busy
+ * tab, a shared NAT or a burst of navigations can get a 429 — and a restart,
+ * a proxy hiccup or a flaky connection can get a 5xx or nothing at all. None
+ * of those mean "signed out": only a definitive 401 does. These tests pin
+ * that distinction, and pin the number of `/me` requests a cold load makes.
+ */
+import "@testing-library/jest-dom/vitest";
+
+import { QueryClient } from "@tanstack/react-query";
+import { createMemoryHistory, RouterProvider } from "@tanstack/react-router";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SESSION_RETRY_COUNT, sessionQueryOptions } from "../src/lib/session";
+import type { HouseholdSummary, SessionData } from "../src/types";
+import { readRequest } from "./fetch-mock";
+
+const authState = vi.hoisted(() => ({
+  session: null as SessionData | null,
+  /** Set to make the lookup fail the way a 429 or a 5xx does. */
+  failure: null as Error | null,
+  /** How many of the next lookups `failure` applies to. */
+  failuresLeft: Number.POSITIVE_INFINITY,
+  calls: 0,
+}));
+
+vi.mock("@/lib/auth-client", async () => {
+  const actual = await vi.importActual<typeof import("../src/lib/auth-client")>(
+    "../src/lib/auth-client",
+  );
+  return {
+    ...actual,
+    getSession: async () => {
+      authState.calls += 1;
+      if (authState.failure !== null && authState.failuresLeft > 0) {
+        authState.failuresLeft -= 1;
+        throw authState.failure;
+      }
+      return authState.session;
+    },
+    signIn: async () => ({ twoFactorRequired: false }),
+    signOut: async () => {},
+  };
+});
+
+const { SessionUnavailableError } = await import("../src/lib/auth-client");
+const { createAppRouter } = await import("../src/router");
+
+const owner: HouseholdSummary = {
+  id: "h1",
+  slug: "casa",
+  displayName: "Casa",
+  role: "owner",
+};
+
+const signedIn: SessionData = {
+  user: { email: "alex@example.com", name: "Alex" },
+};
+
+/** What Limen's limiter answers with once the 60/min budget is spent. */
+function rateLimited() {
+  return new SessionUnavailableError("Too many requests", 429, null);
+}
+
+function json(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function mockApi({
+  households = [owner],
+}: {
+  households?: HouseholdSummary[];
+} = {}) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const { url } = await readRequest(input);
+
+      if (url.includes("/api/setup/status")) {
+        return json({
+          needsSetup: false,
+          setupLocked: false,
+          isConfigured: true,
+          status: "complete",
+          emailDomain: "example.com",
+        });
+      }
+      if (url.includes("/api/settings/households")) return json({ households });
+
+      throw new Error(`Unexpected request: ${url}`);
+    }),
+  );
+}
+
+/** Retries are the query's own business here, so the client must not veto them. */
+function testQueryClient() {
+  return new QueryClient();
+}
+
+function routerAt(path: string, queryClient: QueryClient) {
+  return createAppRouter({
+    queryClient,
+    history: createMemoryHistory({ initialEntries: [path] }),
+  });
+}
+
+/**
+ * Staying off `/login` is only half the answer: a guard that *threw* also
+ * leaves the URL alone, and puts the error screen where the page should be.
+ * This is how the tests tell "carried on" apart from "gave up in place".
+ */
+function guardError(
+  router: ReturnType<typeof routerAt>,
+): { message?: string } | null {
+  const failed = router.state.matches.find((match) => match.status === "error");
+  return (failed?.error as { message?: string } | undefined) ?? null;
+}
+
+beforeEach(() => {
+  authState.session = null;
+  authState.failure = null;
+  authState.failuresLeft = Number.POSITIVE_INFINITY;
+  authState.calls = 0;
+  sessionStorage.clear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("a failing session lookup is not a sign-out", () => {
+  it("keeps a signed-in visitor on the inbox when /me answers 429", async () => {
+    authState.session = signedIn;
+    mockApi();
+
+    const queryClient = testQueryClient();
+    const warmUp = routerAt("/casa/inbox", queryClient);
+    await warmUp.load();
+    expect(warmUp.state.location.pathname).toBe("/casa/inbox");
+
+    // Everything the guards need is cached now — and stale, so the next
+    // navigation re-reads it and meets the limiter.
+    authState.failure = rateLimited();
+    await queryClient.invalidateQueries({
+      queryKey: sessionQueryOptions.queryKey,
+    });
+
+    const router = routerAt("/casa/inbox", queryClient);
+    await router.load();
+
+    expect(router.state.location.pathname).toBe("/casa/inbox");
+    expect(router.state.location.search).not.toMatchObject({
+      redirect: expect.anything(),
+    });
+    // The screen renders: the guard used the session it already had.
+    expect(guardError(router)).toBeNull();
+    // The last known answer survives the failure; it is not overwritten with
+    // "anonymous".
+    expect(queryClient.getQueryData(sessionQueryOptions.queryKey)).toEqual({
+      status: "signed-in",
+      user: signedIn.user,
+    });
+  });
+
+  it("keeps a signed-in visitor in place when the whole app revalidates into a 429", async () => {
+    authState.session = signedIn;
+    mockApi();
+
+    const queryClient = testQueryClient();
+    const router = routerAt("/casa/members", queryClient);
+    await router.load();
+    expect(router.state.location.pathname).toBe("/casa/members");
+
+    authState.failure = rateLimited();
+    await queryClient.invalidateQueries({
+      queryKey: sessionQueryOptions.queryKey,
+    });
+    await router.invalidate();
+
+    expect(router.state.location.pathname).toBe("/casa/members");
+    expect(guardError(router)).toBeNull();
+  });
+
+  it("does not sign anyone out over a 5xx or a dead network", async () => {
+    authState.session = signedIn;
+    mockApi();
+
+    const queryClient = testQueryClient();
+    const warmUp = routerAt("/casa/inbox", queryClient);
+    await warmUp.load();
+
+    for (const failure of [
+      new SessionUnavailableError("Bad gateway", 502, null),
+      new SessionUnavailableError("Failed to fetch", 0, null),
+    ]) {
+      authState.failure = failure;
+      await queryClient.invalidateQueries({
+        queryKey: sessionQueryOptions.queryKey,
+      });
+
+      const router = routerAt("/casa/inbox", queryClient);
+      await router.load();
+      expect(router.state.location.pathname).toBe("/casa/inbox");
+      expect(guardError(router)).toBeNull();
+    }
+  });
+
+  it("shows an error with a retry — not /login — when a 429 meets a cold cache", async () => {
+    authState.failure = rateLimited();
+    mockApi();
+
+    const queryClient = testQueryClient();
+    const router = routerAt("/casa/inbox", queryClient);
+    await router.load();
+
+    // The one thing that must not happen: a visitor with a perfectly valid
+    // session bounced to sign in because the server was busy.
+    expect(router.state.location.pathname).toBe("/casa/inbox");
+    // Nothing was known, so the guard stopped rather than guessing.
+    expect(guardError(router)).not.toBeNull();
+    // It retried before giving up.
+    expect(authState.calls).toBe(1 + SESSION_RETRY_COUNT);
+
+    render(<RouterProvider router={router} />);
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/couldn.t check|sign|session/i);
+    expect(
+      screen.getByRole("button", { name: /try again/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("still sends a genuinely signed-out visitor to /login", async () => {
+    authState.session = null;
+    mockApi();
+
+    const queryClient = testQueryClient();
+    const router = routerAt("/casa/inbox", queryClient);
+    await router.load();
+
+    expect(router.state.location.pathname).toBe("/login");
+    expect(router.state.location.search).toMatchObject({
+      redirect: "/casa/inbox",
+    });
+    expect(queryClient.getQueryData(sessionQueryOptions.queryKey)).toEqual({
+      status: "anonymous",
+      user: null,
+    });
+  });
+
+  it("lets a visitor reach /login while the session lookup is failing", async () => {
+    // The way out of an outage must stay open: nothing is known about this
+    // visitor, so the public page renders rather than an error screen.
+    authState.failure = rateLimited();
+    mockApi();
+
+    const queryClient = testQueryClient();
+    const router = routerAt("/login", queryClient);
+    await router.load();
+
+    expect(router.state.location.pathname).toBe("/login");
+    // And the sign-in form itself, not an error screen in front of it.
+    expect(guardError(router)).toBeNull();
+  });
+
+  it("retries a 429 and recovers without the visitor seeing it", async () => {
+    // One 429, then the real answer — from a cold cache, so the retry is the
+    // only thing standing between this visitor and a wrongful /login.
+    mockApi();
+    authState.session = signedIn;
+    authState.failure = rateLimited();
+    authState.failuresLeft = 1;
+
+    const queryClient = testQueryClient();
+    const router = routerAt("/casa/inbox", queryClient);
+    await router.load();
+
+    expect(router.state.location.pathname).toBe("/casa/inbox");
+    expect(guardError(router)).toBeNull();
+    expect(authState.calls).toBe(2);
+  });
+});
+
+describe("session retry policy", () => {
+  it("retries an unavailable lookup twice and never retries a definitive answer", () => {
+    const { retry } = sessionQueryOptions;
+    if (typeof retry !== "function")
+      throw new Error("expected a retry predicate");
+
+    const unavailable = rateLimited();
+    expect(retry(0, unavailable)).toBe(true);
+    expect(retry(SESSION_RETRY_COUNT - 1, unavailable)).toBe(true);
+    expect(retry(SESSION_RETRY_COUNT, unavailable)).toBe(false);
+    // A programming error in the query function must surface at once.
+    expect(retry(0, new TypeError("boom"))).toBe(false);
+  });
+
+  it("waits for Retry-After when the server sent one", () => {
+    const { retryDelay } = sessionQueryOptions;
+    if (typeof retryDelay !== "function") {
+      throw new Error("expected a retryDelay function");
+    }
+
+    const withHeader = new SessionUnavailableError("Too many", 429, 3_000);
+    expect(retryDelay(0, withHeader)).toBe(3_000);
+    // Backoff otherwise, and it grows.
+    const plain = rateLimited();
+    expect(retryDelay(1, plain)).toBeGreaterThan(retryDelay(0, plain));
+  });
+});
+
+describe("how often a cold load asks who is signed in", () => {
+  it("asks once", async () => {
+    authState.session = signedIn;
+    mockApi();
+
+    const queryClient = testQueryClient();
+    const router = routerAt("/casa/inbox", queryClient);
+    await router.load();
+    render(<RouterProvider router={router} />);
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/casa/inbox"),
+    );
+
+    expect(authState.calls).toBe(1);
+  });
+});
+
+describe("the session request itself", () => {
+  it("sends exactly one GET /api/auth/me per lookup", async () => {
+    const calls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const { url } = await readRequest(input);
+        calls.push(url);
+        return json({ user: { email: "alex@example.com" } });
+      }),
+    );
+
+    // The real module, imported *after* the stub is in place and with a
+    // fresh registry — a genuinely cold page load. That matters: the SDK
+    // captures `globalThis.fetch` when its client is constructed, and its
+    // session store fires its extra request only on the first mount.
+    vi.resetModules();
+    const actual = await vi.importActual<
+      typeof import("../src/lib/auth-client")
+    >("../src/lib/auth-client");
+
+    await expect(actual.getSession()).resolves.toEqual({
+      user: { email: "alex@example.com" },
+    });
+    // A second request fired *after* the first resolves is exactly the bug.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(calls.filter((url) => url.endsWith("/api/auth/me"))).toHaveLength(1);
+  });
+
+  it("reports 401 as anonymous and everything else as unavailable", async () => {
+    const responses = new Map<number, Response | null>();
+    let status = 401;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        const body = responses.get(status);
+        if (body === null) throw new TypeError("Failed to fetch");
+        return new Response(JSON.stringify({ message: "nope" }), {
+          status,
+          headers: { "content-type": "application/json", "retry-after": "2" },
+        });
+      }),
+    );
+    responses.set(401, new Response());
+    responses.set(429, new Response());
+    responses.set(503, new Response());
+    responses.set(0, null);
+
+    vi.resetModules();
+    const actual = await vi.importActual<
+      typeof import("../src/lib/auth-client")
+    >("../src/lib/auth-client");
+
+    status = 401;
+    await expect(actual.getSession()).resolves.toBeNull();
+
+    for (const failing of [429, 503, 0]) {
+      status = failing;
+      const error = await actual.getSession().then(
+        () => null,
+        (caught: unknown) => caught,
+      );
+      expect(error).toBeInstanceOf(actual.SessionUnavailableError);
+      expect(
+        (error as InstanceType<typeof actual.SessionUnavailableError>).status,
+      ).toBe(failing);
+    }
+
+    status = 429;
+    const rateLimit = await actual.getSession().catch((e: unknown) => e);
+    expect(
+      (rateLimit as InstanceType<typeof actual.SessionUnavailableError>)
+        .retryAfterMs,
+    ).toBe(2_000);
+  });
+});


### PR DESCRIPTION
Closes #229. Found by the end-to-end suite.

Both symptoms were one defect in `limen-auth`'s `getSession()`: reading its nanostores atom mounts it, which fires a second `GET /api/auth/me` on every cold load and synchronously clears the error before it is read, so a 429 or 5xx resolved as "no user" and the router guards bounced a validly signed-in visitor to `/login`.

- `getSession()` now calls `GET /api/auth/me` directly: `null` only for a definitive 401, `SessionUnavailableError` (status, `Retry-After`) for anything else; the session query retries twice with backoff
- guards keep the last cached session when the check is unavailable, and show a retryable error screen (never `/login`) when nothing is cached
- one session request per cold load, pinned by tests at both the guard and HTTP level
- 12 new tests in `apps/frontend/test/session.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yS5kEFd3AcfSkVidBs4Fj